### PR TITLE
Fix docs light theme navbar and code readability

### DIFF
--- a/website/docs/docusaurus.config.js
+++ b/website/docs/docusaurus.config.js
@@ -60,7 +60,7 @@ const config = {
         title: 'Gantry',
         logo: {
           alt: 'Gantry Logo',
-          src: 'img/logo-black.png',
+          src: 'img/logo-white.png',
           srcDark: 'img/logo-white.png',
         },
         items: [
@@ -122,7 +122,7 @@ const config = {
       },
 
       prism: {
-        theme: prismThemes.github,
+        theme: prismThemes.vsDark,
         darkTheme: prismThemes.dracula,
         additionalLanguages: ['bash', 'yaml', 'go', 'json', 'docker'],
       },

--- a/website/docs/src/css/custom.css
+++ b/website/docs/src/css/custom.css
@@ -98,12 +98,7 @@
 }
 
 .navbar__logo {
-  filter: brightness(10);
-}
-
-/* Keep logo visible in dark mode too */
-[data-theme='dark'] .navbar__logo {
-  filter: brightness(10);
+  filter: none;
 }
 
 .navbar__link {
@@ -117,13 +112,30 @@
   color: #ffffff;
 }
 
-/* Color mode toggle icon — make it visible on dark navbar */
+/* Color mode toggle icon — keep it visible against the dark navbar */
 .navbar__items button[class*='colorModeToggle'] {
-  color: rgba(255, 255, 255, 0.6);
+  color: #ffffff;
 }
+
+[data-theme='light'] .navbar__items button[class*='colorModeToggle'] {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+[data-theme='dark'] .navbar__items button[class*='colorModeToggle'] {
+  color: rgba(255, 255, 255, 0.82);
+}
+
 .navbar__items button[class*='colorModeToggle']:hover {
   color: #ffffff;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.navbar__items button[class*='colorModeToggle'] svg,
+.navbar__items button[class*='colorModeToggle'] path {
+  fill: currentColor;
+  stroke: currentColor;
 }
 
 /* Search bar on dark navbar */
@@ -180,6 +192,7 @@
 [data-theme='light'] .theme-code-block,
 [data-theme='light'] pre {
   background: #0d0d0f !important;
+  border: 1px solid rgba(255, 255, 255, 0.06) !important;
 }
 
 /* Dark mode code block */
@@ -192,6 +205,18 @@
 pre code {
   font-size: 13px !important;
   line-height: 1.85 !important;
+  color: #f5f5f7 !important;
+}
+
+.prism-code,
+.prism-code .token,
+.theme-code-block code {
+  color: #f5f5f7;
+}
+
+.theme-code-block [class*='codeBlockTitle'],
+.theme-code-block [class*='codeBlockContent'] {
+  color: #f5f5f7;
 }
 
 /* Inline code */
@@ -203,8 +228,8 @@ code {
 }
 
 [data-theme='light'] code:not([class*='codeBlock']) {
-  background: rgba(0, 0, 0, 0.05);
-  color: #111111;
+  background: rgba(0, 0, 0, 0.08);
+  color: #1f2937;
 }
 
 [data-theme='dark'] code:not([class*='codeBlock']) {

--- a/website/docs/src/css/custom.css
+++ b/website/docs/src/css/custom.css
@@ -9,6 +9,13 @@
    LIGHT MODE
    ============================================================ */
 :root {
+  --gantry-bg-primary: #ffffff;
+  --gantry-bg-secondary: #f0f0f0;
+  --gantry-bg-tertiary: #e5e5ea;
+  --gantry-text-primary: #111111;
+  --gantry-text-secondary: #636366;
+  --gantry-border: #d5d5d7;
+
   /* Primary / accent — matches website --blue */
   --ifm-color-primary:          #007AFF;
   --ifm-color-primary-dark:     #0066d6;
@@ -56,6 +63,13 @@
    DARK MODE
    ============================================================ */
 [data-theme='dark'] {
+  --gantry-bg-primary: #1c1c1e;
+  --gantry-bg-secondary: #111113;
+  --gantry-bg-tertiary: #2c2c2e;
+  --gantry-text-primary: #f5f5f7;
+  --gantry-text-secondary: #8e8e93;
+  --gantry-border: #38383a;
+
   --ifm-color-primary:          #59abff;
   --ifm-color-primary-dark:     #3a9aff;
   --ifm-color-primary-darker:   #2b92ff;
@@ -117,7 +131,7 @@
 .navbar__items button[class*='colorModeToggle'],
 .navbar__items button[class*='toggleButton'],
 .navbar__items button[class*='darkNavbarColorModeToggle'] {
-  color: #ffffff;
+  color: var(--gantry-bg-primary);
   border-radius: 999px;
 }
 
@@ -125,33 +139,33 @@
 [data-theme='light'] .navbar__items button[class*='colorModeToggle'],
 [data-theme='light'] .navbar__items button[class*='toggleButton'],
 [data-theme='light'] .navbar__items button[class*='darkNavbarColorModeToggle'] {
-  color: #1c1c1e;
-  background: #ffffff;
-  border: 1px solid rgba(255, 255, 255, 0.9);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
+  color: var(--gantry-text-primary);
+  background: var(--gantry-bg-primary);
+  border: 1px solid color-mix(in srgb, var(--gantry-bg-primary) 90%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--gantry-border) 60%, transparent);
 }
 
 [data-theme='dark'] .navbar__items [class*='colorModeToggle'] button,
 [data-theme='dark'] .navbar__items button[class*='colorModeToggle'],
 [data-theme='dark'] .navbar__items button[class*='toggleButton'],
 [data-theme='dark'] .navbar__items button[class*='darkNavbarColorModeToggle'] {
-  color: rgba(255, 255, 255, 0.82);
+  color: color-mix(in srgb, var(--gantry-text-primary) 82%, transparent);
 }
 
 .navbar__items [class*='colorModeToggle'] button:hover,
 .navbar__items button[class*='colorModeToggle']:hover,
 .navbar__items button[class*='toggleButton']:hover,
 .navbar__items button[class*='darkNavbarColorModeToggle']:hover {
-  color: #ffffff;
-  background: rgba(255, 255, 255, 0.16);
+  color: var(--gantry-text-primary);
+  background: color-mix(in srgb, var(--gantry-text-primary) 16%, transparent);
 }
 
 [data-theme='light'] .navbar__items [class*='colorModeToggle'] button:hover,
 [data-theme='light'] .navbar__items button[class*='colorModeToggle']:hover,
 [data-theme='light'] .navbar__items button[class*='toggleButton']:hover,
 [data-theme='light'] .navbar__items button[class*='darkNavbarColorModeToggle']:hover {
-  color: #1c1c1e;
-  background: rgba(255, 255, 255, 0.92);
+  color: var(--gantry-text-primary);
+  background: color-mix(in srgb, var(--gantry-bg-primary) 92%, transparent);
 }
 
 .navbar__items [class*='colorModeToggle'] button svg,
@@ -162,8 +176,8 @@
 .navbar__items button[class*='toggleButton'] path,
 .navbar__items button[class*='darkNavbarColorModeToggle'] svg,
 .navbar__items button[class*='darkNavbarColorModeToggle'] path {
-  fill: currentColor;
-  stroke: currentColor;
+  fill: currentcolor;
+  stroke: currentcolor;
 }
 
 /* Search bar on dark navbar */

--- a/website/docs/src/css/custom.css
+++ b/website/docs/src/css/custom.css
@@ -113,27 +113,55 @@
 }
 
 /* Color mode toggle icon — keep it visible against the dark navbar */
-.navbar__items button[class*='colorModeToggle'] {
+.navbar__items [class*='colorModeToggle'] button,
+.navbar__items button[class*='colorModeToggle'],
+.navbar__items button[class*='toggleButton'],
+.navbar__items button[class*='darkNavbarColorModeToggle'] {
   color: #ffffff;
+  border-radius: 999px;
 }
 
-[data-theme='light'] .navbar__items button[class*='colorModeToggle'] {
-  color: #ffffff;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+[data-theme='light'] .navbar__items [class*='colorModeToggle'] button,
+[data-theme='light'] .navbar__items button[class*='colorModeToggle'],
+[data-theme='light'] .navbar__items button[class*='toggleButton'],
+[data-theme='light'] .navbar__items button[class*='darkNavbarColorModeToggle'] {
+  color: #1c1c1e;
+  background: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
 }
 
-[data-theme='dark'] .navbar__items button[class*='colorModeToggle'] {
+[data-theme='dark'] .navbar__items [class*='colorModeToggle'] button,
+[data-theme='dark'] .navbar__items button[class*='colorModeToggle'],
+[data-theme='dark'] .navbar__items button[class*='toggleButton'],
+[data-theme='dark'] .navbar__items button[class*='darkNavbarColorModeToggle'] {
   color: rgba(255, 255, 255, 0.82);
 }
 
-.navbar__items button[class*='colorModeToggle']:hover {
+.navbar__items [class*='colorModeToggle'] button:hover,
+.navbar__items button[class*='colorModeToggle']:hover,
+.navbar__items button[class*='toggleButton']:hover,
+.navbar__items button[class*='darkNavbarColorModeToggle']:hover {
   color: #ffffff;
   background: rgba(255, 255, 255, 0.16);
 }
 
+[data-theme='light'] .navbar__items [class*='colorModeToggle'] button:hover,
+[data-theme='light'] .navbar__items button[class*='colorModeToggle']:hover,
+[data-theme='light'] .navbar__items button[class*='toggleButton']:hover,
+[data-theme='light'] .navbar__items button[class*='darkNavbarColorModeToggle']:hover {
+  color: #1c1c1e;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.navbar__items [class*='colorModeToggle'] button svg,
+.navbar__items [class*='colorModeToggle'] button path,
 .navbar__items button[class*='colorModeToggle'] svg,
-.navbar__items button[class*='colorModeToggle'] path {
+.navbar__items button[class*='colorModeToggle'] path,
+.navbar__items button[class*='toggleButton'] svg,
+.navbar__items button[class*='toggleButton'] path,
+.navbar__items button[class*='darkNavbarColorModeToggle'] svg,
+.navbar__items button[class*='darkNavbarColorModeToggle'] path {
   fill: currentColor;
   stroke: currentColor;
 }


### PR DESCRIPTION
### Motivation
- Improve documentation readability and contrast in light theme by fixing logo visibility in the dark navbar, making the theme toggle visible, and making fenced and inline code blocks readable in light mode.

### Description
- Updated `website/docs/docusaurus.config.js` to use the white logo for the navbar in both themes and switched the light-mode Prism theme to `prismThemes.vsDark` for better contrast.
- Adjusted `website/docs/src/css/custom.css` to remove the brightness filter on `.navbar__logo` and to style the color mode toggle so it appears white and its SVG fills/strokes inherit `currentColor`.
- Added a subtle border and stronger foreground colors to light-mode code blocks and pragma/prism selectors so fenced code, code block titles, and inline tokens are readable on the dark background used in light theme.
- Increased inline code contrast in light mode by darkening the inline code background and text color.

### Testing
- Built the docs with `cd website/docs && npm run build` and the build completed successfully.
- Served the generated site with `npm run serve` and captured a light-theme screenshot to validate visual changes (artifact `artifacts/docs-light-theme-fixes.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9f9c2c91c832b9854860ac85e3248)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated navbar logo appearance for better visibility in the header
  * Switched code syntax highlighting to VS Dark for improved readability
  * Enhanced light and dark mode styling with stronger contrast for code blocks, inline code, and UI elements
  * Refined color-mode toggle visuals and hover states for clearer interaction feedback
  * Ensured icons and SVGs inherit color; unified borders and backgrounds across themes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->