### PR TITLE
fix: update HealthCheckProxy test to allow internal and private IPs

### DIFF
--- a/internal/api/handlers/health_proxy.go
+++ b/internal/api/handlers/health_proxy.go
@@ -1,9 +1,7 @@
 package handlers
 
 import (
-	"context"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -26,10 +24,6 @@ func (h *Handlers) HealthCheckProxy(w http.ResponseWriter, r *http.Request) {
 	}
 	if parsed.User != nil {
 		writeError(w, http.StatusBadRequest, "url must not contain userinfo")
-		return
-	}
-	if err := ensurePublicTarget(r.Context(), parsed.Hostname()); err != nil {
-		writeError(w, http.StatusForbidden, err.Error())
 		return
 	}
 
@@ -70,52 +64,3 @@ func (h *Handlers) HealthCheckProxy(w http.ResponseWriter, r *http.Request) {
 		"body":       string(body),
 	})
 }
-
-func ensurePublicTarget(ctx context.Context, host string) error {
-	if host == "" {
-		return errForbiddenTarget("missing host")
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		if !isPublicIP(ip) {
-			return errForbiddenTarget("private and loopback targets are not allowed")
-		}
-		return nil
-	}
-
-	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil || len(addrs) == 0 {
-		return errForbiddenTarget("unable to resolve target host")
-	}
-	for _, addr := range addrs {
-		if !isPublicIP(addr.IP) {
-			return errForbiddenTarget("private and loopback targets are not allowed")
-		}
-	}
-	return nil
-}
-
-func isPublicIP(ip net.IP) bool {
-	if ip == nil {
-		return false
-	}
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() ||
-		ip.IsMulticast() || ip.IsUnspecified() {
-		return false
-	}
-	if v4 := ip.To4(); v4 != nil {
-		if v4[0] == 169 && v4[1] == 254 {
-			return false
-		}
-	}
-	return true
-}
-
-func errForbiddenTarget(msg string) error {
-	return &targetError{msg: msg}
-}
-
-type targetError struct {
-	msg string
-}
-
-func (e *targetError) Error() string { return e.msg }

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -348,16 +348,38 @@ func TestWebSocketHandshakeAcceptsSessionCookieAuth(t *testing.T) {
 }
 
 func TestHealthCheckProxyAllowsLoopbackTargets(t *testing.T) {
+	// Spin up a local server on loopback to act as the health endpoint.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"UP"}`))
+	}))
+	defer upstream.Close()
+
 	env := newTestServerEnv(t)
 	_, token := env.createUser(t, "health-user", "viewer")
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/health-check?url=http://127.0.0.1/healthz", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health-check?url="+upstream.URL+"/healthz", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	env.server.Router().ServeHTTP(rec, req)
 
-	// Should not be forbidden — the proxy allows internal targets.
-	if rec.Code == http.StatusForbidden {
-		t.Fatalf("expected non-403, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result["reachable"] != true {
+		t.Fatalf("expected reachable=true, got %v", result["reachable"])
+	}
+	if result["statusCode"] != float64(200) {
+		t.Fatalf("expected statusCode=200, got %v", result["statusCode"])
+	}
+	body, _ := result["body"].(string)
+	if body != `{"status":"UP"}` {
+		t.Fatalf("expected upstream body, got %q", body)
 	}
 }

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -347,7 +347,7 @@ func TestWebSocketHandshakeAcceptsSessionCookieAuth(t *testing.T) {
 	}
 }
 
-func TestHealthCheckProxyRejectsLoopbackTargets(t *testing.T) {
+func TestHealthCheckProxyAllowsLoopbackTargets(t *testing.T) {
 	env := newTestServerEnv(t)
 	_, token := env.createUser(t, "health-user", "viewer")
 
@@ -356,7 +356,8 @@ func TestHealthCheckProxyRejectsLoopbackTargets(t *testing.T) {
 	rec := httptest.NewRecorder()
 	env.server.Router().ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	// Should not be forbidden — the proxy allows internal targets.
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("expected non-403, got %d: %s", rec.Code, rec.Body.String())
 	}
 }


### PR DESCRIPTION
This pull request removes the restriction that previously prevented the health check proxy endpoint from targeting private or loopback addresses. The proxy now allows requests to internal network targets, and the associated code and tests have been updated accordingly.

Security policy changes:

* Removed the `ensurePublicTarget` check in the `HealthCheckProxy` handler, so requests to private and loopback targets are now allowed (`internal/api/handlers/health_proxy.go`).
* Deleted the `ensurePublicTarget`, `isPublicIP`, `errForbiddenTarget`, and related helper types and functions, as they are no longer needed (`internal/api/handlers/health_proxy.go`).

Test updates:

* Updated the test to expect that loopback targets are allowed, renaming it to `TestHealthCheckProxyAllowsLoopbackTargets` and changing the assertion to expect a non-403 response (`internal/api/server_security_test.go`). [[1]](diffhunk://#diff-1047686344328c751d6561521118412c725ca19001047fbbb4c4822fd4ba833fL350-R350) [[2]](diffhunk://#diff-1047686344328c751d6561521118412c725ca19001047fbbb4c4822fd4ba833fL359-R361)

Code cleanup:

* Removed unused imports (`context`, `net`) from `internal/api/handlers/health_proxy.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health check proxy now accepts loopback and local target addresses previously rejected.
  * Simplified health check validation to require valid HTTP(S) URLs without additional host filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->