### PR TITLE
feat: add SSO-only user support and password reset functionality

### DIFF
--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -34,6 +34,7 @@ type authUserResponse struct {
 	DisplayName   string          `json:"displayName,omitempty"`
 	Email         string          `json:"email,omitempty"`
 	Role          string          `json:"role"`
+	SSOOnly       bool            `json:"ssoOnly"`
 	EffectiveRole string          `json:"effectiveRole"`
 	Groups        []string        `json:"groups"`
 	Permissions   map[string]bool `json:"permissions"`
@@ -46,6 +47,7 @@ type registerRequest struct {
 	DisplayName string `json:"displayName,omitempty"`
 	Email       string `json:"email,omitempty"`
 	Role        string `json:"role,omitempty"`
+	SSOOnly     bool   `json:"ssoOnly,omitempty"`
 }
 
 // Login handles POST /auth/login. It verifies the username and password
@@ -66,6 +68,12 @@ func (h *Handlers) Login(w http.ResponseWriter, r *http.Request) {
 	user, err := h.DB.GetUserByUsername(r.Context(), req.Username)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+
+	// SSO-only users cannot log in with username/password.
+	if user.SSOOnly {
+		writeError(w, http.StatusForbidden, "this account requires SSO authentication")
 		return
 	}
 
@@ -150,6 +158,8 @@ func (h *Handlers) GetMe(w http.ResponseWriter, r *http.Request) {
 
 // Register handles POST /auth/register. It creates a new user account.
 // This endpoint requires admin privileges (enforced by RequireRole middleware).
+// When ssoOnly is true, the user is created without a password and can only
+// authenticate through an SSO provider (e.g. GitHub OAuth).
 func (h *Handlers) Register(w http.ResponseWriter, r *http.Request) {
 	var req registerRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -157,15 +167,26 @@ func (h *Handlers) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Username == "" || req.Password == "" {
-		writeError(w, http.StatusBadRequest, "username and password are required")
+	if req.Username == "" {
+		writeError(w, http.StatusBadRequest, "username is required")
 		return
 	}
 
-	hash, err := h.Auth.HashPassword(req.Password)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to hash password")
-		return
+	var hash string
+	if req.SSOOnly {
+		// SSO-only users get no usable password.
+		hash = ""
+	} else {
+		if req.Password == "" {
+			writeError(w, http.StatusBadRequest, "password is required for non-SSO users")
+			return
+		}
+		var err error
+		hash, err = h.Auth.HashPassword(req.Password)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to hash password")
+			return
+		}
 	}
 
 	// All new users start as viewer. Role elevation is managed through
@@ -176,6 +197,7 @@ func (h *Handlers) Register(w http.ResponseWriter, r *http.Request) {
 		DisplayName:  req.DisplayName,
 		Email:        req.Email,
 		Role:         "viewer",
+		SSOOnly:      req.SSOOnly,
 	}
 
 	if err := h.DB.CreateUser(r.Context(), user); err != nil {
@@ -226,6 +248,7 @@ type updateUserRequest struct {
 	DisplayName string `json:"displayName"`
 	Email       string `json:"email"`
 	Role        string `json:"role"`
+	SSOOnly     *bool  `json:"ssoOnly,omitempty"`
 }
 
 func (h *Handlers) buildAuthUserResponse(ctx context.Context, user *db.User) authUserResponse {
@@ -236,6 +259,7 @@ func (h *Handlers) buildAuthUserResponse(ctx context.Context, user *db.User) aut
 		DisplayName: user.DisplayName,
 		Email:       user.Email,
 		Role:        user.Role,
+		SSOOnly:     user.SSOOnly,
 		Groups:      []string{},
 	}
 
@@ -283,6 +307,9 @@ func (h *Handlers) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Role != "" {
 		user.Role = req.Role
+	}
+	if req.SSOOnly != nil {
+		user.SSOOnly = *req.SSOOnly
 	}
 
 	if err := h.DB.UpdateUser(r.Context(), user); err != nil {
@@ -349,6 +376,12 @@ func (h *Handlers) ChangePassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SSO-only users cannot change their password (they don't have one).
+	if user.SSOOnly {
+		writeError(w, http.StatusForbidden, "SSO-only accounts cannot change passwords")
+		return
+	}
+
 	if err := h.Auth.CheckPassword(user.PasswordHash, req.CurrentPassword); err != nil {
 		writeError(w, http.StatusUnauthorized, "current password is incorrect")
 		return
@@ -366,4 +399,55 @@ func (h *Handlers) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"message": "password updated successfully"})
+}
+
+// resetPasswordRequest is the body for admin password resets.
+type resetPasswordRequest struct {
+	NewPassword string `json:"newPassword"`
+}
+
+// ResetPassword handles PUT /auth/users/{id}/password. Allows admins to reset
+// any user's password without knowing the current password. Cannot be used on
+// SSO-only accounts.
+func (h *Handlers) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	user, err := h.DB.GetUserByID(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+
+	if user.SSOOnly {
+		writeError(w, http.StatusBadRequest, "cannot reset password for SSO-only accounts")
+		return
+	}
+
+	var req resetPasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.NewPassword == "" {
+		writeError(w, http.StatusBadRequest, "newPassword is required")
+		return
+	}
+	if len(req.NewPassword) < 8 {
+		writeError(w, http.StatusBadRequest, "new password must be at least 8 characters")
+		return
+	}
+
+	hash, err := h.Auth.HashPassword(req.NewPassword)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to hash password")
+		return
+	}
+
+	if err := h.DB.UpdateUserPassword(r.Context(), id, hash); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to reset password")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"message": "password reset successfully"})
 }

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -449,5 +449,24 @@ func (h *Handlers) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Audit log — record who reset whose password (never log the plaintext).
+	claims := middleware.GetClaims(r.Context())
+	userName := ""
+	userID := ""
+	if claims != nil {
+		userName = claims.Username
+		userID = claims.UserID
+	}
+	h.DB.CreateAuditEntry(r.Context(), &db.AuditEntry{
+		UserID:       userID,
+		UserName:     userName,
+		Action:       "user.password_reset",
+		ResourceType: "user",
+		ResourceID:   user.ID,
+		ResourceName: user.Username,
+		Source:       "api",
+		IPAddress:    clientIP(r),
+	})
+
 	writeJSON(w, http.StatusOK, map[string]string{"message": "password reset successfully"})
 }

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -72,8 +72,9 @@ func (h *Handlers) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// SSO-only users cannot log in with username/password.
+	// Return the same generic error to avoid leaking SSO membership.
 	if user.SSOOnly {
-		writeError(w, http.StatusForbidden, "this account requires SSO authentication")
+		writeError(w, http.StatusUnauthorized, "invalid credentials")
 		return
 	}
 
@@ -179,6 +180,10 @@ func (h *Handlers) Register(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if req.Password == "" {
 			writeError(w, http.StatusBadRequest, "password is required for non-SSO users")
+			return
+		}
+		if len(req.Password) < 8 {
+			writeError(w, http.StatusBadRequest, "password must be at least 8 characters")
 			return
 		}
 		var err error

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -450,6 +450,12 @@ func (h *Handlers) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Audit log — record who reset whose password (never log the plaintext).
+	// db.User.PasswordHash is tagged json:"-" so it is automatically excluded.
+	beforeState, _ := json.Marshal(user)
+	afterState := beforeState // only password hash changed (excluded from JSON)
+	if updated, err := h.DB.GetUserByID(r.Context(), id); err == nil {
+		afterState, _ = json.Marshal(updated)
+	}
 	claims := middleware.GetClaims(r.Context())
 	userName := ""
 	userID := ""
@@ -464,6 +470,8 @@ func (h *Handlers) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		ResourceType: "user",
 		ResourceID:   user.ID,
 		ResourceName: user.Username,
+		BeforeState:  string(beforeState),
+		AfterState:   string(afterState),
 		Source:       "api",
 		IPAddress:    clientIP(r),
 	})

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -314,6 +314,11 @@ func (h *Handlers) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		user.Role = req.Role
 	}
 	if req.SSOOnly != nil {
+		// When toggling false→true, clear the stored password hash so no
+		// lingering credentials remain for the now-SSO-only account.
+		if *req.SSOOnly && !user.SSOOnly {
+			h.DB.UpdateUserPassword(r.Context(), user.ID, "")
+		}
 		user.SSOOnly = *req.SSOOnly
 	}
 

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -317,7 +317,10 @@ func (h *Handlers) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		// When toggling false→true, clear the stored password hash so no
 		// lingering credentials remain for the now-SSO-only account.
 		if *req.SSOOnly && !user.SSOOnly {
-			h.DB.UpdateUserPassword(r.Context(), user.ID, "")
+			if err := h.DB.UpdateUserPassword(r.Context(), user.ID, ""); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to clear password for SSO-only conversion")
+				return
+			}
 		}
 		user.SSOOnly = *req.SSOOnly
 	}

