### PR TITLE
feat: add Nexus Repository Manager plugin integration with components and assets endpoints

### DIFF
--- a/internal/api/handlers/nexus.go
+++ b/internal/api/handlers/nexus.go
@@ -281,6 +281,7 @@ func (h *Handlers) GetNexusComponents(w http.ResponseWriter, r *http.Request) {
 	for _, raw := range allItems {
 		var c NexusComponent
 		if err := json.Unmarshal(raw, &c); err != nil {
+			log.Printf("[nexus] skipping component: unmarshal error: %v", err)
 			continue
 		}
 		if c.Assets == nil {
@@ -332,6 +333,7 @@ func (h *Handlers) GetNexusAssets(w http.ResponseWriter, r *http.Request) {
 	for _, raw := range allItems {
 		var a NexusAsset
 		if err := json.Unmarshal(raw, &a); err != nil {
+			log.Printf("[nexus] skipping asset: unmarshal error: %v", err)
 			continue
 		}
 		assets = append(assets, a)

--- a/internal/api/handlers/nexus.go
+++ b/internal/api/handlers/nexus.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"sync"
@@ -67,22 +68,38 @@ func nexusCacheGet(key string) ([]byte, bool) {
 	return entry.data, true
 }
 
+const maxNexusCacheEntries = 200
+
 func nexusCacheSet(key string, data []byte) {
 	nexusCacheMu.Lock()
 	defer nexusCacheMu.Unlock()
 	if nexusCacheEntries == nil {
 		nexusCacheEntries = make(map[string]nexusCacheEntry)
 	}
-	now := time.Now()
-	// Evict expired entries to prevent unbounded growth.
-	for k, v := range nexusCacheEntries {
-		if now.After(v.expiresAt) {
-			delete(nexusCacheEntries, k)
-		}
-	}
 	nexusCacheEntries[key] = nexusCacheEntry{
 		data:      data,
-		expiresAt: now.Add(60 * time.Second),
+		expiresAt: time.Now().Add(60 * time.Second),
+	}
+	// Evict if over capacity: remove expired first, then oldest entries.
+	if len(nexusCacheEntries) > maxNexusCacheEntries {
+		now := time.Now()
+		for k, v := range nexusCacheEntries {
+			if now.After(v.expiresAt) {
+				delete(nexusCacheEntries, k)
+			}
+		}
+		// If still over capacity, remove nearest-expiry entries.
+		for len(nexusCacheEntries) > maxNexusCacheEntries {
+			var oldestKey string
+			var oldestExp time.Time
+			for k, v := range nexusCacheEntries {
+				if oldestKey == "" || v.expiresAt.Before(oldestExp) {
+					oldestKey = k
+					oldestExp = v.expiresAt
+				}
+			}
+			delete(nexusCacheEntries, oldestKey)
+		}
 	}
 }
 
@@ -219,7 +236,8 @@ func (h *Handlers) GetNexusComponents(w http.ResponseWriter, r *http.Request) {
 	path := "/service/rest/v1/search?" + params.Encode()
 	body, err := nexusRequest(r.Context(), cfg.URL, cfg.Username, cfg.Password, path)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to fetch components: "+err.Error())
+		log.Printf("[nexus] failed to fetch components (path=%s): %v", path, err)
+		writeError(w, http.StatusBadGateway, "failed to fetch components from Nexus")
 		return
 	}
 
@@ -275,7 +293,8 @@ func (h *Handlers) GetNexusAssets(w http.ResponseWriter, r *http.Request) {
 	path := "/service/rest/v1/search/assets?" + params.Encode()
 	body, err := nexusRequest(r.Context(), cfg.URL, cfg.Username, cfg.Password, path)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to fetch assets: "+err.Error())
+		log.Printf("[nexus] failed to fetch assets (path=%s): %v", path, err)
+		writeError(w, http.StatusBadGateway, "failed to fetch assets from Nexus")
 		return
 	}
 

--- a/internal/api/handlers/nexus.go
+++ b/internal/api/handlers/nexus.go
@@ -167,10 +167,8 @@ func getNexusConfig(cfg map[string]any) (nexusPluginConfig, error) {
 	if c.URL == "" {
 		return c, fmt.Errorf("nexus plugin requires url")
 	}
-	// Normalise: strip trailing slash so callers can just append /service/rest/...
-	for len(c.URL) > 0 && c.URL[len(c.URL)-1] == '/' {
-		c.URL = c.URL[:len(c.URL)-1]
-	}
+	// Normalise: strip trailing slashes so callers can just append /service/rest/...
+	c.URL = strings.TrimRight(c.URL, "/")
 	return c, nil
 }
 

--- a/internal/api/handlers/nexus.go
+++ b/internal/api/handlers/nexus.go
@@ -1,0 +1,298 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// Shared HTTP client for all Nexus API requests.
+var nexusHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+// Nexus response types.
+
+type NexusAsset struct {
+	DownloadURL string `json:"downloadUrl"`
+	Path        string `json:"path"`
+	ID          string `json:"id"`
+	Repository  string `json:"repository"`
+	Format      string `json:"format"`
+	ContentType string `json:"contentType"`
+	LastModified string `json:"lastModified"`
+	FileSize    int64  `json:"fileSize"`
+}
+
+type NexusComponent struct {
+	ID         string       `json:"id"`
+	Repository string       `json:"repository"`
+	Format     string       `json:"format"`
+	Group      string       `json:"group"`
+	Name       string       `json:"name"`
+	Version    string       `json:"version"`
+	Assets     []NexusAsset `json:"assets"`
+}
+
+type nexusSearchResponse struct {
+	Items             []json.RawMessage `json:"items"`
+	ContinuationToken string           `json:"continuationToken"`
+}
+
+// In-memory cache for Nexus API responses.
+var (
+	nexusCacheMu      sync.RWMutex
+	nexusCacheEntries map[string]nexusCacheEntry
+)
+
+type nexusCacheEntry struct {
+	data      []byte
+	expiresAt time.Time
+}
+
+func nexusCacheGet(key string) ([]byte, bool) {
+	nexusCacheMu.RLock()
+	defer nexusCacheMu.RUnlock()
+	if nexusCacheEntries == nil {
+		return nil, false
+	}
+	entry, ok := nexusCacheEntries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.data, true
+}
+
+func nexusCacheSet(key string, data []byte) {
+	nexusCacheMu.Lock()
+	defer nexusCacheMu.Unlock()
+	if nexusCacheEntries == nil {
+		nexusCacheEntries = make(map[string]nexusCacheEntry)
+	}
+	now := time.Now()
+	// Evict expired entries to prevent unbounded growth.
+	for k, v := range nexusCacheEntries {
+		if now.After(v.expiresAt) {
+			delete(nexusCacheEntries, k)
+		}
+	}
+	nexusCacheEntries[key] = nexusCacheEntry{
+		data:      data,
+		expiresAt: now.Add(60 * time.Second),
+	}
+}
+
+func nexusRequest(ctx context.Context, baseURL, username, password, path string) ([]byte, error) {
+	reqURL := baseURL + path
+
+	// Check cache first.
+	if cached, ok := nexusCacheGet(reqURL); ok {
+		return cached, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Gantry/1.0 NexusRepositoryManager")
+	if username != "" && password != "" {
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	}
+
+	resp, err := nexusHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	const maxBody = 2 << 20 // 2 MiB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxBody {
+		return nil, fmt.Errorf("nexus API response exceeded %d bytes", maxBody)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("nexus API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	nexusCacheSet(reqURL, body)
+	return body, nil
+}
+
+type nexusPluginConfig struct {
+	URL               string
+	Username          string
+	Password          string
+	DefaultRepository string
+}
+
+func getNexusConfig(cfg map[string]any) (nexusPluginConfig, error) {
+	c := nexusPluginConfig{}
+	if cfg == nil {
+		return c, fmt.Errorf("nexus plugin has no configuration")
+	}
+	c.URL, _ = cfg["url"].(string)
+	c.Username, _ = cfg["username"].(string)
+	c.Password, _ = cfg["password"].(string)
+	c.DefaultRepository, _ = cfg["defaultRepository"].(string)
+	if c.URL == "" {
+		return c, fmt.Errorf("nexus plugin requires url")
+	}
+	// Normalise: strip trailing slash so callers can just append /service/rest/...
+	for len(c.URL) > 0 && c.URL[len(c.URL)-1] == '/' {
+		c.URL = c.URL[:len(c.URL)-1]
+	}
+	return c, nil
+}
+
+// ensureNexusConfig checks the nexus plugin is installed, enabled, and configured.
+func (h *Handlers) ensureNexusConfig(w http.ResponseWriter, r *http.Request) (nexusPluginConfig, error) {
+	p, err := h.DB.GetPlugin(r.Context(), "nexus-repository-manager")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "plugin lookup failed")
+		return nexusPluginConfig{}, fmt.Errorf("plugin lookup failed: %w", err)
+	}
+	if p == nil {
+		writeError(w, http.StatusNotFound, "nexus-repository-manager plugin not installed")
+		return nexusPluginConfig{}, fmt.Errorf("not installed")
+	}
+	if !p.Enabled {
+		writeError(w, http.StatusBadRequest, "nexus-repository-manager plugin is not enabled")
+		return nexusPluginConfig{}, fmt.Errorf("not enabled")
+	}
+	cfg, err := getNexusConfig(p.Config)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return nexusPluginConfig{}, err
+	}
+	return cfg, nil
+}
+
+// GetNexusComponents searches for components in Nexus Repository Manager.
+func (h *Handlers) GetNexusComponents(w http.ResponseWriter, r *http.Request) {
+	cfg, err := h.ensureNexusConfig(w, r)
+	if err != nil {
+		return
+	}
+
+	name := r.URL.Query().Get("name")
+	repository := r.URL.Query().Get("repository")
+	group := r.URL.Query().Get("group")
+	format := r.URL.Query().Get("format")
+
+	if repository == "" {
+		repository = cfg.DefaultRepository
+	}
+
+	params := url.Values{}
+	if name != "" {
+		// Wrap in wildcards for partial matching — the Nexus name field may
+		// include a group prefix (e.g. "goodville/report-claims-module" or
+		// "gbiz/claims-elements-0.0.0.zip") so *name* matches regardless of
+		// prefix/suffix. This is much more precise than the "q" keyword param
+		// which splits on word boundaries and returns unrelated components.
+		if name[0] != '*' {
+			name = "*" + name
+		}
+		if name[len(name)-1] != '*' {
+			name = name + "*"
+		}
+		params.Set("name", name)
+	}
+	if repository != "" {
+		params.Set("repository", repository)
+	}
+	if group != "" {
+		params.Set("group", group)
+	}
+	if format != "" {
+		params.Set("format", format)
+	}
+
+	path := "/service/rest/v1/search?" + params.Encode()
+	body, err := nexusRequest(r.Context(), cfg.URL, cfg.Username, cfg.Password, path)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch components: "+err.Error())
+		return
+	}
+
+	var searchResp nexusSearchResponse
+	if err := json.Unmarshal(body, &searchResp); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to parse nexus response")
+		return
+	}
+
+	components := make([]NexusComponent, 0, len(searchResp.Items))
+	for _, raw := range searchResp.Items {
+		var c NexusComponent
+		if err := json.Unmarshal(raw, &c); err != nil {
+			continue
+		}
+		if c.Assets == nil {
+			c.Assets = []NexusAsset{}
+		}
+		components = append(components, c)
+	}
+
+	writeJSON(w, http.StatusOK, components)
+}
+
+// GetNexusAssets searches for assets in Nexus Repository Manager.
+func (h *Handlers) GetNexusAssets(w http.ResponseWriter, r *http.Request) {
+	cfg, err := h.ensureNexusConfig(w, r)
+	if err != nil {
+		return
+	}
+
+	name := r.URL.Query().Get("name")
+	repository := r.URL.Query().Get("repository")
+
+	if repository == "" {
+		repository = cfg.DefaultRepository
+	}
+
+	params := url.Values{}
+	if name != "" {
+		if name[0] != '*' {
+			name = "*" + name
+		}
+		if name[len(name)-1] != '*' {
+			name = name + "*"
+		}
+		params.Set("name", name)
+	}
+	if repository != "" {
+		params.Set("repository", repository)
+	}
+
+	path := "/service/rest/v1/search/assets?" + params.Encode()
+	body, err := nexusRequest(r.Context(), cfg.URL, cfg.Username, cfg.Password, path)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch assets: "+err.Error())
+		return
+	}
+
+	var searchResp nexusSearchResponse
+	if err := json.Unmarshal(body, &searchResp); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to parse nexus response")
+		return
+	}
+
+	assets := make([]NexusAsset, 0, len(searchResp.Items))
+	for _, raw := range searchResp.Items {
+		var a NexusAsset
+		if err := json.Unmarshal(raw, &a); err != nil {
+			continue
+		}
+		assets = append(assets, a)
+	}
+
+	writeJSON(w, http.StatusOK, assets)
+}

