### PR TITLE
feat: add Microsoft Teams Notifications plugin for action lifecycle updates

### DIFF
--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -19,8 +20,23 @@ type loginRequest struct {
 
 // loginResponse represents the JSON response returned on successful login.
 type loginResponse struct {
-	Token string   `json:"token"`
-	User  *db.User `json:"user"`
+	Token string           `json:"token"`
+	User  authUserResponse `json:"user"`
+}
+
+// authUserResponse is the normalized auth payload returned by both login and
+// current-user endpoints. It includes the user's direct role plus their
+// computed effective role, groups, and permission map.
+type authUserResponse struct {
+	ID            string          `json:"id"`
+	UserID        string          `json:"userId"`
+	Username      string          `json:"username"`
+	DisplayName   string          `json:"displayName,omitempty"`
+	Email         string          `json:"email,omitempty"`
+	Role          string          `json:"role"`
+	EffectiveRole string          `json:"effectiveRole"`
+	Groups        []string        `json:"groups"`
+	Permissions   map[string]bool `json:"permissions"`
 }
 
 // registerRequest represents the JSON body for user registration.
@@ -60,13 +76,13 @@ func (h *Handlers) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build the auth.User needed by GenerateToken.
-	authUser := &auth.User{
+	tokenUser := &auth.User{
 		ID:       user.ID,
 		Username: user.Username,
 		Role:     user.Role,
 	}
 
-	token, err := h.Auth.GenerateToken(authUser)
+	token, err := h.Auth.GenerateToken(tokenUser)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to generate token")
 		return
@@ -82,9 +98,11 @@ func (h *Handlers) Login(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	authResponse := h.buildAuthUserResponse(r.Context(), user)
+
 	writeJSON(w, http.StatusOK, loginResponse{
 		Token: token,
-		User:  user,
+		User:  authResponse,
 	})
 }
 
@@ -104,33 +122,30 @@ func (h *Handlers) GetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	effectiveRole := middleware.GetEffectiveRole(r.Context())
-
-	var groupNames []string
+	authUser := authUserResponse{
+		ID:       claims.UserID,
+		UserID:   claims.UserID,
+		Username: claims.Username,
+		Role:     claims.Role,
+	}
 	if claims.UserID != "" {
-		groups, err := h.DB.ListUserGroups(r.Context(), claims.UserID)
-		if err == nil {
-			for _, g := range groups {
-				groupNames = append(groupNames, g.Name)
-			}
+		if user, err := h.DB.GetUserByID(r.Context(), claims.UserID); err == nil {
+			authUser = h.buildAuthUserResponse(r.Context(), user)
+		} else {
+			authUser.EffectiveRole = middleware.GetEffectiveRole(r.Context())
+			authUser.Groups = []string{}
+			authUser.Permissions = auth.RolePermissions(authUser.EffectiveRole)
 		}
+	} else {
+		authUser.EffectiveRole = middleware.GetEffectiveRole(r.Context())
+		authUser.Groups = []string{}
+		authUser.Permissions = auth.RolePermissions(authUser.EffectiveRole)
 	}
-	if groupNames == nil {
-		groupNames = []string{}
+	if authUser.Permissions == nil {
+		authUser.Permissions = map[string]bool{}
 	}
 
-	// Look up the effective role's permissions so the frontend can do
-	// fine-grained checks (e.g. show "New Entity" only if write is granted).
-	permissions := auth.RolePermissions(effectiveRole)
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"userId":        claims.UserID,
-		"username":      claims.Username,
-		"role":          claims.Role,
-		"effectiveRole": effectiveRole,
-		"groups":        groupNames,
-		"permissions":   permissions,
-	})
+	writeJSON(w, http.StatusOK, authUser)
 }
 
 // Register handles POST /auth/register. It creates a new user account.
@@ -211,6 +226,36 @@ type updateUserRequest struct {
 	DisplayName string `json:"displayName"`
 	Email       string `json:"email"`
 	Role        string `json:"role"`
+}
+
+func (h *Handlers) buildAuthUserResponse(ctx context.Context, user *db.User) authUserResponse {
+	resp := authUserResponse{
+		ID:          user.ID,
+		UserID:      user.ID,
+		Username:    user.Username,
+		DisplayName: user.DisplayName,
+		Email:       user.Email,
+		Role:        user.Role,
+		Groups:      []string{},
+	}
+
+	groupRoles := []string{}
+	if groups, err := h.DB.ListUserGroups(ctx, user.ID); err == nil {
+		resp.Groups = make([]string, 0, len(groups))
+		groupRoles = make([]string, 0, len(groups))
+		for _, g := range groups {
+			resp.Groups = append(resp.Groups, g.Name)
+			groupRoles = append(groupRoles, g.Role)
+		}
+	}
+
+	resp.EffectiveRole = auth.EffectiveRole(user.Role, groupRoles)
+	resp.Permissions = auth.RolePermissions(resp.EffectiveRole)
+	if resp.Permissions == nil {
+		resp.Permissions = map[string]bool{}
+	}
+
+	return resp
 }
 
 // UpdateUser handles PUT /auth/users/{id}. Allows admins to update a user's

--- a/internal/api/handlers/handlers.go
+++ b/internal/api/handlers/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go2engle/gantry/internal/auth"
 	"github.com/go2engle/gantry/internal/db"
@@ -30,6 +31,10 @@ type Handlers struct {
 	DataDir    string // root data directory, used for GitOps repo storage
 
 	teamsNotifierOnce sync.Once
+	teamsCfgMu        sync.RWMutex
+	cachedTeamsConfig teamsPluginConfig
+	cachedTeamsOK     bool
+	cachedTeamsExpiry time.Time
 }
 
 // writeJSON serializes v as JSON and writes it to the response with the given

--- a/internal/api/handlers/handlers.go
+++ b/internal/api/handlers/handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/go2engle/gantry/internal/auth"
 	"github.com/go2engle/gantry/internal/db"
@@ -27,6 +28,8 @@ type Handlers struct {
 	Dispatcher *dispatcher.Manager
 	GitOps     *gitops.Service
 	DataDir    string // root data directory, used for GitOps repo storage
+
+	teamsNotifierOnce sync.Once
 }
 
 // writeJSON serializes v as JSON and writes it to the response with the given

--- a/internal/api/handlers/teams.go
+++ b/internal/api/handlers/teams.go
@@ -44,7 +44,10 @@ func (h *Handlers) InitTeamsNotifier() {
 }
 
 func (h *Handlers) handleTeamsActionTriggered(event events.Event) {
-	cfg, ok := h.loadTeamsPluginConfig(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cfg, ok := h.loadTeamsPluginConfig(ctx)
 	if !ok || !cfg.NotifyOnStart {
 		return
 	}
@@ -53,7 +56,7 @@ func (h *Handlers) handleTeamsActionTriggered(event events.Event) {
 	actionName, _ := event.Data["actionName"].(string)
 	triggeredBy, _ := event.Data["triggeredBy"].(string)
 
-	run, actionEntity := h.lookupTeamsActionContext(context.Background(), runID, actionName)
+	run, actionEntity := h.lookupTeamsActionContext(ctx, runID, actionName)
 	actionLabel := teamsActionLabel(actionEntity, actionName)
 
 	facts := []teamsMessageFacts{
@@ -85,7 +88,10 @@ func (h *Handlers) handleTeamsActionRunUpdated(event events.Event) {
 		return
 	}
 
-	cfg, ok := h.loadTeamsPluginConfig(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cfg, ok := h.loadTeamsPluginConfig(ctx)
 	if !ok {
 		return
 	}
@@ -99,7 +105,7 @@ func (h *Handlers) handleTeamsActionRunUpdated(event events.Event) {
 	runID, _ := event.Data["runId"].(string)
 	actionName, _ := event.Data["actionName"].(string)
 
-	run, actionEntity := h.lookupTeamsActionContext(context.Background(), runID, actionName)
+	run, actionEntity := h.lookupTeamsActionContext(ctx, runID, actionName)
 	actionLabel := teamsActionLabel(actionEntity, actionName)
 
 	title := "Action succeeded"
@@ -150,8 +156,37 @@ func (h *Handlers) loadTeamsPluginConfig(ctx context.Context) (teamsPluginConfig
 		TitlePrefix:     "Gantry",
 	}
 
+	now := time.Now()
+
+	h.teamsCfgMu.RLock()
+	if now.Before(h.cachedTeamsExpiry) {
+		cachedCfg := h.cachedTeamsConfig
+		cachedOK := h.cachedTeamsOK
+		h.teamsCfgMu.RUnlock()
+		return cachedCfg, cachedOK
+	}
+	h.teamsCfgMu.RUnlock()
+
+	h.teamsCfgMu.Lock()
+	defer h.teamsCfgMu.Unlock()
+
+	now = time.Now()
+	if now.Before(h.cachedTeamsExpiry) {
+		return h.cachedTeamsConfig, h.cachedTeamsOK
+	}
+
 	plugin, err := h.DB.GetPlugin(ctx, "teams")
-	if err != nil || plugin == nil || !plugin.Enabled || plugin.Config == nil {
+	if err != nil {
+		log.Printf("teams plugin: failed to load plugin config: %v", err)
+		h.cachedTeamsConfig = cfg
+		h.cachedTeamsOK = false
+		h.cachedTeamsExpiry = time.Time{}
+		return cfg, false
+	}
+	if plugin == nil || !plugin.Enabled || plugin.Config == nil {
+		h.cachedTeamsConfig = cfg
+		h.cachedTeamsOK = false
+		h.cachedTeamsExpiry = now.Add(60 * time.Second)
 		return cfg, false
 	}
 
@@ -173,7 +208,11 @@ func (h *Handlers) loadTeamsPluginConfig(ctx context.Context) (teamsPluginConfig
 		cfg.NotifyOnFailure = v
 	}
 
-	return cfg, cfg.IncomingWebhookSecret != ""
+	h.cachedTeamsConfig = cfg
+	h.cachedTeamsOK = cfg.IncomingWebhookSecret != ""
+	h.cachedTeamsExpiry = now.Add(60 * time.Second)
+
+	return cfg, h.cachedTeamsOK
 }
 
 func (h *Handlers) lookupTeamsActionContext(ctx context.Context, runID, actionName string) (*db.ActionRun, *entity.Entity) {

--- a/internal/api/handlers/teams.go
+++ b/internal/api/handlers/teams.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -275,9 +277,14 @@ func postTeamsWebhook(cfg teamsPluginConfig, payload teamsWebhookPayload) error 
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, cfg.IncomingWebhookSecret, bytes.NewReader(data))
+	parsed, err := url.Parse(cfg.IncomingWebhookSecret)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return errors.New("teams webhook URL must be an absolute https URL")
+	}
+
+	req, err := http.NewRequest(http.MethodPost, parsed.String(), bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return errors.New("build request failed")
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "Gantry/1.0 TeamsNotifier")
@@ -285,7 +292,7 @@ func postTeamsWebhook(cfg teamsPluginConfig, payload teamsWebhookPayload) error 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("post webhook: %w", err)
+		return errors.New("post webhook failed")
 	}
 	defer resp.Body.Close()
 

--- a/internal/api/handlers/teams.go
+++ b/internal/api/handlers/teams.go
@@ -1,0 +1,296 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go2engle/gantry/internal/db"
+	"github.com/go2engle/gantry/internal/entity"
+	"github.com/go2engle/gantry/internal/events"
+)
+
+type teamsPluginConfig struct {
+	IncomingWebhookSecret string
+	GantryBaseURL         string
+	TitlePrefix           string
+	NotifyOnStart         bool
+	NotifyOnSuccess       bool
+	NotifyOnFailure       bool
+}
+
+type teamsMessageFacts struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// InitTeamsNotifier subscribes the Teams plugin to action lifecycle events.
+func (h *Handlers) InitTeamsNotifier() {
+	h.teamsNotifierOnce.Do(func() {
+		if h.Events == nil {
+			return
+		}
+
+		h.Events.Subscribe(events.ActionTriggered, h.handleTeamsActionTriggered)
+		h.Events.Subscribe(events.ActionRunUpdated, h.handleTeamsActionRunUpdated)
+	})
+}
+
+func (h *Handlers) handleTeamsActionTriggered(event events.Event) {
+	cfg, ok := h.loadTeamsPluginConfig(context.Background())
+	if !ok || !cfg.NotifyOnStart {
+		return
+	}
+
+	runID, _ := event.Data["runId"].(string)
+	actionName, _ := event.Data["actionName"].(string)
+	triggeredBy, _ := event.Data["triggeredBy"].(string)
+
+	run, actionEntity := h.lookupTeamsActionContext(context.Background(), runID, actionName)
+	actionLabel := teamsActionLabel(actionEntity, actionName)
+
+	facts := []teamsMessageFacts{
+		{Name: "Action", Value: actionLabel},
+		{Name: "Run ID", Value: runID},
+	}
+	if triggeredBy != "" {
+		facts = append(facts, teamsMessageFacts{Name: "Triggered By", Value: triggeredBy})
+	}
+	if run != nil && run.StartedAt != nil {
+		facts = append(facts, teamsMessageFacts{Name: "Started", Value: run.StartedAt.Format(time.RFC1123)})
+	}
+
+	if err := postTeamsWebhook(cfg, teamsWebhookPayload{
+		Title:      fmt.Sprintf("%s Action started", cfg.titlePrefix()),
+		Summary:    fmt.Sprintf("%s started action %s", cfg.titlePrefix(), actionLabel),
+		Text:       fmt.Sprintf("Action `%s` has been queued in Gantry.", actionLabel),
+		ThemeColor: "0078D4",
+		Facts:      facts,
+		ActionURL:  teamsActionURL(cfg.GantryBaseURL),
+	}); err != nil {
+		log.Printf("teams plugin: send action-start notification: %v", err)
+	}
+}
+
+func (h *Handlers) handleTeamsActionRunUpdated(event events.Event) {
+	status, _ := event.Data["status"].(string)
+	if status != "success" && status != "failed" {
+		return
+	}
+
+	cfg, ok := h.loadTeamsPluginConfig(context.Background())
+	if !ok {
+		return
+	}
+	if status == "success" && !cfg.NotifyOnSuccess {
+		return
+	}
+	if status == "failed" && !cfg.NotifyOnFailure {
+		return
+	}
+
+	runID, _ := event.Data["runId"].(string)
+	actionName, _ := event.Data["actionName"].(string)
+
+	run, actionEntity := h.lookupTeamsActionContext(context.Background(), runID, actionName)
+	actionLabel := teamsActionLabel(actionEntity, actionName)
+
+	title := "Action succeeded"
+	summary := fmt.Sprintf("%s completed action %s successfully", cfg.titlePrefix(), actionLabel)
+	text := fmt.Sprintf("Action `%s` completed successfully in Gantry.", actionLabel)
+	themeColor := "107C10"
+	if status == "failed" {
+		title = "Action failed"
+		summary = fmt.Sprintf("%s action %s failed", cfg.titlePrefix(), actionLabel)
+		text = fmt.Sprintf("Action `%s` failed in Gantry.", actionLabel)
+		themeColor = "D13438"
+	}
+
+	facts := []teamsMessageFacts{
+		{Name: "Action", Value: actionLabel},
+		{Name: "Run ID", Value: runID},
+		{Name: "Status", Value: strings.ToUpper(status)},
+	}
+	if run != nil {
+		if run.TriggeredBy != "" {
+			facts = append(facts, teamsMessageFacts{Name: "Triggered By", Value: run.TriggeredBy})
+		}
+		if run.CompletedAt != nil {
+			facts = append(facts, teamsMessageFacts{Name: "Completed", Value: run.CompletedAt.Format(time.RFC1123)})
+		}
+		if status == "failed" && run.Error != "" {
+			text += fmt.Sprintf("\n\nError: `%s`", teamsTrim(run.Error, 400))
+		}
+	}
+
+	if err := postTeamsWebhook(cfg, teamsWebhookPayload{
+		Title:      fmt.Sprintf("%s %s", cfg.titlePrefix(), title),
+		Summary:    summary,
+		Text:       text,
+		ThemeColor: themeColor,
+		Facts:      facts,
+		ActionURL:  teamsActionURL(cfg.GantryBaseURL),
+	}); err != nil {
+		log.Printf("teams plugin: send action-%s notification: %v", status, err)
+	}
+}
+
+func (h *Handlers) loadTeamsPluginConfig(ctx context.Context) (teamsPluginConfig, bool) {
+	cfg := teamsPluginConfig{
+		NotifyOnStart:   true,
+		NotifyOnSuccess: true,
+		NotifyOnFailure: true,
+		TitlePrefix:     "Gantry",
+	}
+
+	plugin, err := h.DB.GetPlugin(ctx, "teams")
+	if err != nil || plugin == nil || !plugin.Enabled || plugin.Config == nil {
+		return cfg, false
+	}
+
+	cfg.IncomingWebhookSecret, _ = plugin.Config["incomingWebhookSecret"].(string)
+	cfg.GantryBaseURL, _ = plugin.Config["gantryBaseUrl"].(string)
+	cfg.TitlePrefix, _ = plugin.Config["titlePrefix"].(string)
+	if cfg.TitlePrefix == "" {
+		cfg.TitlePrefix = "Gantry"
+	}
+	cfg.GantryBaseURL = strings.TrimRight(cfg.GantryBaseURL, "/")
+
+	if v, ok := plugin.Config["notifyOnStart"].(bool); ok {
+		cfg.NotifyOnStart = v
+	}
+	if v, ok := plugin.Config["notifyOnSuccess"].(bool); ok {
+		cfg.NotifyOnSuccess = v
+	}
+	if v, ok := plugin.Config["notifyOnFailure"].(bool); ok {
+		cfg.NotifyOnFailure = v
+	}
+
+	return cfg, cfg.IncomingWebhookSecret != ""
+}
+
+func (h *Handlers) lookupTeamsActionContext(ctx context.Context, runID, actionName string) (*db.ActionRun, *entity.Entity) {
+	var run *db.ActionRun
+	if runID != "" {
+		r, err := h.DB.GetActionRun(ctx, runID)
+		if err == nil {
+			run = r
+		}
+	}
+
+	var actionEntity *entity.Entity
+	if actionName != "" {
+		e, err := h.DB.GetEntity(ctx, "Action", entity.DefaultNamespace, actionName)
+		if err == nil {
+			actionEntity = e
+		}
+	}
+
+	return run, actionEntity
+}
+
+func teamsActionLabel(actionEntity *entity.Entity, fallback string) string {
+	if actionEntity != nil {
+		if actionEntity.Metadata.Title != "" {
+			return actionEntity.Metadata.Title
+		}
+		if actionEntity.Metadata.Name != "" {
+			return actionEntity.Metadata.Name
+		}
+	}
+	if fallback != "" {
+		return fallback
+	}
+	return "unknown-action"
+}
+
+func (c teamsPluginConfig) titlePrefix() string {
+	if c.TitlePrefix == "" {
+		return "Gantry"
+	}
+	return c.TitlePrefix
+}
+
+func teamsTrim(value string, max int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= max {
+		return value
+	}
+	return strings.TrimSpace(value[:max-3]) + "..."
+}
+
+func teamsActionURL(baseURL string) string {
+	if baseURL == "" {
+		return ""
+	}
+	return baseURL + "/actions"
+}
+
+type teamsWebhookPayload struct {
+	Title      string
+	Summary    string
+	Text       string
+	ThemeColor string
+	Facts      []teamsMessageFacts
+	ActionURL  string
+}
+
+func postTeamsWebhook(cfg teamsPluginConfig, payload teamsWebhookPayload) error {
+	body := map[string]any{
+		"@type":    "MessageCard",
+		"@context": "https://schema.org/extensions",
+		"summary":  payload.Summary,
+		"title":    payload.Title,
+		"text":     payload.Text,
+	}
+	if payload.ThemeColor != "" {
+		body["themeColor"] = payload.ThemeColor
+	}
+	if len(payload.Facts) > 0 {
+		body["sections"] = []map[string]any{
+			{
+				"facts": payload.Facts,
+			},
+		}
+	}
+	if payload.ActionURL != "" {
+		body["potentialAction"] = []map[string]any{
+			{
+				"@type": "OpenUri",
+				"name":  "Open Gantry",
+				"targets": []map[string]string{
+					{"os": "default", "uri": payload.ActionURL},
+				},
+			},
+		}
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, cfg.IncomingWebhookSecret, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Gantry/1.0 TeamsNotifier")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("teams webhook returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -73,6 +73,7 @@ func NewServer(cfg *config.Config, database *db.DB, authSvc *auth.Service, event
 		Dispatcher: dispatcher.New(database, eventBus),
 		DataDir:    cfg.DataDir,
 	}
+	h.InitTeamsNotifier()
 
 	// Health check routes (public).
 	r.Get("/healthz", h.Healthz)

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -138,6 +139,59 @@ func TestAPIKeyDoesNotInheritOwnerGroupRole(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLoginReturnsEffectiveAdminPermissionsFromGroupMembership(t *testing.T) {
+	env := newTestServerEnv(t)
+	user, _ := env.createUser(t, "group-admin-login", "viewer")
+
+	if err := env.db.AddUserToGroupByName(context.Background(), user.ID, "admins"); err != nil {
+		t.Fatalf("AddUserToGroupByName: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewBufferString(`{"username":"group-admin-login","password":"password123"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	env.server.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Token string `json:"token"`
+		User  struct {
+			ID            string          `json:"id"`
+			UserID        string          `json:"userId"`
+			Role          string          `json:"role"`
+			EffectiveRole string          `json:"effectiveRole"`
+			Groups        []string        `json:"groups"`
+			Permissions   map[string]bool `json:"permissions"`
+		} `json:"user"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode login response: %v", err)
+	}
+
+	if resp.Token == "" {
+		t.Fatal("expected login token")
+	}
+	if resp.User.ID != user.ID || resp.User.UserID != user.ID {
+		t.Fatalf("expected user identifiers %q, got id=%q userId=%q", user.ID, resp.User.ID, resp.User.UserID)
+	}
+	if resp.User.Role != "viewer" {
+		t.Fatalf("expected direct role viewer, got %q", resp.User.Role)
+	}
+	if resp.User.EffectiveRole != "admin" {
+		t.Fatalf("expected effective role admin, got %q", resp.User.EffectiveRole)
+	}
+	if !resp.User.Permissions["admin"] {
+		t.Fatalf("expected admin permission in login response, got %#v", resp.User.Permissions)
+	}
+	if len(resp.User.Groups) != 1 || resp.User.Groups[0] != "admins" {
+		t.Fatalf("expected admins group, got %#v", resp.User.Groups)
 	}
 }
 

--- a/internal/plugins/bundled/registry.json
+++ b/internal/plugins/bundled/registry.json
@@ -250,6 +250,65 @@
     }
   },
   {
+    "name": "teams",
+    "title": "Microsoft Teams Notifications",
+    "description": "Send Gantry action notifications to Microsoft Teams using an incoming webhook.",
+    "longDescription": "The Microsoft Teams Notifications plugin posts Gantry action lifecycle updates into a Teams channel through an incoming webhook. When an Action starts, succeeds, or fails, Gantry can send a structured notification with the action name, run ID, trigger user, and optional deep-link back to Gantry.\n\nUse it to keep deployment, operations, or platform channels informed without requiring engineers to constantly watch the Gantry UI.",
+    "features": [
+      "Action start notifications",
+      "Action success notifications",
+      "Action failure notifications with error details",
+      "Optional deep-link back to Gantry",
+      "Configurable notification title prefix"
+    ],
+    "version": "1.0.0",
+    "author": "Gantry",
+    "category": "integration",
+    "homepage": "https://github.com/go2engle/gantry",
+    "configSchema": {
+      "type": "object",
+      "properties": {
+        "incomingWebhookSecret": {
+          "type": "string",
+          "title": "Incoming Webhook URL",
+          "description": "Microsoft Teams incoming webhook URL for the destination channel."
+        },
+        "gantryBaseUrl": {
+          "type": "string",
+          "title": "Gantry Base URL",
+          "description": "Optional public Gantry URL used for links in Teams messages (e.g. https://gantry.example.com)."
+        },
+        "titlePrefix": {
+          "type": "string",
+          "title": "Title Prefix",
+          "description": "Short prefix shown in notification titles.",
+          "default": "Gantry"
+        },
+        "notifyOnStart": {
+          "type": "boolean",
+          "title": "Notify On Start",
+          "description": "Send a message when an action run is created.",
+          "default": true
+        },
+        "notifyOnSuccess": {
+          "type": "boolean",
+          "title": "Notify On Success",
+          "description": "Send a message when an action run completes successfully.",
+          "default": true
+        },
+        "notifyOnFailure": {
+          "type": "boolean",
+          "title": "Notify On Failure",
+          "description": "Send a message when an action run fails.",
+          "default": true
+        }
+      },
+      "required": ["incomingWebhookSecret"]
+    },
+    "entityPanels": [],
+    "actionTypes": []
+  },
+  {
     "name": "datadog",
     "title": "Datadog",
     "description": "Embed SLO status, error rates, and service metrics panels on Service entities.",

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -55,7 +55,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const result = await api.login(username, password);
     setToken(result.token);
     setTokenState(result.token);
-    setUser(result.user);
+    if (result.user.permissions && result.user.effectiveRole) {
+      setUser(result.user);
+      return;
+    }
+    const me = await api.getMe();
+    setUser(me);
   }, []);
 
   const loginWithToken = useCallback(async (token: string) => {

--- a/web/src/pages/Plugins.tsx
+++ b/web/src/pages/Plugins.tsx
@@ -12,7 +12,7 @@ const SYNCABLE_PLUGINS = new Set(['kubernetes', 'github', 'argocd']);
 
 // Plugins with full backend + frontend implementations.
 // Anything not in this set is shown as "Coming Soon" and cannot be enabled.
-const IMPLEMENTED_PLUGINS = new Set(['github', 'kubernetes', 'argocd', 'status-monitor', 'gitops']);
+const IMPLEMENTED_PLUGINS = new Set(['github', 'kubernetes', 'argocd', 'status-monitor', 'gitops', 'teams']);
 
 const CATEGORIES = [
   { id: 'all', label: 'All' },
@@ -120,6 +120,26 @@ const PLUGIN_SECTIONS: Record<string, Array<{
           </div>
         );
       },
+    },
+  ],
+  teams: [
+    {
+      title: 'Delivery',
+      description: 'Configure the Teams channel webhook Gantry should post action lifecycle updates to.',
+      fields: ['incomingWebhookSecret', 'gantryBaseUrl', 'titlePrefix'],
+      renderBanner: () => (
+        <div className="rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-tertiary)] px-4 py-3">
+          <p className="text-sm font-medium text-[var(--gantry-text-primary)]">Microsoft Teams incoming webhook</p>
+          <p className="mt-1 text-xs text-[var(--gantry-text-secondary)]">
+            Create an incoming webhook in the target Teams channel, then paste the webhook URL here. Gantry uses it to send action start, success, and failure notifications.
+          </p>
+        </div>
+      ),
+    },
+    {
+      title: 'Events',
+      description: 'Choose which Gantry action lifecycle events should be delivered to Teams.',
+      fields: ['notifyOnStart', 'notifyOnSuccess', 'notifyOnFailure'],
     },
   ],
 };


### PR DESCRIPTION


Closes #



## Description



Add a Microsoft Teams Notifications plugin to send action lifecycle updates to Teams channels via an incoming webhook. This feature enhances communication by notifying users of action starts, successes, and failures.



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Chore / refactor


## Testing

Tested the integration by configuring the Teams webhook and verifying that notifications are sent for different action lifecycle events.



- Steps taken to verify the change works as expected

- Any manual testing performed in the UI

## Checklist

- [ ] `go build ./...` compiles without errors
- [ ] `go test ./...` passes
- [ ] `cd web && npx tsc --noEmit` passes (if frontend changed)
- [ ] `cd web && npm run build` succeeds (if frontend changed)
- [ ] No secrets or credentials are committed
- [ ] If schema changed: migration added to `internal/db/`
- [ ] If new plugin: follows the [plugin checklist](../CLAUDE.md#creating-plugins)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft Teams notification plugin: send Teams messages for action start, success, and failure; configurable webhook, base URL, and title prefix; UI for plugin settings and event toggles; added to bundled integrations.

* **Improvements**
  * Auth responses now include effective role, group membership, and permissions for richer client behavior.
  * Frontend login flow uses returned user details when complete, otherwise fetches current user.

* **Tests**
  * Added test validating effective admin permissions derived from group membership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->