### PR TITLE
fix: enhance version display in upgrade process and add unit tests fo…

### DIFF
--- a/cmd/gantry/upgrade.go
+++ b/cmd/gantry/upgrade.go
@@ -61,7 +61,8 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
 	noRestart, _ := cmd.Flags().GetBool("no-restart")
 
-	fmt.Printf("  Current version: %s\n", Version)
+	currentVersion := displayVersion(Version)
+	fmt.Printf("  Current version: %s\n", currentVersion)
 
 	// 1. Fetch the target release.
 	var release *githubRelease
@@ -80,19 +81,20 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	}
 
 	newVersion := release.TagName
-	fmt.Printf("  Target version:  %s\n\n", newVersion)
+	displayTargetVersion := displayVersion(newVersion)
+	fmt.Printf("  Target version:  %s\n\n", displayTargetVersion)
 
 	// 2. Compare versions.
 	cmp := compareVersions(Version, strings.TrimPrefix(newVersion, "v"))
 	if cmp == 0 && !force {
-		fmt.Printf("  Already up to date (%s)\n", Version)
+		fmt.Printf("  Already up to date (%s)\n", currentVersion)
 		return nil
 	}
 	if Version == "dev" {
 		fmt.Println("  Note: current version is a development build; version comparison may not be meaningful.")
 	}
 	if cmp > 0 && !force {
-		fmt.Printf("  Warning: target version %s is older than current version %s\n", newVersion, Version)
+		fmt.Printf("  Warning: target version %s is older than current version %s\n", displayTargetVersion, currentVersion)
 		fmt.Println("  Use --force to downgrade.")
 		return nil
 	}
@@ -204,9 +206,16 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 	// 11. Print success.
 	fmt.Println()
 	fmt.Printf("  Gantry upgraded successfully!\n")
-	fmt.Printf("    %s → %s\n\n", Version, newVersion)
+	fmt.Printf("    %s -> %s\n\n", currentVersion, displayTargetVersion)
 
 	return nil
+}
+
+func displayVersion(v string) string {
+	if v == "dev" {
+		return v
+	}
+	return strings.TrimPrefix(v, "v")
 }
 
 // fetchLatestRelease fetches the latest release from GitHub.

--- a/cmd/gantry/upgrade_test.go
+++ b/cmd/gantry/upgrade_test.go
@@ -42,6 +42,25 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
+func TestDisplayVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"0.3.0", "0.3.0"},
+		{"v0.3.0", "0.3.0"},
+		{"dev", "dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := displayVersion(tt.in); got != tt.want {
+				t.Errorf("displayVersion(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestVerifyChecksum(t *testing.T) {
 	// Create a temp file with known content.
 	tmpDir := t.TempDir()


### PR DESCRIPTION
This pull request improves the way version strings are displayed during the upgrade process in `cmd/gantry/upgrade.go` by introducing a helper function to normalize version formatting. It also adds unit tests to ensure this behavior is correct.

**Version display improvements:**

* Added a new `displayVersion` function to consistently strip the leading `v` from version strings (except for the special `"dev"` version), ensuring version numbers are shown in a clean and uniform format throughout the upgrade output.
* Updated all version-related output in `runUpgrade` to use the normalized format, including the current version, target version, "already up to date" messages, downgrade warnings, and the final upgrade success message. [[1]](diffhunk://#diff-ca602036513ccc186a1df8b184f243546037c62070e4f587663086c2a1037f3dL64-R65) [[2]](diffhunk://#diff-ca602036513ccc186a1df8b184f243546037c62070e4f587663086c2a1037f3dL83-R97) [[3]](diffhunk://#diff-ca602036513ccc186a1df8b184f243546037c62070e4f587663086c2a1037f3dL207-R220)

**Testing:**

* Added a `TestDisplayVersion` unit test to verify the correct formatting of various version string inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced version string formatting consistency throughout the upgrade workflow. Version numbers now display uniformly across status checks, downgrade warnings, and completion messages for improved user clarity.

* **Tests**
  * Added comprehensive unit test coverage for version formatting to validate correct output handling across different version string input patterns and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->