--- a/internal/api/handlers/nexus.go
+++ b/internal/api/handlers/nexus.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -194,10 +195,10 @@ func nexusPaginatedSearch(ctx context.Context, cfg nexusPluginConfig, basePath s
 		if resp.ContinuationToken == "" {
 			break
 		}
-		// Append or replace continuationToken query param.
-		sep := "&"
-		if basePath == "" {
-			sep = "?"
+		// Append continuationToken query param.
+		sep := "?"
+		if strings.Contains(basePath, "?") {
+			sep = "&"
 		}
 		path = basePath + sep + "continuationToken=" + url.QueryEscape(resp.ContinuationToken)
 	}

--- a/internal/api/handlers/nexus.go
+++ b/internal/api/handlers/nexus.go
@@ -136,7 +136,11 @@ func nexusRequest(ctx context.Context, baseURL, username, password, path string)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("nexus API returned %d: %s", resp.StatusCode, string(body))
+		excerpt := string(body)
+		if len(excerpt) > 200 {
+			excerpt = excerpt[:200] + "…(truncated)"
+		}
+		return nil, fmt.Errorf("nexus API returned %d: %s", resp.StatusCode, excerpt)
 	}
 
 	nexusCacheSet(reqURL, body)
@@ -167,6 +171,37 @@ func getNexusConfig(cfg map[string]any) (nexusPluginConfig, error) {
 		c.URL = c.URL[:len(c.URL)-1]
 	}
 	return c, nil