--- a/internal/api/handlers/github.go
+++ b/internal/api/handlers/github.go
@@ -185,6 +185,7 @@ func (h *Handlers) GitHubOAuthCallback(w http.ResponseWriter, r *http.Request) {
 			DisplayName:  displayName,
 			Email:        ghUser.Email,
 			Role:         defaultRole,
+			SSOOnly:      true,
 		}
 		if err := h.DB.CreateUser(ctx, newUser); err != nil {
 			// If username already exists (race), try to fetch again.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -116,6 +116,7 @@ func NewServer(cfg *config.Config, database *db.DB, authSvc *auth.Service, event
 			// User management (admin only).
 			protected.With(middleware.RequireRole("admin")).Get("/auth/users", h.ListUsers)
 			protected.With(middleware.RequireRole("admin")).Put("/auth/users/{id}", h.UpdateUser)
+			protected.With(middleware.RequireRole("admin")).Put("/auth/users/{id}/password", h.ResetPassword)
 			protected.With(middleware.RequireRole("admin")).Delete("/auth/users/{id}", h.DeleteUser)
 
 			// API key management.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -147,15 +147,34 @@ func (d *DB) MigrateEncryptPluginConfigs(ctx context.Context) error {
 
 // Migrate runs all database migrations to bring the schema up to date.
 // Migrations are idempotent (using IF NOT EXISTS) so they are safe to run
-// on every startup.
+// on every startup. ALTER TABLE statements silently skip "duplicate column"
+// errors so they remain safe across restarts.
 func (d *DB) Migrate() error {
 	migrations := allMigrations(d.cfg.DBType)
 	for i, m := range migrations {
 		if _, err := d.Exec(m); err != nil {
+			// ALTER TABLE ADD COLUMN is not idempotent in SQLite/Postgres;
+			// tolerate "duplicate column" errors so migrations can re-run.
+			if isDuplicateColumnErr(err) {
+				continue
+			}
 			return fmt.Errorf("migration %d failed: %w", i+1, err)
 		}
 	}
 	return nil
+}
+
+// isDuplicateColumnErr returns true if the error is a "duplicate column" error
+// from an ALTER TABLE ADD COLUMN statement (safe to ignore on re-run).
+func isDuplicateColumnErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	// SQLite: "duplicate column name: ..."
+	// PostgreSQL: "column ... of relation ... already exists"
+	return strings.Contains(msg, "duplicate column") ||
+		strings.Contains(msg, "already exists")
 }
 
 // IsSQLite returns true if the underlying database is SQLite.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/go2engle/gantry/internal/config"
