### PR TITLE
fix: enhance ActionWizard with role-based permissions and slug auto-generation

### DIFF
--- a/web/src/components/ActionWizard.tsx
+++ b/web/src/components/ActionWizard.tsx
@@ -668,7 +668,7 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
                   onClick={() => setRequireApproval((v) => !v)}
                   className={`relative h-5 w-9 rounded-full transition-colors ${requireApproval ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-border)]'}`}
                 >
-                  <div className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${requireApproval ? 'translate-x-4' : 'translate-x-0.5'}`} />
+                  <div className={`absolute top-0.5 h-4 w-4 rounded-full bg-[var(--gantry-bg-primary)] shadow transition-transform ${requireApproval ? 'translate-x-4' : 'translate-x-0.5'}`} />
                 </div>
                 <div>
                   <span className="text-sm font-medium text-[var(--gantry-text-primary)]">Require approval</span>

--- a/web/src/components/ActionWizard.tsx
+++ b/web/src/components/ActionWizard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { X, ChevronLeft, ChevronRight, Loader2, AlertCircle, Github, Webhook, Zap, Check, Download, RefreshCw } from 'lucide-react';
 import { api } from '../lib/api';
-import type { Entity, ActionInputDef, GitHubWorkflow } from '../lib/types';
+import type { Entity, ActionInputDef, GitHubWorkflow, Role } from '../lib/types';
 import ActionFormBuilder from './ActionFormBuilder';
 
 interface Props {
@@ -61,12 +61,13 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
   const [error, setError] = useState('');
 
   // Step 1: Basic
+  // For new actions: name is auto-derived from title. For edits: name is fixed.
   const [name, setName] = useState(existing?.metadata.name ?? '');
-  const [title, setTitle] = useState(existing?.metadata.title ?? '');
+  const [title, setTitle] = useState(existing?.metadata.title ?? existing?.metadata.name ?? '');
   const [description, setDescription] = useState(existing?.metadata.description ?? '');
   const [owner, setOwner] = useState(existing?.metadata.owner ?? '');
   const [category, setCategory] = useState(existing?.spec?.category ?? '');
-  const [autoSlug] = useState(!existing);
+  const isNew = !existing;
 
   // Step 2: Type & Config
   const [actionType, setActionType] = useState<ActionType>(
@@ -98,12 +99,56 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
   );
 
   // Step 4: Permissions
-  const [allowedRoles, setAllowedRoles] = useState<string>(
-    (existing?.spec?.permissions?.allowedRoles as string[] | undefined)?.join(', ') ?? ''
-  );
+  // minRole: empty = any authenticated user; otherwise = minimum role required to execute
+  const [minRole, setMinRole] = useState<string>('');
+  const [availableRoles, setAvailableRoles] = useState<Role[]>([]);
   const [requireApproval, setRequireApproval] = useState<boolean>(
     existing?.spec?.permissions?.requireApproval ?? false
   );
+
+  // Load roles for permissions dropdown
+  useEffect(() => {
+    const fallback: Role[] = [
+      { id: 'viewer', name: 'viewer', displayName: 'Viewer', level: 1, builtIn: true, permissions: {}, createdAt: '', updatedAt: '' },
+      { id: 'developer', name: 'developer', displayName: 'Developer', level: 2, builtIn: true, permissions: {}, createdAt: '', updatedAt: '' },
+      { id: 'platform-engineer', name: 'platform-engineer', displayName: 'Platform Engineer', level: 3, builtIn: true, permissions: {}, createdAt: '', updatedAt: '' },
+      { id: 'admin', name: 'admin', displayName: 'Admin', level: 4, builtIn: true, permissions: {}, createdAt: '', updatedAt: '' },
+    ];
+    api.listRoles().then((roles) => {
+      const sorted = [...roles].sort((a, b) => a.level - b.level);
+      setAvailableRoles(sorted.length > 0 ? sorted : fallback);
+      // Derive min role from existing entity
+      const existingRoles = (existing?.spec?.permissions?.allowedRoles as string[] | undefined) ?? [];
+      if (existingRoles.length > 0) {
+        let minLevel = Infinity;
+        let minRoleName = '';
+        for (const rName of existingRoles) {
+          const found = (sorted.length > 0 ? sorted : fallback).find((r) => r.name === rName);
+          if (found && found.level < minLevel) {
+            minLevel = found.level;
+            minRoleName = rName;
+          }
+        }
+        if (minRoleName) setMinRole(minRoleName);
+      }
+    }).catch(() => {
+      setAvailableRoles(fallback);
+      const existingRoles = (existing?.spec?.permissions?.allowedRoles as string[] | undefined) ?? [];
+      if (existingRoles.length > 0) {
+        const sorted = [...fallback].sort((a, b) => a.level - b.level);
+        let minLevel = Infinity;
+        let minRoleName = '';
+        for (const rName of existingRoles) {
+          const found = sorted.find((r) => r.name === rName);
+          if (found && found.level < minLevel) {
+            minLevel = found.level;
+            minRoleName = rName;
+          }
+        }
+        if (minRoleName) setMinRole(minRoleName);
+      }
+    });
+  }, []);
 
   // Load workflows when repo URL changes
   useEffect(() => {
@@ -151,10 +196,16 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
       config = { url: webhookConfig.url, method: webhookConfig.method, ...(Object.keys(headers).length > 0 ? { headers } : {}) };
     }
 
-    const roles = allowedRoles
-      .split(',')
-      .map((r) => r.trim())
-      .filter(Boolean);
+    // Expand minRole to all roles at or above the selected level
+    let allowedRolesArr: string[] = [];
+    if (minRole) {
+      const minRoleObj = availableRoles.find((r) => r.name === minRole);
+      if (minRoleObj) {
+        allowedRolesArr = availableRoles
+          .filter((r) => r.level >= minRoleObj.level)
+          .map((r) => r.name);
+      }
+    }
 
     const cleanInputs = inputs.map((inp) => {
       const clean: ActionInputDef = { name: inp.name, type: inp.type };
@@ -180,9 +231,9 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
         ...(category ? { category } : {}),
         ...(Object.keys(config).length > 0 ? { config } : {}),
         ...(cleanInputs.length > 0 ? { inputs: cleanInputs } : {}),
-        ...((roles.length > 0 || requireApproval) ? {
+        ...((allowedRolesArr.length > 0 || requireApproval) ? {
           permissions: {
-            ...(roles.length > 0 ? { allowedRoles: roles } : {}),
+            ...(allowedRolesArr.length > 0 ? { allowedRoles: allowedRolesArr } : {}),
             ...(requireApproval ? { requireApproval: true } : {}),
           },
         } : {}),
@@ -192,7 +243,7 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
 
   const handleSave = async () => {
     setError('');
-    if (!name) { setError('Name is required'); setStep(0); return; }
+    if (!title) { setError('Title is required'); setStep(0); return; }
 
     setSaving(true);
     try {
@@ -212,7 +263,7 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
   };
 
   const canAdvance = () => {
-    if (step === 0) return name.length > 0;
+    if (step === 0) return title.trim().length > 0;
     if (step === 1) {
       if (actionType === 'github-action') return ghConfig.repoUrl.length > 0 && ghConfig.workflow.length > 0;
       if (actionType === 'webhook') return webhookConfig.url.length > 0;
@@ -282,37 +333,28 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
             <div className="space-y-4">
               <div>
                 <label className="mb-1 block text-sm font-medium text-[var(--gantry-text-primary)]">
-                  Name <span className="text-[var(--gantry-danger)]">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={name}
-                  onChange={(e) => {
-                    if (autoSlug) setName(slugify(e.target.value));
-                    else setName(e.target.value);
-                  }}
-                  placeholder="e.g. deploy-service"
-                  className="w-full rounded-md border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-                />
-                <p className="mt-0.5 text-xs text-[var(--gantry-text-secondary)]">Unique identifier (slug); used in the API URL.</p>
-              </div>
-
-              <div>
-                <label className="mb-1 block text-sm font-medium text-[var(--gantry-text-primary)]">
-                  Title
+                  Title <span className="text-[var(--gantry-danger)]">*</span>
                 </label>
                 <input
                   type="text"
                   value={title}
                   onChange={(e) => {
                     setTitle(e.target.value);
-                    if (autoSlug && !existing) {
-                      setName(slugify(e.target.value));
-                    }
+                    if (isNew) setName(slugify(e.target.value));
                   }}
                   placeholder="e.g. Deploy Service"
                   className="w-full rounded-md border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
                 />
+                {isNew && name && (
+                  <p className="mt-0.5 text-xs text-[var(--gantry-text-secondary)]">
+                    Slug: <span className="font-mono">{name}</span>
+                  </p>
+                )}
+                {!isNew && (
+                  <p className="mt-0.5 text-xs text-[var(--gantry-text-secondary)]">
+                    Slug: <span className="font-mono">{name}</span> (cannot be changed after creation)
+                  </p>
+                )}
               </div>
 
               <div>
@@ -600,17 +642,22 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
             <div className="space-y-4">
               <div>
                 <label className="mb-1 block text-sm font-medium text-[var(--gantry-text-primary)]">
-                  Allowed Roles
+                  Minimum Role Required
                 </label>
-                <input
-                  type="text"
-                  value={allowedRoles}
-                  onChange={(e) => setAllowedRoles(e.target.value)}
-                  placeholder="viewer, developer, platform-engineer, admin"
-                  className="w-full rounded-md border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-                />
+                <select
+                  value={minRole}
+                  onChange={(e) => setMinRole(e.target.value)}
+                  className="w-full rounded-md border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+                >
+                  <option value="">Any authenticated user</option>
+                  {availableRoles.map((r) => (
+                    <option key={r.name} value={r.name}>
+                      {r.displayName || r.name}{r.level < Math.max(...availableRoles.map((x) => x.level)) ? ' and above' : ' only'}
+                    </option>
+                  ))}
+                </select>
                 <p className="mt-0.5 text-xs text-[var(--gantry-text-secondary)]">
-                  Comma-separated list of roles that may execute this action. Leave blank to allow all roles.
+                  Users with the selected role or a higher role can execute this action.
                 </p>
               </div>
 

--- a/web/src/components/ActionWizard.tsx
+++ b/web/src/components/ActionWizard.tsx
@@ -272,6 +272,8 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
     return true;
   };
 
+  const maxRoleLevel = availableRoles.length > 0 ? Math.max(...availableRoles.map((x) => x.level)) : 0;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <div className="flex h-[90vh] w-full max-w-2xl flex-col rounded-xl bg-[var(--gantry-bg-primary)] shadow-2xl">
@@ -652,7 +654,7 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
                   <option value="">Any authenticated user</option>
                   {availableRoles.map((r) => (
                     <option key={r.name} value={r.name}>
-                      {r.displayName || r.name}{r.level < Math.max(...availableRoles.map((x) => x.level)) ? ' and above' : ' only'}
+                      {r.displayName || r.name}{r.level < maxRoleLevel ? ' and above' : ' only'}
                     </option>
                   ))}
                 </select>


### PR DESCRIPTION
## Related Issue

Closes #

## Description

Improves the Action creation wizard in two ways:

1. **Simplified name/title field**: Removed the redundant "Name" input field. The **Title** field is now the single required field — the slugified API identifier is auto-derived from the title and shown as a read-only hint below the input. When editing an existing action, the slug is shown as informational text (immutable after creation).

2. **Role dropdown on Permissions tab**: Replaced the free-text comma-separated "Allowed Roles" input with a **Minimum Role Required** dropdown. Roles are fetched from `api.listRoles()` (falls back to the 4 built-in roles if the API call fails). Selecting a minimum role (e.g. "Developer") automatically expands to include all roles at or above that level (`developer`, `platform-engineer`, `admin`) when the action is saved — reflecting the existing role hierarchy. "Any authenticated user" remains the default.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Chore / refactor

## Testing

- Opened the "New Action" wizard and verified only the **Title** field is shown; typing a title auto-populates the slug preview below it
- Confirmed the slug preview updates live as the title changes (e.g. "Deploy Service" → `deploy-service`)
- Opened the **Permissions** step and verified the role dropdown populates with sorted roles (Viewer → Developer → Platform Engineer → Admin)
- Selected "Developer and above" and confirmed the saved entity's `spec.permissions.allowedRoles` contains `["developer", "platform-engineer", "admin"]`
- Opened an **existing** action for edit and confirmed the title field pre-populates, the slug is shown read-only, and the minimum role is correctly inferred from the existing `allowedRoles` array
- Verified "Any authenticated user" selection results in no `permissions` block in the saved entity
- `cd web && npx tsc --noEmit` passes with no errors

## Checklist

- [x] `go build ./...` compiles without errors
- [x] `go test ./...` passes
- [x] `cd web && npx tsc --noEmit` passes (if frontend changed)
- [ ] `cd web && npm run build` succeeds (if frontend changed)
- [x] No secrets or credentials are committed
- [x] If schema changed: migration added to `internal/db/`
- [x] If new plugin: follows the [plugin checklist](../CLAUDE.md#creating-plugins)
```The PR template has been filled out based on the changes made to ActionWizard.tsx in this session. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Title is now the primary action identifier and required when creating actions.
  * Role-based permissions: choose a minimum role and the system expands it to applicable roles.
  * Slug is derived for new actions; existing action slugs are immutable and shown in the UI.

* **UI Improvements**
  * Name input removed; Title-driven slug and immutability notes added to setup and summary panels.
  * Permissions redesigned as a "Minimum Role Required" dropdown with clearer helper text, deterministic role loading, updated toggle visuals, and styled approval toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->