+}
+
+// nexusPaginatedSearch fetches all pages of a Nexus search endpoint,
+// following continuationToken until exhausted. maxPages caps the loop to
+// prevent runaway requests against very large result sets.
+func nexusPaginatedSearch(ctx context.Context, cfg nexusPluginConfig, basePath string) ([]json.RawMessage, error) {
+	const maxPages = 20
+	var allItems []json.RawMessage
+	path := basePath
+
+	for page := 0; page < maxPages; page++ {
+		body, err := nexusRequest(ctx, cfg.URL, cfg.Username, cfg.Password, path)
+		if err != nil {
+			return nil, err
+		}
+		var resp nexusSearchResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("failed to parse nexus response: %w", err)
+		}
+		allItems = append(allItems, resp.Items...)
+		if resp.ContinuationToken == "" {
+			break
+		}
+		// Append or replace continuationToken query param.
+		sep := "&"
+		if basePath == "" {
+			sep = "?"
+		}
+		path = basePath + sep + "continuationToken=" + url.QueryEscape(resp.ContinuationToken)
+	}
+	return allItems, nil
 }
 
 // ensureNexusConfig checks the nexus plugin is installed, enabled, and configured.
@@ -233,22 +268,16 @@ func (h *Handlers) GetNexusComponents(w http.ResponseWriter, r *http.Request) {
 		params.Set("format", format)
 	}
 
-	path := "/service/rest/v1/search?" + params.Encode()
-	body, err := nexusRequest(r.Context(), cfg.URL, cfg.Username, cfg.Password, path)
+	basePath := "/service/rest/v1/search?" + params.Encode()
+	allItems, err := nexusPaginatedSearch(r.Context(), cfg, basePath)
 	if err != nil {
-		log.Printf("[nexus] failed to fetch components (path=%s): %v", path, err)
+		log.Printf("[nexus] failed to fetch components (path=%s): %v", basePath, err)
 		writeError(w, http.StatusBadGateway, "failed to fetch components from Nexus")
 		return
 	}
 