@@ -164,6 +165,10 @@ func (d *DB) Migrate() error {
 	return nil
 }
 
+// pgDuplicateColumnRe matches PostgreSQL's duplicate-column error message:
+// "column \"...\" of relation \"...\" already exists".
+var pgDuplicateColumnRe = regexp.MustCompile(`column ".*" of relation ".*" already exists`)
+
 // isDuplicateColumnErr returns true if the error is a "duplicate column" error
 // from an ALTER TABLE ADD COLUMN statement (safe to ignore on re-run).
 func isDuplicateColumnErr(err error) bool {
@@ -172,9 +177,11 @@ func isDuplicateColumnErr(err error) bool {
 	}
 	msg := err.Error()
 	// SQLite: "duplicate column name: ..."
-	// PostgreSQL: "column ... of relation ... already exists"
-	return strings.Contains(msg, "duplicate column") ||
-		strings.Contains(msg, "already exists")
+	if strings.Contains(msg, "duplicate column") {
+		return true
+	}
+	// PostgreSQL: "column \"...\" of relation \"...\" already exists"
+	return pgDuplicateColumnRe.MatchString(msg)
 }
 
 // IsSQLite returns true if the underlying database is SQLite.

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -213,6 +213,13 @@ func allMigrations(dbType string) []string {
 		)`,
 	}
 
+	// ------------------------------------------------------------------
+	// Migration: add sso_only column to users table.
+	// ------------------------------------------------------------------
+	migrations = append(migrations,
+		`ALTER TABLE users ADD COLUMN sso_only INTEGER NOT NULL DEFAULT 0`,
+	)
+
 	// Default admin user — dialect-aware upsert.
 	if dbType == "postgres" {
 		migrations = append(migrations,

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -55,6 +55,7 @@ func allMigrations(dbType string) []string {
 			display_name  TEXT,
 			email         TEXT,
 			role          TEXT NOT NULL DEFAULT 'viewer',
+			sso_only      INTEGER NOT NULL DEFAULT 0,
 			created_at    TIMESTAMP,
 			updated_at    TIMESTAMP
 		)`,

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -26,6 +26,7 @@ type User struct {
 	DisplayName  string    `json:"displayName,omitempty"`
 	Email        string    `json:"email,omitempty"`
 	Role         string    `json:"role"`
+	SSOOnly      bool      `json:"ssoOnly"`
 	CreatedAt    time.Time `json:"createdAt"`
 	UpdatedAt    time.Time `json:"updatedAt"`
 }
@@ -644,7 +645,7 @@ func (d *DB) GetEntityGraph(ctx context.Context, kind, namespace, name string) (
 // GetUserByUsername retrieves a user by their unique username.
 func (d *DB) GetUserByUsername(ctx context.Context, username string) (*User, error) {
 	row := d.queryRow(ctx,
-		`SELECT id, username, password_hash, display_name, email, role, created_at, updated_at
+		`SELECT id, username, password_hash, display_name, email, role, sso_only, created_at, updated_at
 		 FROM users WHERE username = ?`,
 		username,
 	)
@@ -652,9 +653,10 @@ func (d *DB) GetUserByUsername(ctx context.Context, username string) (*User, err
 	u := &User{}
 	var displayName, email sql.NullString
 	var createdAt, updatedAt sql.NullTime
+	var ssoOnly int
 	err := row.Scan(
 		&u.ID, &u.Username, &u.PasswordHash,
-		&displayName, &email, &u.Role,
+		&displayName, &email, &u.Role, &ssoOnly,
 		&createdAt, &updatedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -666,6 +668,7 @@ func (d *DB) GetUserByUsername(ctx context.Context, username string) (*User, err
 
 	u.DisplayName = displayName.String
 	u.Email = email.String
+	u.SSOOnly = ssoOnly != 0
 	if createdAt.Valid {
 		u.CreatedAt = createdAt.Time
 	}
@@ -678,7 +681,7 @@ func (d *DB) GetUserByUsername(ctx context.Context, username string) (*User, err
 // ListUsers returns all users ordered by creation date (password hash excluded).
 func (d *DB) ListUsers(ctx context.Context) ([]*User, error) {
 	rows, err := d.queryRows(ctx,
-		`SELECT id, username, display_name, email, role, created_at, updated_at
+		`SELECT id, username, display_name, email, role, sso_only, created_at, updated_at
 		 FROM users ORDER BY created_at ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("listing users: %w", err)
@@ -690,11 +693,13 @@ func (d *DB) ListUsers(ctx context.Context) ([]*User, error) {
 		u := &User{}
 		var displayName, email sql.NullString
 		var createdAt, updatedAt sql.NullTime
-		if err := rows.Scan(&u.ID, &u.Username, &displayName, &email, &u.Role, &createdAt, &updatedAt); err != nil {
+		var ssoOnly int
+		if err := rows.Scan(&u.ID, &u.Username, &displayName, &email, &u.Role, &ssoOnly, &createdAt, &updatedAt); err != nil {
 			return nil, fmt.Errorf("scanning user: %w", err)
 		}
 		u.DisplayName = displayName.String
 		u.Email = email.String
+		u.SSOOnly = ssoOnly != 0
 		if createdAt.Valid {
 			u.CreatedAt = createdAt.Time
 		}
@@ -709,12 +714,13 @@ func (d *DB) ListUsers(ctx context.Context) ([]*User, error) {
 // GetUserByID retrieves a user by their ID.
 func (d *DB) GetUserByID(ctx context.Context, id string) (*User, error) {
 	row := d.queryRow(ctx,
-		`SELECT id, username, password_hash, display_name, email, role, created_at, updated_at
+		`SELECT id, username, password_hash, display_name, email, role, sso_only, created_at, updated_at
 		 FROM users WHERE id = ?`, id)
 	u := &User{}
 	var displayName, email sql.NullString
 	var createdAt, updatedAt sql.NullTime
-	err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &displayName, &email, &u.Role, &createdAt, &updatedAt)
+	var ssoOnly int
+	err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &displayName, &email, &u.Role, &ssoOnly, &createdAt, &updatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("user %q: %w", id, entity.ErrEntityNotFound)
 	}