-	var searchResp nexusSearchResponse
-	if err := json.Unmarshal(body, &searchResp); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to parse nexus response")
-		return
-	}
-
-	components := make([]NexusComponent, 0, len(searchResp.Items))
-	for _, raw := range searchResp.Items {
+	components := make([]NexusComponent, 0, len(allItems))
+	for _, raw := range allItems {
 		var c NexusComponent
 		if err := json.Unmarshal(raw, &c); err != nil {
 			continue
@@ -290,22 +319,16 @@ func (h *Handlers) GetNexusAssets(w http.ResponseWriter, r *http.Request) {
 		params.Set("repository", repository)
 	}
 
-	path := "/service/rest/v1/search/assets?" + params.Encode()
-	body, err := nexusRequest(r.Context(), cfg.URL, cfg.Username, cfg.Password, path)
+	basePath := "/service/rest/v1/search/assets?" + params.Encode()
+	allItems, err := nexusPaginatedSearch(r.Context(), cfg, basePath)
 	if err != nil {
-		log.Printf("[nexus] failed to fetch assets (path=%s): %v", path, err)
+		log.Printf("[nexus] failed to fetch assets (path=%s): %v", basePath, err)
 		writeError(w, http.StatusBadGateway, "failed to fetch assets from Nexus")
 		return
 	}
 
-	var searchResp nexusSearchResponse
-	if err := json.Unmarshal(body, &searchResp); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to parse nexus response")
-		return
-	}
-
-	assets := make([]NexusAsset, 0, len(searchResp.Items))
-	for _, raw := range searchResp.Items {
+	assets := make([]NexusAsset, 0, len(allItems))
+	for _, raw := range allItems {
 		var a NexusAsset
 		if err := json.Unmarshal(raw, &a); err != nil {
 			continue

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,6 +214,9 @@ func NewServer(cfg *config.Config, database *db.DB, authSvc *auth.Service, event
 			protected.Get("/plugins/harbor/artifacts", h.GetHarborArtifacts)
 			protected.Get("/plugins/harbor/vulnerabilities", h.GetHarborVulnerabilities)
 			protected.Get("/plugins/harbor/summary", h.GetHarborSummary)
+			// Nexus Repository Manager plugin endpoints.
+			protected.Get("/plugins/nexus-repository-manager/components", h.GetNexusComponents)
+			protected.Get("/plugins/nexus-repository-manager/assets", h.GetNexusAssets)
 			// ArgoCD-specific plugin endpoints.
 			protected.Get("/plugins/argocd/entity-apps", h.GetArgoCDEntityApps)
 			protected.Get("/plugins/argocd/apps/{appName}", h.GetArgoCDApp)

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -56,7 +56,7 @@ func newTestServerEnv(t *testing.T) *testServerEnv {
 	}
 
 	authSvc := auth.NewService(cfg.JWTSecret)
-	server := NewServer(cfg, database, authSvc, events.New(), nil, search.New(database.DB), websocket.NewHub())
+	server := NewServer(cfg, database, authSvc, events.New(), nil, search.New(database.DB), websocket.NewHub(), "test")
 
 	return &testServerEnv{
 		server:  server,

--- a/internal/plugins/bundled/registry.json
+++ b/internal/plugins/bundled/registry.json
@@ -699,5 +699,52 @@
     },
     "entityPanels": ["Service", "Infrastructure"],
     "actionTypes": []
+  },
+  {
+    "name": "nexus-repository-manager",
+    "title": "Nexus Repository Manager",
+    "description": "Browse build artifacts, Docker images, and package versions from Sonatype Nexus Repository Manager on entity pages.",
+    "longDescription": "The Nexus Repository Manager plugin connects Gantry to your Sonatype Nexus instance, enriching Service and Infrastructure entities with live artifact data — component versions, asset details, download links, and repository metadata.\n\nOnce installed, any entity with a `nexus-repository-manager/name` annotation will automatically show a Nexus tab listing matching components and their assets. Supports all repository formats including Maven, npm, Docker, PyPI, NuGet, and raw.",
+    "features": [
+      "Component and asset browser on Service and Infrastructure entities",
+      "View component versions, formats, and repository locations",
+      "Expandable asset details with download URLs, file sizes, and content types",
+      "Supports all Nexus repository formats (Maven, npm, Docker, PyPI, NuGet, raw, etc.)",
+      "Annotation-driven setup — no code required",
+      "In-memory caching with 60-second TTL for Nexus API responses"
+    ],
+    "version": "1.0.0",
+    "author": "Gantry",
+    "category": "integration",
+    "homepage": "https://help.sonatype.com/en/sonatype-nexus-repository.html",
+    "configSchema": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "title": "Nexus URL",
+          "description": "Base URL of your Nexus Repository Manager instance (e.g. https://nexus.example.com)"
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "Nexus username for API authentication (optional for anonymous access)"
+        },
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "description": "Nexus password or API token",
+          "secret": true
+        },
+        "defaultRepository": {
+          "type": "string",
+          "title": "Default Repository",
+          "description": "Default repository to search when no repository annotation is set on the entity."
+        }
+      },
+      "required": ["url"]
+    },
+    "entityPanels": ["Service", "Infrastructure"],
+    "actionTypes": []
   }
 ]

--- a/web/src/components/NexusTab.tsx
+++ b/web/src/components/NexusTab.tsx
@@ -1,0 +1,306 @@
+import { useState, useEffect, useMemo } from 'react';
+import { ChevronDown, ChevronRight, ChevronUp, Package, FileDown, Archive } from 'lucide-react';
+import { api } from '../lib/api';
+import type { Entity, NexusComponent, NexusAsset } from '../lib/types';
+
+const FORMAT_BADGE: Record<string, string> = {
+  maven2: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  npm: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  docker: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  pypi: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  nuget: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  raw: 'bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400',
+};
+
+type SortKey = 'name' | 'version' | 'format' | 'repository' | 'assets' | 'modified';
+type SortDir = 'asc' | 'desc';
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes === 0) return '—';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+function formatDate(ts: string): string {
+  if (!ts) return '—';
+  return new Date(ts).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+/** Return the most recent lastModified from a component's assets, or '' if none. */
+function latestModified(component: NexusComponent): string {
+  let latest = '';
+  for (const a of component.assets) {
+    if (a.lastModified && a.lastModified > latest) latest = a.lastModified;
+  }
+  return latest;
+}
+
+function SortIcon({ column, sortKey, sortDir }: { column: SortKey; sortKey: SortKey; sortDir: SortDir }) {
+  if (column !== sortKey) return null;
+  return sortDir === 'asc'
+    ? <ChevronUp className="inline h-3 w-3 ml-0.5" />
+    : <ChevronDown className="inline h-3 w-3 ml-0.5" />;
+}
+
+function AssetRow({ asset }: { asset: NexusAsset }) {
+  const fileName = asset.path?.split('/').pop() || asset.path || '—';
+  return (
+    <tr className="text-xs">
+      <td className="py-1.5 pr-4 text-[var(--gantry-text-primary)]">
+        <div className="flex items-center gap-1.5">
+          <FileDown className="h-3 w-3 text-[var(--gantry-text-secondary)]" />
+          {asset.downloadUrl ? (
+            <a
+              href={asset.downloadUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-[var(--gantry-accent)] hover:text-[var(--gantry-accent-hover)]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {fileName}
+            </a>
+          ) : (
+            <span>{fileName}</span>
+          )}
+        </div>
+      </td>
+      <td className="py-1.5 pr-4 font-mono text-[var(--gantry-text-secondary)]">{asset.contentType || '—'}</td>
+      <td className="py-1.5 pr-4 text-[var(--gantry-text-secondary)]">{formatBytes(asset.fileSize)}</td>
+      <td className="py-1.5 text-[var(--gantry-text-secondary)]">{formatDate(asset.lastModified)}</td>
+    </tr>
+  );
+}
+
+function ComponentRow({ component }: { component: NexusComponent }) {
+  const [expanded, setExpanded] = useState(false);
+  const formatCls = FORMAT_BADGE[component.format] || FORMAT_BADGE.raw;
+  const modified = latestModified(component);
+
+  return (
+    <>
+      <tr
+        className="cursor-pointer hover:bg-[var(--gantry-bg-secondary)]"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <td className="px-4 py-3">
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-[var(--gantry-text-secondary)]" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-[var(--gantry-text-secondary)]" />
+          )}
+        </td>
+        <td className="px-4 py-3 text-xs font-medium text-[var(--gantry-text-primary)]">
+          {component.group ? `${component.group}/${component.name}` : component.name}
+        </td>
+        <td className="px-4 py-3 font-mono text-xs text-[var(--gantry-text-primary)]">{component.version || '—'}</td>
+        <td className="px-4 py-3">
+          <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${formatCls}`}>
+            {component.format}
+          </span>
+        </td>
+        <td className="px-4 py-3 text-xs text-[var(--gantry-text-secondary)]">{component.repository}</td>
+        <td className="px-4 py-3 text-xs text-[var(--gantry-text-secondary)]">
+          {component.assets.length} {component.assets.length === 1 ? 'asset' : 'assets'}
+        </td>
+        <td className="px-4 py-3 text-xs text-[var(--gantry-text-secondary)]">
+          {modified ? formatDate(modified) : '—'}
+        </td>
+      </tr>
+      {expanded && component.assets.length > 0 && (
+        <tr>
+          <td colSpan={7} className="bg-[var(--gantry-bg-secondary)] px-8 pb-4 pt-2">
+            <table className="min-w-full text-xs">
+              <thead>
+                <tr className="text-left text-[var(--gantry-text-secondary)]">
+                  <th className="pb-1 pr-4 font-medium">File</th>
+                  <th className="pb-1 pr-4 font-medium">Content Type</th>
+                  <th className="pb-1 pr-4 font-medium">Size</th>
+                  <th className="pb-1 font-medium">Modified</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--gantry-border)]">
+                {component.assets.map((a) => (
+                  <AssetRow key={a.id || a.path} asset={a} />
+                ))}
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      )}
+      {expanded && component.assets.length === 0 && (
+        <tr>
+          <td colSpan={7} className="bg-[var(--gantry-bg-secondary)] px-8 pb-4 pt-2">
+            <p className="py-2 text-xs text-[var(--gantry-text-secondary)]">No assets found for this component.</p>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+export default function NexusTab({ entity }: { entity: Entity }) {
+  const [components, setComponents] = useState<NexusComponent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('modified');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const nexusName = entity.metadata.annotations?.['nexus-repository-manager/name'] || '';
+  const nexusRepository = entity.metadata.annotations?.['nexus-repository-manager/repository'] || '';
+  const nexusGroup = entity.metadata.annotations?.['nexus-repository-manager/group'] || '';
+
+  useEffect(() => {
+    setComponents([]);
+    setError('');
+    if (!nexusName) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    api
+      .getNexusComponents(nexusName, nexusRepository || undefined, nexusGroup || undefined)
+      .then(setComponents)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [nexusName, nexusRepository, nexusGroup]);
+
+  const sorted = useMemo(() => {
+    const copy = [...components];
+    copy.sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case 'name':
+          cmp = (a.name || '').localeCompare(b.name || '');
+          break;
+        case 'version':
+          cmp = (a.version || '').localeCompare(b.version || '');
+          break;
+        case 'format':
+          cmp = (a.format || '').localeCompare(b.format || '');
+          break;
+        case 'repository':
+          cmp = (a.repository || '').localeCompare(b.repository || '');
+          break;
+        case 'assets':
+          cmp = a.assets.length - b.assets.length;
+          break;
+        case 'modified':
+          cmp = (latestModified(a) || '').localeCompare(latestModified(b) || '');
+          break;
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return copy;
+  }, [components, sortKey, sortDir]);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'modified' ? 'desc' : 'asc');
+    }
+  }
+
+  const thClass = 'px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)] cursor-pointer select-none hover:text-[var(--gantry-text-primary)] transition-colors';
+
+  if (!nexusName) {
+    return (
+      <div className="rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-6 text-center">
+        <Archive className="mx-auto mb-2 h-8 w-8 text-[var(--gantry-text-secondary)]" />
+        <p className="text-sm text-[var(--gantry-text-secondary)]">
+          No Nexus component configured. Add a <code className="rounded bg-[var(--gantry-bg-tertiary)] px-1.5 py-0.5 text-xs">nexus-repository-manager/name</code> annotation to this entity.
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="h-7 w-7 animate-spin rounded-full border-2 border-[var(--gantry-accent)] border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="mb-3 text-sm font-semibold text-[var(--gantry-text-primary)]">
+          <Package className="mr-1.5 inline h-4 w-4" />
+          {nexusName}
+          {nexusRepository && (
+            <span className="ml-2 text-xs font-normal text-[var(--gantry-text-secondary)]">
+              in {nexusRepository}
+            </span>
+          )}
+          <span className="ml-2 text-xs font-normal text-[var(--gantry-text-secondary)]">
+            — click a row to view assets
+          </span>
+        </h3>
+        {sorted.length === 0 ? (
+          <p className="text-sm text-[var(--gantry-text-secondary)]">No components found.</p>
+        ) : (
+          <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] overflow-hidden">
+            <table className="min-w-full divide-y divide-[var(--gantry-border)]">
+              <thead>
+                <tr className="bg-[var(--gantry-bg-secondary)]">
+                  <th className="w-8 px-4 py-3" />
+                  <th className={thClass} onClick={() => toggleSort('name')}>
+                    Component <SortIcon column="name" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('version')}>
+                    Version <SortIcon column="version" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('format')}>
+                    Format <SortIcon column="format" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('repository')}>
+                    Repository <SortIcon column="repository" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('assets')}>
+                    Assets <SortIcon column="assets" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('modified')}>
+                    Modified <SortIcon column="modified" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--gantry-border)]">
+                {sorted.map((c) => (
+                  <ComponentRow key={c.id || `${c.name}-${c.version}`} component={c} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Summary banner */}
+      {components.length > 0 && (
+        <div className="flex items-center gap-3 rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-5 py-4">
+          <Archive className="h-5 w-5 shrink-0 text-[var(--gantry-accent)]" />
+          <div>
+            <p className="text-sm font-semibold text-[var(--gantry-text-primary)]">
+              {components.length} {components.length === 1 ? 'component' : 'components'}
+            </p>
+            <p className="text-xs text-[var(--gantry-text-secondary)]">
+              {components.reduce((sum, c) => sum + c.assets.length, 0)} total assets
+              {nexusRepository && <> in <span className="font-medium">{nexusRepository}</span></>}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse } from './types';
+import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse, NexusComponent, NexusAsset } from './types';
 
 let authToken: string | null = localStorage.getItem('gantry_token');
 
@@ -158,6 +158,22 @@ export const api = {
     request<HarborVulnerability[]>('GET', `/plugins/harbor/vulnerabilities?project=${encodeURIComponent(project)}&repository=${encodeURIComponent(repository)}&reference=${encodeURIComponent(reference)}`),
   getHarborSummary: () =>
     request<HarborSummaryResponse>('GET', '/plugins/harbor/summary'),
+
+  // Nexus Repository Manager
+  getNexusComponents: (name: string, repository?: string, group?: string, format?: string) => {
+    const params = new URLSearchParams();
+    if (name) params.set('name', name);
+    if (repository) params.set('repository', repository);
+    if (group) params.set('group', group);
+    if (format) params.set('format', format);
+    return request<NexusComponent[]>('GET', `/plugins/nexus-repository-manager/components?${params.toString()}`);
+  },
+  getNexusAssets: (name?: string, repository?: string) => {
+    const params = new URLSearchParams();
+    if (name) params.set('name', name);
+    if (repository) params.set('repository', repository);
+    return request<NexusAsset[]>('GET', `/plugins/nexus-repository-manager/assets?${params.toString()}`);
+  },
 
   // Status Monitor
   getStatusMonitorStatuses: () =>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -465,6 +465,29 @@ export interface HarborSummaryResponse {
   repositories: number;
 }
 
+// ─── Nexus Repository Manager ─────────────────────────────────────────────
+
+export interface NexusAsset {
+  downloadUrl: string;
+  path: string;
+  id: string;
+  repository: string;
+  format: string;
+  contentType: string;
+  lastModified: string;
+  fileSize: number;
+}
+
+export interface NexusComponent {
+  id: string;
+  repository: string;
+  format: string;
+  group: string;
+  name: string;
+  version: string;
+  assets: NexusAsset[];
+}
+
 export interface DashboardConfig {
   announcements: DashboardAnnouncement[];
   quickLinks: DashboardQuickLink[];

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -135,6 +135,12 @@ export default function Catalog() {
       const harborRepo = (raw._harbor_repository as string) || '';
       if (harborProject) annotations['harbor.io/project'] = harborProject;
       if (harborRepo) annotations['harbor.io/repository'] = harborRepo;
+      const nexusName = (raw._nexus_name as string) || '';
+      const nexusRepo = (raw._nexus_repository as string) || '';
+      const nexusGroup = (raw._nexus_group as string) || '';
+      if (nexusName) annotations['nexus-repository-manager/name'] = nexusName;
+      if (nexusRepo) annotations['nexus-repository-manager/repository'] = nexusRepo;
+      if (nexusGroup) annotations['nexus-repository-manager/group'] = nexusGroup;
 
       const newEntity: Entity = {
         kind: createKind,
@@ -154,6 +160,7 @@ export default function Catalog() {
     const kindSchema = schemas[createKind.toLowerCase()] || { type: 'object', properties: {} };
     const kindRequired: string[] = (kindSchema as any).required || [];
     const showHarbor = enabledPlugins.has('harbor') && (createKind === 'Service' || createKind === 'Infrastructure');
+    const showNexus = enabledPlugins.has('nexus-repository-manager') && (createKind === 'Service' || createKind === 'Infrastructure');
     return {
       type: 'object',
       properties: {
@@ -165,6 +172,11 @@ export default function Catalog() {
         ...(showHarbor ? {
           _harbor_project: { type: 'string', title: 'Harbor Project', description: 'Harbor registry project name (e.g. my-project)' },
           _harbor_repository: { type: 'string', title: 'Harbor Repository', description: 'Harbor repository path within the project (e.g. my-app)' },
+        } : {}),
+        ...(showNexus ? {
+          _nexus_name: { type: 'string', title: 'Nexus Component Name', description: 'Name of the component or Docker image in Nexus (e.g. my-app)' },
+          _nexus_repository: { type: 'string', title: 'Nexus Repository', description: 'Nexus repository name (e.g. docker-hosted)' },
+          _nexus_group: { type: 'string', title: 'Nexus Group', description: 'Maven group or namespace (e.g. com.example)' },
         } : {}),
       },
       required: ['_name', ...kindRequired],

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -138,9 +138,11 @@ export default function Catalog() {
       const nexusName = (raw._nexus_name as string) || '';
       const nexusRepo = (raw._nexus_repository as string) || '';
       const nexusGroup = (raw._nexus_group as string) || '';
-      if (nexusName) annotations['nexus-repository-manager/name'] = nexusName;
-      if (nexusRepo) annotations['nexus-repository-manager/repository'] = nexusRepo;
-      if (nexusGroup) annotations['nexus-repository-manager/group'] = nexusGroup;
+      if (nexusName) {
+        annotations['nexus-repository-manager/name'] = nexusName;
+        if (nexusRepo) annotations['nexus-repository-manager/repository'] = nexusRepo;
+        if (nexusGroup) annotations['nexus-repository-manager/group'] = nexusGroup;
+      }
 
       const newEntity: Entity = {
         kind: createKind,

--- a/web/src/pages/EntityDetail.tsx
+++ b/web/src/pages/EntityDetail.tsx
@@ -12,6 +12,7 @@ import GitHubTab from '../components/GitHubTab';
 import ArgoCDTab from '../components/ArgoCDTab';
 import APIDocsTab from '../components/APIDocsTab';
 import HarborTab from '../components/HarborTab';
+import NexusTab from '../components/NexusTab';
 
 const ACTION_COLORS: Record<string, string> = {
   'entity.created': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
@@ -88,7 +89,7 @@ const LINK_ICONS: Record<string, React.ReactNode> = {
   other:     <CircleHelp className="h-3.5 w-3.5" />,
 };
 
-type Tab = 'overview' | 'yaml' | 'relationships' | 'activity' | 'kubernetes' | 'github' | 'argocd' | 'apidocs' | 'harbor';
+type Tab = 'overview' | 'yaml' | 'relationships' | 'activity' | 'kubernetes' | 'github' | 'argocd' | 'apidocs' | 'harbor' | 'nexus';
 
 const TAB_LABELS: Partial<Record<Tab, string>> = {
   relationships: 'Dependencies',
@@ -97,6 +98,7 @@ const TAB_LABELS: Partial<Record<Tab, string>> = {
   argocd: 'ArgoCD',
   apidocs: 'API Docs',
   harbor: 'Harbor',
+  nexus: 'Nexus',
 };
 
 export default function EntityDetail() {
@@ -114,7 +116,7 @@ export default function EntityDetail() {
   const [tab, setTab] = useState<Tab>('overview');
   const [editing, setEditing] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
-  const [editMeta, setEditMeta] = useState({ title: '', description: '', owner: '', tags: '', harborProject: '', harborRepository: '' });
+  const [editMeta, setEditMeta] = useState({ title: '', description: '', owner: '', tags: '', harborProject: '', harborRepository: '', nexusName: '', nexusRepository: '', nexusGroup: '' });
   const [graphData, setGraphData] = useState<GraphData | null>(null);
   const [graphLoading, setGraphLoading] = useState(false);
   const [enabledPlugins, setEnabledPlugins] = useState<Set<string>>(new Set());
@@ -184,6 +186,9 @@ export default function EntityDetail() {
       tags: (entity.metadata.tags ?? []).join(', '),
       harborProject: entity.metadata.annotations?.['harbor.io/project'] ?? '',
       harborRepository: entity.metadata.annotations?.['harbor.io/repository'] ?? '',
+      nexusName: entity.metadata.annotations?.['nexus-repository-manager/name'] ?? '',
+      nexusRepository: entity.metadata.annotations?.['nexus-repository-manager/repository'] ?? '',
+      nexusGroup: entity.metadata.annotations?.['nexus-repository-manager/group'] ?? '',
     });
     setEditing(true);
   }
@@ -207,6 +212,26 @@ export default function EntityDetail() {
       } else {
         delete annotations['harbor.io/project'];
         delete annotations['harbor.io/repository'];
+      }
+      const nxName = editMeta.nexusName?.trim();
+      const nxRepo = editMeta.nexusRepository?.trim();
+      const nxGroup = editMeta.nexusGroup?.trim();
+      if (nxName) {
+        annotations['nexus-repository-manager/name'] = nxName;
+        if (nxRepo) {
+          annotations['nexus-repository-manager/repository'] = nxRepo;
+        } else {
+          delete annotations['nexus-repository-manager/repository'];
+        }
+        if (nxGroup) {
+          annotations['nexus-repository-manager/group'] = nxGroup;
+        } else {
+          delete annotations['nexus-repository-manager/group'];
+        }
+      } else {
+        delete annotations['nexus-repository-manager/name'];
+        delete annotations['nexus-repository-manager/repository'];
+        delete annotations['nexus-repository-manager/group'];
       }
       const updated = await api.updateEntity(kind, name, {
         ...entity,
@@ -338,12 +363,14 @@ export default function EntityDetail() {
         );
         const hasAPIDocs = !!(entity.spec?.apiDocsUrl) && (entity.kind === 'Service' || entity.kind === 'API');
         const hasHarbor = !!entity.metadata.annotations?.['harbor.io/project'];
+        const hasNexus = !!entity.metadata.annotations?.['nexus-repository-manager/name'];
         const tabs: Tab[] = ['overview', 'relationships', 'yaml', 'activity'];
         if (isK8sEntity && (entity.kind === 'Service' || entity.kind === 'Infrastructure') && enabledPlugins.has('kubernetes')) tabs.splice(1, 0, 'kubernetes');
         if (hasGitHub && enabledPlugins.has('github')) tabs.splice(1, 0, 'github');
         if (hasArgoCD && entity.kind === 'Service' && enabledPlugins.has('argocd')) tabs.splice(1, 0, 'argocd');
         if (hasAPIDocs) tabs.splice(1, 0, 'apidocs');
         if (hasHarbor && (entity.kind === 'Service' || entity.kind === 'Infrastructure') && enabledPlugins.has('harbor')) tabs.splice(1, 0, 'harbor');
+        if (hasNexus && (entity.kind === 'Service' || entity.kind === 'Infrastructure') && enabledPlugins.has('nexus-repository-manager')) tabs.splice(1, 0, 'nexus');
         return (
           <div className="mt-6 flex gap-1 border-b border-[var(--gantry-border)]">
             {tabs.map((t) => (
@@ -790,6 +817,10 @@ export default function EntityDetail() {
           <HarborTab entity={entity} />
         )}
 
+        {tab === 'nexus' && (
+          <NexusTab entity={entity} />
+        )}
+
         {tab === 'relationships' && (
           graphLoading ? (
             <div className="flex items-center justify-center py-16">
@@ -914,6 +945,50 @@ export default function EntityDetail() {
                         value={editMeta.harborRepository}
                         placeholder="my-app"
                         onChange={(e) => setEditMeta((m) => ({ ...m, harborRepository: e.target.value }))}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Nexus Repository Manager plugin annotations */}
+              {enabledPlugins.has('nexus-repository-manager') && (entity.kind === 'Service' || entity.kind === 'Infrastructure') && (
+                <div>
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--gantry-text-secondary)] mb-4">
+                    Nexus Repository Manager
+                  </h3>
+                  <div className="grid grid-cols-3 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-[var(--gantry-text-primary)] mb-1">Component Name</label>
+                      <p className="text-xs text-[var(--gantry-text-secondary)] mb-1.5">Name of the component or Docker image in Nexus</p>
+                      <input
+                        type="text"
+                        className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--gantry-accent)]"
+                        value={editMeta.nexusName}
+                        placeholder="my-app"
+                        onChange={(e) => setEditMeta((m) => ({ ...m, nexusName: e.target.value }))}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-[var(--gantry-text-primary)] mb-1">Repository</label>
+                      <p className="text-xs text-[var(--gantry-text-secondary)] mb-1.5">Nexus repository name (optional)</p>
+                      <input
+                        type="text"
+                        className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--gantry-accent)]"
+                        value={editMeta.nexusRepository}
+                        placeholder="docker-hosted"
+                        onChange={(e) => setEditMeta((m) => ({ ...m, nexusRepository: e.target.value }))}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-[var(--gantry-text-primary)] mb-1">Group</label>
+                      <p className="text-xs text-[var(--gantry-text-secondary)] mb-1.5">Maven group or namespace (optional)</p>
+                      <input
+                        type="text"
+                        className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--gantry-accent)]"
+                        value={editMeta.nexusGroup}
+                        placeholder="com.example"
+                        onChange={(e) => setEditMeta((m) => ({ ...m, nexusGroup: e.target.value }))}
                       />
                     </div>
                   </div>

--- a/web/src/pages/Plugins.tsx
+++ b/web/src/pages/Plugins.tsx
@@ -12,7 +12,7 @@ const SYNCABLE_PLUGINS = new Set(['kubernetes', 'github', 'argocd']);
 
 // Plugins with full backend + frontend implementations.
 // Anything not in this set is shown as "Coming Soon" and cannot be enabled.
-const IMPLEMENTED_PLUGINS = new Set(['github', 'kubernetes', 'argocd', 'status-monitor', 'gitops', 'teams', 'harbor']);
+const IMPLEMENTED_PLUGINS = new Set(['github', 'kubernetes', 'argocd', 'status-monitor', 'gitops', 'teams', 'harbor', 'nexus-repository-manager']);
 
 const CATEGORIES = [
   { id: 'all', label: 'All' },


### PR DESCRIPTION
- Implemented Nexus API handlers for fetching components and assets.
- Added routes for Nexus components and assets in the server.
- Updated server security tests to accommodate new Nexus functionality.
- Enhanced registry.json to include Nexus Repository Manager plugin details.
- Created NexusTab component for displaying Nexus components and their assets.
- Updated API library to include methods for fetching Nexus components and assets.
- Defined Nexus-related types in types.ts for TypeScript support.
- Modified Catalog and EntityDetail pages to support Nexus annotations.
- Updated Plugins page to include Nexus Repository Manager in the implemented plugins list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nexus Repository Manager plugin: backend endpoints to browse components and assets with caching for faster responses.
  * UI: new Nexus tab on entity detail pages with searchable, sortable component and asset tables, expandable asset rows, and download links.
  * Entity create/edit: optional Nexus fields to attach component name, repository, and group annotations.
  * Admin: plugin appears in the registry and settings with URL and optional credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->