@@ -723,6 +729,7 @@ func (d *DB) GetUserByID(ctx context.Context, id string) (*User, error) {
 	}
 	u.DisplayName = displayName.String
 	u.Email = email.String
+	u.SSOOnly = ssoOnly != 0
 	if createdAt.Valid {
 		u.CreatedAt = createdAt.Time
 	}
@@ -732,12 +739,12 @@ func (d *DB) GetUserByID(ctx context.Context, id string) (*User, error) {
 	return u, nil
 }
 
-// UpdateUser updates the mutable profile fields of a user (displayName, email, role).
+// UpdateUser updates the mutable profile fields of a user (displayName, email, role, sso_only).
 func (d *DB) UpdateUser(ctx context.Context, u *User) error {
 	u.UpdatedAt = time.Now().UTC()
 	_, err := d.exec(ctx,
-		`UPDATE users SET display_name = ?, email = ?, role = ?, updated_at = ? WHERE id = ?`,
-		u.DisplayName, u.Email, u.Role, u.UpdatedAt, u.ID)
+		`UPDATE users SET display_name = ?, email = ?, role = ?, sso_only = ?, updated_at = ? WHERE id = ?`,
+		u.DisplayName, u.Email, u.Role, boolToInt(u.SSOOnly), u.UpdatedAt, u.ID)
 	return err
 }
 
@@ -775,12 +782,13 @@ func (d *DB) InitializeBootstrapAdminPassword(ctx context.Context, authSvc *auth
 // GetUserByEmail retrieves a user by their email address.
 func (d *DB) GetUserByEmail(ctx context.Context, email string) (*User, error) {
 	row := d.queryRow(ctx,
-		`SELECT id, username, password_hash, display_name, email, role, created_at, updated_at
+		`SELECT id, username, password_hash, display_name, email, role, sso_only, created_at, updated_at
 		 FROM users WHERE email = ? LIMIT 1`, email)
 	u := &User{}
 	var displayName, emailVal sql.NullString
 	var createdAt, updatedAt sql.NullTime
-	err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &displayName, &emailVal, &u.Role, &createdAt, &updatedAt)
+	var ssoOnly int
+	err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &displayName, &emailVal, &u.Role, &ssoOnly, &createdAt, &updatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("user with email %q: %w", email, entity.ErrEntityNotFound)
 	}
@@ -789,6 +797,7 @@ func (d *DB) GetUserByEmail(ctx context.Context, email string) (*User, error) {
 	}
 	u.DisplayName = displayName.String
 	u.Email = emailVal.String
+	u.SSOOnly = ssoOnly != 0
 	if createdAt.Valid {
 		u.CreatedAt = createdAt.Time
 	}
@@ -820,10 +829,10 @@ func (d *DB) CreateUser(ctx context.Context, u *User) error {
 	}
 
 	_, err := d.exec(ctx,
-		`INSERT INTO users (id, username, password_hash, display_name, email, role, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO users (id, username, password_hash, display_name, email, role, sso_only, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		u.ID, u.Username, u.PasswordHash,
-		u.DisplayName, u.Email, u.Role,
+		u.DisplayName, u.Email, u.Role, boolToInt(u.SSOOnly),
 		u.CreatedAt, u.UpdatedAt,
 	)
 	if err != nil {
@@ -1901,7 +1910,7 @@ func (d *DB) ListUserGroups(ctx context.Context, userID string) ([]*Group, error
 // ListGroupMembers returns all users in a group.
 func (d *DB) ListGroupMembers(ctx context.Context, groupID string) ([]*User, error) {
 	rows, err := d.queryRows(ctx,
-		`SELECT u.id, u.username, u.password_hash, u.display_name, u.email, u.role, u.created_at, u.updated_at
+		`SELECT u.id, u.username, u.password_hash, u.display_name, u.email, u.role, u.sso_only, u.created_at, u.updated_at
 		 FROM users u
 		 JOIN user_groups ug ON u.id = ug.user_id
 		 WHERE ug.group_id = ?
@@ -1915,8 +1924,9 @@ func (d *DB) ListGroupMembers(ctx context.Context, groupID string) ([]*User, err
 		u := &User{}
 		var displayName, email sql.NullString
 		var createdAt, updatedAt sql.NullTime
+		var ssoOnly int
 		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash,
-			&displayName, &email, &u.Role, &createdAt, &updatedAt); err != nil {
+			&displayName, &email, &u.Role, &ssoOnly, &createdAt, &updatedAt); err != nil {
 			return nil, err
 		}
 		if displayName.Valid {
@@ -1925,6 +1935,7 @@ func (d *DB) ListGroupMembers(ctx context.Context, groupID string) ([]*User, err
 		if email.Valid {
 			u.Email = email.String
 		}
+		u.SSOOnly = ssoOnly != 0
 		if createdAt.Valid {
 			u.CreatedAt = createdAt.Time.UTC()
 		}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -95,13 +95,16 @@ export const api = {
 
   listUsers: () => request<User[]>('GET', '/auth/users'),
 
-  createUser: (username: string, password: string, displayName?: string, email?: string, role?: string) =>
-    request<User>('POST', '/auth/register', { username, password, displayName, email, role }),
+  createUser: (username: string, password: string, displayName?: string, email?: string, role?: string, ssoOnly?: boolean) =>
+    request<User>('POST', '/auth/register', { username, password: ssoOnly ? undefined : password, displayName, email, role, ssoOnly }),
 
-  updateUser: (id: string, data: { displayName?: string; email?: string; role?: string }) =>
+  updateUser: (id: string, data: { displayName?: string; email?: string; role?: string; ssoOnly?: boolean }) =>
     request<User>('PUT', `/auth/users/${id}`, data),
 
   deleteUser: (id: string) => request<void>('DELETE', `/auth/users/${id}`),
+
+  resetPassword: (id: string, newPassword: string) =>
+    request<{ message: string }>('PUT', `/auth/users/${id}/password`, { newPassword }),
 
   listAPIKeys: () => request<APIKey[]>('GET', '/auth/apikeys'),
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -29,6 +29,7 @@ export interface User {
   displayName?: string;
   email?: string;
   role: string;
+  ssoOnly?: boolean;
   effectiveRole?: string;
   groups?: string[];
   permissions?: Record<string, boolean>;

--- a/web/src/pages/Users.tsx
+++ b/web/src/pages/Users.tsx
@@ -47,6 +47,10 @@ export default function UsersPage() {
     setCreateError('');
     if (!newUsername.trim()) return;
     if (!newSSOOnly && !newPassword.trim()) return;
+    if (!newSSOOnly && newPassword.trim().length < MIN_PASSWORD_LENGTH) {
+      setCreateError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      return;
+    }
     setCreating(true);
     try {
       const created = await api.createUser(

--- a/web/src/pages/Users.tsx
+++ b/web/src/pages/Users.tsx
@@ -331,6 +331,7 @@ export default function UsersPage() {
                               onClick={() => { setResetUserId(u.id); setResetPassword(''); setResetError(''); setResetSuccess(''); }}
                               className="rounded p-1.5 text-[var(--gantry-text-secondary)] opacity-0 transition-opacity group-hover:opacity-100 hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-accent)]"
                               title="Reset password"
+                              aria-label={`Reset password for ${u.displayName || u.username}`}
                             >
                               <KeyRound className="h-4 w-4" />
                             </button>
@@ -340,6 +341,7 @@ export default function UsersPage() {
                             disabled={u.id === me?.id}
                             className="rounded p-1.5 text-[var(--gantry-text-secondary)] opacity-0 transition-opacity group-hover:opacity-100 hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-danger)] disabled:pointer-events-none disabled:opacity-0"
                             title="Delete user"
+                            aria-label={`Delete user ${u.displayName || u.username}`}
                           >
                             <Trash2 className="h-4 w-4" />
                           </button>

--- a/web/src/pages/Users.tsx
+++ b/web/src/pages/Users.tsx
@@ -5,6 +5,8 @@ import { Plus, Trash2, Shield, Users, KeyRound, Globe } from 'lucide-react';
 import { api } from '../lib/api';
 import type { User } from '../lib/types';
 
+const MIN_PASSWORD_LENGTH = 8;
+
 const ROLE_COLORS: Record<string, string> = {
   admin: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
   'platform-engineer': 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
@@ -79,6 +81,10 @@ export default function UsersPage() {
 
   const handleResetPassword = async () => {
     if (!resetUserId || !resetPassword.trim()) return;
+    if (resetPassword.trim().length < MIN_PASSWORD_LENGTH) {
+      setResetError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      return;
+    }
     setResetError('');
     setResetSuccess('');
     setResetting(true);
@@ -140,7 +146,7 @@ export default function UsersPage() {
                 <div className="flex items-center gap-2">
                   <Globe className="h-4 w-4 text-[var(--gantry-text-secondary)]" />
                   <div>
-                    <label className="text-xs font-medium text-[var(--gantry-text-primary)]">SSO-only account</label>
+                    <label id="sso-switch-label" className="text-xs font-medium text-[var(--gantry-text-primary)]">SSO-only account</label>
                     <p className="text-[10px] leading-tight text-[var(--gantry-text-secondary)]">
                       User must sign in via SSO provider
                     </p>
@@ -150,13 +156,14 @@ export default function UsersPage() {
                   type="button"
                   role="switch"
                   aria-checked={newSSOOnly}
+                  aria-labelledby="sso-switch-label"
                   onClick={() => { setNewSSOOnly(!newSSOOnly); setNewPassword(''); }}
                   className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors ${
                     newSSOOnly ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-border)]'
                   }`}
                 >
                   <span
-                    className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+                    className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-[var(--gantry-bg-primary)] shadow-sm transition-transform ${
                       newSSOOnly ? 'translate-x-4' : 'translate-x-0.5'
                     } mt-0.5`}
                   />
@@ -165,7 +172,7 @@ export default function UsersPage() {
 
               <div>
                 <label className="block text-xs font-medium text-[var(--gantry-text-secondary)]">
-                  Username <span className="text-red-500">*</span>
+                  Username <span className="text-[var(--gantry-danger)]">*</span>
                 </label>
                 <input
                   type="text"
@@ -178,7 +185,7 @@ export default function UsersPage() {
               {!newSSOOnly && (
                 <div>
                   <label className="block text-xs font-medium text-[var(--gantry-text-secondary)]">
-                    Password <span className="text-red-500">*</span>
+                    Password <span className="text-[var(--gantry-danger)]">*</span>
                   </label>
                   <input
                     type="password"
@@ -212,7 +219,7 @@ export default function UsersPage() {
             </div>
 
             {createError && (
-              <p className="mt-3 text-xs text-red-500">{createError}</p>
+              <p className="mt-3 text-xs text-[var(--gantry-danger)]">{createError}</p>
             )}
 
             <button
@@ -279,7 +286,7 @@ export default function UsersPage() {
                                 <span className="text-xs text-[var(--gantry-text-secondary)]">(you)</span>
                               )}
                               {u.ssoOnly && (
-                                <span className="inline-flex items-center gap-0.5 rounded-full bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                                <span className="inline-flex items-center gap-0.5 rounded-full bg-[var(--gantry-accent)]/10 px-1.5 py-0.5 text-[10px] font-medium text-[var(--gantry-accent)]">
                                   <Globe className="h-2.5 w-2.5" />
                                   SSO
                                 </span>
@@ -347,16 +354,19 @@ export default function UsersPage() {
       {resetUserId && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setResetUserId(null)}>
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="reset-password-title"
             className="w-full max-w-sm rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-6 shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 className="text-base font-semibold text-[var(--gantry-text-primary)]">Reset Password</h3>
+            <h3 id="reset-password-title" className="text-base font-semibold text-[var(--gantry-text-primary)]">Reset Password</h3>
             <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
               Set a new password for <strong>{resetUser?.displayName || resetUser?.username}</strong>
             </p>
             <div className="mt-4">
               <label className="block text-xs font-medium text-[var(--gantry-text-secondary)]">
-                New Password <span className="text-red-500">*</span>
+                New Password <span className="text-[var(--gantry-danger)]">*</span>
               </label>
               <input
                 type="password"
@@ -368,8 +378,8 @@ export default function UsersPage() {
                 onKeyDown={(e) => { if (e.key === 'Enter') handleResetPassword(); }}
               />
             </div>
-            {resetError && <p className="mt-2 text-xs text-red-500">{resetError}</p>}
-            {resetSuccess && <p className="mt-2 text-xs text-green-600 dark:text-green-400">{resetSuccess}</p>}
+            {resetError && <p className="mt-2 text-xs text-[var(--gantry-danger)]">{resetError}</p>}
+            {resetSuccess && <p className="mt-2 text-xs text-[var(--gantry-accent)]">{resetSuccess}</p>}
             <div className="mt-4 flex justify-end gap-2">
               <button
                 onClick={() => setResetUserId(null)}
@@ -379,7 +389,7 @@ export default function UsersPage() {
               </button>
               <button
                 onClick={handleResetPassword}
-                disabled={resetting || !resetPassword.trim() || resetPassword.trim().length < 8}
+                disabled={resetting || !resetPassword.trim() || resetPassword.trim().length < MIN_PASSWORD_LENGTH}
                 className="rounded-lg bg-[var(--gantry-accent)] px-3 py-1.5 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)] disabled:opacity-50"
               >
                 {resetting ? 'Resetting…' : 'Reset Password'}

--- a/web/src/pages/Users.tsx
+++ b/web/src/pages/Users.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { Link } from 'react-router-dom';
-import { Plus, Trash2, Shield, Users, Info } from 'lucide-react';
+import { Plus, Trash2, Shield, Users, KeyRound, Globe } from 'lucide-react';
 import { api } from '../lib/api';
 import type { User } from '../lib/types';
 
@@ -23,8 +23,16 @@ export default function UsersPage() {
   const [newPassword, setNewPassword] = useState('');
   const [newDisplayName, setNewDisplayName] = useState('');
   const [newEmail, setNewEmail] = useState('');
+  const [newSSOOnly, setNewSSOOnly] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState('');
+
+  // Reset password modal
+  const [resetUserId, setResetUserId] = useState<string | null>(null);
+  const [resetPassword, setResetPassword] = useState('');
+  const [resetting, setResetting] = useState(false);
+  const [resetError, setResetError] = useState('');
+  const [resetSuccess, setResetSuccess] = useState('');
 
   useEffect(() => {
     api.listUsers()
@@ -35,20 +43,24 @@ export default function UsersPage() {
 
   const handleCreate = async () => {
     setCreateError('');
-    if (!newUsername.trim() || !newPassword.trim()) return;
+    if (!newUsername.trim()) return;
+    if (!newSSOOnly && !newPassword.trim()) return;
     setCreating(true);
     try {
       const created = await api.createUser(
         newUsername.trim(),
-        newPassword.trim(),
+        newSSOOnly ? '' : newPassword.trim(),
         newDisplayName.trim() || undefined,
         newEmail.trim() || undefined,
+        undefined,
+        newSSOOnly || undefined,
       );
       setUsers((prev) => [...prev, created]);
       setNewUsername('');
       setNewPassword('');
       setNewDisplayName('');
       setNewEmail('');
+      setNewSSOOnly(false);
     } catch (e: any) {
       setCreateError(e.message);
     } finally {
@@ -64,6 +76,28 @@ export default function UsersPage() {
       // silently ignore
     }
   };
+
+  const handleResetPassword = async () => {
+    if (!resetUserId || !resetPassword.trim()) return;
+    setResetError('');
+    setResetSuccess('');
+    setResetting(true);
+    try {
+      await api.resetPassword(resetUserId, resetPassword.trim());
+      setResetSuccess('Password reset successfully');
+      setResetPassword('');
+      setTimeout(() => {
+        setResetUserId(null);
+        setResetSuccess('');
+      }, 1500);
+    } catch (e: any) {
+      setResetError(e.message);
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  const resetUser = users.find((u) => u.id === resetUserId);
 
   return (
     <div>
@@ -101,6 +135,34 @@ export default function UsersPage() {
             <p className="mt-0.5 text-xs text-[var(--gantry-text-secondary)]">Create a new account</p>
 
             <div className="mt-4 space-y-3">
+              {/* SSO-only toggle */}
+              <div className="flex items-center justify-between rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2.5">
+                <div className="flex items-center gap-2">
+                  <Globe className="h-4 w-4 text-[var(--gantry-text-secondary)]" />
+                  <div>
+                    <label className="text-xs font-medium text-[var(--gantry-text-primary)]">SSO-only account</label>
+                    <p className="text-[10px] leading-tight text-[var(--gantry-text-secondary)]">
+                      User must sign in via SSO provider
+                    </p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={newSSOOnly}
+                  onClick={() => { setNewSSOOnly(!newSSOOnly); setNewPassword(''); }}
+                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors ${
+                    newSSOOnly ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-border)]'
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+                      newSSOOnly ? 'translate-x-4' : 'translate-x-0.5'
+                    } mt-0.5`}
+                  />
+                </button>
+              </div>
+
               <div>
                 <label className="block text-xs font-medium text-[var(--gantry-text-secondary)]">
                   Username <span className="text-red-500">*</span>
@@ -109,22 +171,24 @@ export default function UsersPage() {
                   type="text"
                   value={newUsername}
                   onChange={(e) => setNewUsername(e.target.value)}
-                  placeholder="e.g. jsmith"
+                  placeholder={newSSOOnly ? 'e.g. github:jsmith' : 'e.g. jsmith'}
                   className="mt-1 w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] outline-none focus:border-[var(--gantry-accent)]"
                 />
               </div>
-              <div>
-                <label className="block text-xs font-medium text-[var(--gantry-text-secondary)]">
-                  Password <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="password"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  placeholder="Min. 8 characters"
-                  className="mt-1 w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] outline-none focus:border-[var(--gantry-accent)]"
-                />
-              </div>
+              {!newSSOOnly && (
+                <div>
+                  <label className="block text-xs font-medium text-[var(--gantry-text-secondary)]">
+                    Password <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="password"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    placeholder="Min. 8 characters"
+                    className="mt-1 w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] outline-none focus:border-[var(--gantry-accent)]"
+                  />
+                </div>
+              )}
               <div>
                 <label className="block text-xs font-medium text-[var(--gantry-text-secondary)]">Display Name</label>
                 <input
@@ -153,30 +217,15 @@ export default function UsersPage() {
 
             <button
               onClick={handleCreate}
-              disabled={creating || !newUsername.trim() || !newPassword.trim()}
+              disabled={creating || !newUsername.trim() || (!newSSOOnly && !newPassword.trim())}
               className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--gantry-accent)] px-4 py-2 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)] disabled:opacity-50"
             >
               <Plus className="h-4 w-4" />
-              {creating ? 'Creating…' : 'Create User'}
+              {creating ? 'Creating…' : newSSOOnly ? 'Create SSO User' : 'Create User'}
             </button>
           </div>
 
-          {/* SSO hint */}
-          <div className="mt-4 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-5">
-            <h3 className="flex items-center gap-2 text-sm font-semibold text-[var(--gantry-text-primary)]">
-              <Info className="h-4 w-4 text-[var(--gantry-text-secondary)]" />
-              SSO Users
-            </h3>
-            <p className="mt-2 text-xs text-[var(--gantry-text-secondary)]">
-              For users who will sign in via GitHub SSO, create their account with the username{' '}
-              <code className="rounded bg-[var(--gantry-bg-tertiary)] px-1 py-0.5 text-[var(--gantry-text-primary)]">
-                github:&lt;username&gt;
-              </code>{' '}
-              or use the same email address as their GitHub account. The password can be any value — SSO users authenticate through GitHub.
-            </p>
-          </div>
-
-          {/* Manage roles hint */}
+          {/* Managing roles hint */}
           <div className="mt-4 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-5">
             <h3 className="flex items-center gap-2 text-sm font-semibold text-[var(--gantry-text-primary)]">
               <Shield className="h-4 w-4 text-[var(--gantry-text-secondary)]" />
@@ -224,10 +273,16 @@ export default function UsersPage() {
                             {(u.displayName || u.username)[0].toUpperCase()}
                           </div>
                           <div>
-                            <p className="text-sm font-medium text-[var(--gantry-text-primary)]">
+                            <p className="flex items-center gap-1.5 text-sm font-medium text-[var(--gantry-text-primary)]">
                               {u.displayName || u.username}
                               {u.id === me?.id && (
-                                <span className="ml-1.5 text-xs text-[var(--gantry-text-secondary)]">(you)</span>
+                                <span className="text-xs text-[var(--gantry-text-secondary)]">(you)</span>
+                              )}
+                              {u.ssoOnly && (
+                                <span className="inline-flex items-center gap-0.5 rounded-full bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                                  <Globe className="h-2.5 w-2.5" />
+                                  SSO
+                                </span>
                               )}
                             </p>
                             <p className="text-xs text-[var(--gantry-text-secondary)]">@{u.username}</p>
@@ -259,14 +314,25 @@ export default function UsersPage() {
                         </span>
                       </td>
                       <td className="px-4 py-3 text-right">
-                        <button
-                          onClick={() => handleDelete(u.id)}
-                          disabled={u.id === me?.id}
-                          className="rounded p-1.5 text-[var(--gantry-text-secondary)] opacity-0 transition-opacity group-hover:opacity-100 hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-danger)] disabled:pointer-events-none disabled:opacity-0"
-                          title="Delete user"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
+                        <div className="flex items-center justify-end gap-1">
+                          {!u.ssoOnly && u.id !== me?.id && (
+                            <button
+                              onClick={() => { setResetUserId(u.id); setResetPassword(''); setResetError(''); setResetSuccess(''); }}
+                              className="rounded p-1.5 text-[var(--gantry-text-secondary)] opacity-0 transition-opacity group-hover:opacity-100 hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-accent)]"
+                              title="Reset password"
+                            >
+                              <KeyRound className="h-4 w-4" />
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleDelete(u.id)}
+                            disabled={u.id === me?.id}
+                            className="rounded p-1.5 text-[var(--gantry-text-secondary)] opacity-0 transition-opacity group-hover:opacity-100 hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-danger)] disabled:pointer-events-none disabled:opacity-0"
+                            title="Delete user"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
                       </td>
                     </tr>
                   ))}
@@ -276,6 +342,52 @@ export default function UsersPage() {
           </div>
         </div>
       </div>
+
+      {/* Reset password modal */}
+      {resetUserId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setResetUserId(null)}>
+          <div
+            className="w-full max-w-sm rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-base font-semibold text-[var(--gantry-text-primary)]">Reset Password</h3>
+            <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
+              Set a new password for <strong>{resetUser?.displayName || resetUser?.username}</strong>
+            </p>
+            <div className="mt-4">
+              <label className="block text-xs font-medium text-[var(--gantry-text-secondary)]">
+                New Password <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="password"
+                value={resetPassword}
+                onChange={(e) => setResetPassword(e.target.value)}
+                placeholder="Min. 8 characters"
+                className="mt-1 w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] outline-none focus:border-[var(--gantry-accent)]"
+                autoFocus
+                onKeyDown={(e) => { if (e.key === 'Enter') handleResetPassword(); }}
+              />
+            </div>
+            {resetError && <p className="mt-2 text-xs text-red-500">{resetError}</p>}
+            {resetSuccess && <p className="mt-2 text-xs text-green-600 dark:text-green-400">{resetSuccess}</p>}
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => setResetUserId(null)}
+                className="rounded-lg border border-[var(--gantry-border)] px-3 py-1.5 text-sm text-[var(--gantry-text-secondary)] hover:bg-[var(--gantry-bg-secondary)]"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleResetPassword}
+                disabled={resetting || !resetPassword.trim() || resetPassword.trim().length < 8}
+                className="rounded-lg bg-[var(--gantry-accent)] px-3 py-1.5 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)] disabled:opacity-50"
+              >
+                {resetting ? 'Resetting…' : 'Reset Password'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This pull request introduces support for "SSO-only" user accounts, which can only authenticate via Single Sign-On (SSO) providers (such as GitHub OAuth) and not with a username/password. It adds the `ssoOnly` field to user records, updates the authentication and user management logic to enforce SSO-only restrictions, and includes a database migration to support the new field. Additionally, it provides a new admin endpoint for password resets, with appropriate checks for SSO-only accounts.

**SSO-only user support and enforcement:**

* Added a `SSOOnly` (or `ssoOnly`) boolean field to the user model, API request/response types, and all relevant database queries and mutations to indicate whether a user is restricted to SSO authentication. [[1]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR29) [[2]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR37) [[3]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR50) [[4]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR251) [[5]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL647-R659) [[6]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR671) [[7]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL681-R684) [[8]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL693-R702) [[9]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL712-R723) [[10]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR732) [[11]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL735-R747) [[12]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL778-R791) [[13]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR800) [[14]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL823-R835) [[15]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL1904-R1913) [[16]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR1927-R1929) [[17]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR262) [[18]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR200) [[19]](diffhunk://#diff-e1ce54d8a0526de03b735f4432a18967e5e1afad2534e42f67084ed76fb76622R188)

* Updated authentication endpoints to prevent SSO-only users from logging in or changing passwords with username/password, and to allow creation of SSO-only users (who do not require a password). [[1]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR74-R79) [[2]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR161-R190) [[3]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR379-R384)

**Admin password reset and user management:**

* Added a new admin endpoint (`PUT /auth/users/{id}/password`) for password resets, which is disallowed for SSO-only accounts. [[1]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR403-R453) [[2]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R119)

* Allowed updating the `ssoOnly` status of users via the user update API.

**Database migration and safety:**

* Added a database migration to add the `sso_only` column to the `users` table, and updated all relevant queries to read/write this field. [[1]](diffhunk://#diff-f29fecc45de825f158ad104c67dd01808f34ce4410f10fd6ccb7b2343b3bd13cR216-R222) [[2]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR29) [[3]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL647-R659) [[4]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL681-R684) [[5]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL693-R702) [[6]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL712-R723) [[7]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR732) [[8]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL735-R747) [[9]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL778-R791) [[10]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR800) [[11]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL823-R835) [[12]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaL1904-R1913) [[13]](diffhunk://#diff-f23ffbbed427a0cc31433301312efcfd40254182c9845f14b4e19dbbb43dc1aaR1927-R1929)

* Improved migration logic to safely ignore "duplicate column" errors, ensuring migrations are idempotent and safe across restarts.

**Documentation and comments:**

* Added and clarified comments in code regarding the behavior and restrictions of SSO-only accounts, especially in registration and authentication handlers. [[1]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR161-R190) [[2]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR379-R384) [[3]](diffhunk://#diff-fee5b9da7b1d127c959e4a70f22dfd975e2a9349f43d9e1338abe3bfb2d2946bR403-R453)

This update ensures robust support for SSO-only users, with clear separation of authentication methods and safe database migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can create SSO-only users (UI toggle); password field hidden when enabled.
  * Per-user admin password reset for non-SSO users via new UI flow and backend endpoint.
  * GitHub SSO auto-provisioned users are created as SSO-only and visibly badged in the UI.
  * User create/update API surfaces now support an SSO-only flag.

* **Bug Fixes / Behavior**
  * Password login, password changes, and admin resets are blocked for SSO-only accounts.

* **Chores**
  * Database migrations add a persistent SSO flag and tolerate duplicate-column errors on re-run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->