### PR TITLE
feat(actions): add entity list dropdown for select fields

### DIFF
--- a/internal/entity/schemas/action.json
+++ b/internal/entity/schemas/action.json
@@ -51,6 +51,10 @@
             "type": "array",
             "items": { "type": "string" },
             "description": "Available options for select-type inputs"
+          },
+          "entityKind": {
+            "type": "string",
+            "description": "When set, dropdown options are populated from entities of this kind (e.g. Service, Environment)"
           }
         },
         "required": ["name", "type"]

--- a/web/src/components/ActionFormBuilder.tsx
+++ b/web/src/components/ActionFormBuilder.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Plus, Trash2, ChevronUp, ChevronDown, ChevronRight, ChevronDown as ExpandIcon, GripVertical } from 'lucide-react';
 import type { ActionInputDef, ActionInputType } from '../lib/types';
+import { ENTITY_KINDS } from '../lib/types';
 
 interface Props {
   inputs: ActionInputDef[];
@@ -247,44 +248,99 @@ export default function ActionFormBuilder({ inputs, onChange }: Props) {
 
                 {/* Options editor for select type */}
                 {inp.type === 'select' && (
-                  <div>
-                    <label className="mb-1 block text-xs font-medium text-[var(--gantry-text-secondary)]">
-                      Options
-                    </label>
-                    <div className="space-y-1.5">
-                      {(inp.options ?? []).map((opt, oi) => (
-                        <div key={oi} className="flex items-center gap-2">
-                          <input
-                            type="text"
-                            value={opt}
-                            onChange={(e) => {
-                              const opts = [...(inp.options ?? [])];
-                              opts[oi] = e.target.value;
-                              update(i, { options: opts });
-                            }}
-                            placeholder={`Option ${oi + 1}`}
-                            className="flex-1 rounded-md border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-1 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-                          />
+                  <div className="space-y-3">
+                    {/* Options source toggle */}
+                    <div>
+                      <label className="mb-1 block text-xs font-medium text-[var(--gantry-text-secondary)]">
+                        Options Source
+                      </label>
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => update(i, { entityKind: undefined })}
+                          className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                            !inp.entityKind
+                              ? 'bg-[var(--gantry-accent)] text-[var(--gantry-bg-primary)]'
+                              : 'bg-[var(--gantry-bg-tertiary)] text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]'
+                          }`}
+                        >
+                          Manual List
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => update(i, { entityKind: ENTITY_KINDS[0].name, options: undefined })}
+                          className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                            inp.entityKind
+                              ? 'bg-[var(--gantry-accent)] text-[var(--gantry-bg-primary)]'
+                              : 'bg-[var(--gantry-bg-tertiary)] text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]'
+                          }`}
+                        >
+                          Entity List
+                        </button>
+                      </div>
+                    </div>
+
+                    {inp.entityKind ? (
+                      /* Entity kind picker */
+                      <div>
+                        <label className="mb-1 block text-xs font-medium text-[var(--gantry-text-secondary)]">
+                          Entity Kind
+                        </label>
+                        <select
+                          value={inp.entityKind}
+                          onChange={(e) => update(i, { entityKind: e.target.value })}
+                          className="w-full rounded-md border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-1.5 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+                        >
+                          {ENTITY_KINDS.map((k) => (
+                            <option key={k.name} value={k.name}>{k.name}</option>
+                          ))}
+                        </select>
+                        <p className="mt-0.5 text-xs text-[var(--gantry-text-secondary)]">
+                          Dropdown will be populated with all {inp.entityKind} entities
+                        </p>
+                      </div>
+                    ) : (
+                      /* Manual options editor */
+                      <div>
+                        <label className="mb-1 block text-xs font-medium text-[var(--gantry-text-secondary)]">
+                          Options
+                        </label>
+                        <div className="space-y-1.5">
+                          {(inp.options ?? []).map((opt, oi) => (
+                            <div key={oi} className="flex items-center gap-2">
+                              <input
+                                type="text"
+                                value={opt}
+                                onChange={(e) => {
+                                  const opts = [...(inp.options ?? [])];
+                                  opts[oi] = e.target.value;
+                                  update(i, { options: opts });
+                                }}
+                                placeholder={`Option ${oi + 1}`}
+                                className="flex-1 rounded-md border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-1 text-sm text-[var(--gantry-text-primary)] placeholder-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+                              />
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  const opts = (inp.options ?? []).filter((_, idx) => idx !== oi);
+                                  update(i, { options: opts });
+                                }}
+                                className="rounded p-1 text-[var(--gantry-danger)] hover:bg-[var(--gantry-bg-tertiary)]"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </button>
+                            </div>
+                          ))}
                           <button
                             type="button"
-                            onClick={() => {
-                              const opts = (inp.options ?? []).filter((_, idx) => idx !== oi);
-                              update(i, { options: opts });
-                            }}
-                            className="rounded p-1 text-[var(--gantry-danger)] hover:bg-[var(--gantry-bg-tertiary)]"
+                            onClick={() => update(i, { options: [...(inp.options ?? []), ''] })}
+                            className="flex items-center gap-1 text-xs text-[var(--gantry-accent)] hover:underline"
                           >
-                            <Trash2 className="h-3.5 w-3.5" />
+                            <Plus className="h-3 w-3" /> Add option
                           </button>
                         </div>
-                      ))}
-                      <button
-                        type="button"
-                        onClick={() => update(i, { options: [...(inp.options ?? []), ''] })}
-                        className="flex items-center gap-1 text-xs text-[var(--gantry-accent)] hover:underline"
-                      >
-                        <Plus className="h-3 w-3" /> Add option
-                      </button>
-                    </div>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/web/src/components/ActionWizard.tsx
+++ b/web/src/components/ActionWizard.tsx
@@ -213,7 +213,8 @@ export default function ActionWizard({ existing, onSave, onClose }: Props) {
       if (inp.description) clean.description = inp.description;
       if (inp.required) clean.required = true;
       if (inp.default !== undefined && inp.default !== '') clean.default = inp.default;
-      if (inp.type === 'select' && inp.options) clean.options = inp.options.filter(Boolean);
+      if (inp.type === 'select' && inp.entityKind) clean.entityKind = inp.entityKind;
+      else if (inp.type === 'select' && inp.options) clean.options = inp.options.filter(Boolean);
       return clean;
     });
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -331,6 +331,8 @@ export interface ActionInputDef {
   required?: boolean;
   default?: string | number | boolean;
   options?: string[];
+  /** When set, dropdown options are populated from entities of this kind. */
+  entityKind?: string;
 }
 
 export interface GitHubWorkflow {

--- a/web/src/pages/Actions.tsx
+++ b/web/src/pages/Actions.tsx
@@ -57,7 +57,8 @@ function getInputSchema(action: Entity): JsonSchema {
       type: input.type === 'select' ? 'string' : input.type === 'textarea' ? 'string' : input.type || 'string',
       title: input.title || input.name,
       description: input.description,
-      enum: input.type === 'select' ? input.options?.map((o: any) => String(o.value ?? o)) : undefined,
+      enum: input.type === 'select' && !input.entityKind ? input.options?.map((o: any) => String(o.value ?? o)) : undefined,
+      'x-entity-ref': input.type === 'select' && input.entityKind ? input.entityKind : undefined,
       default: input.default,
       format: input.type === 'textarea' ? 'textarea' : undefined,
     };


### PR DESCRIPTION
## Summary

- Adds an **Entity List** option source for dropdown (select) fields in the Action form builder
- When selected, the dropdown is populated dynamically from all entities of a chosen kind (Service, API, Infrastructure, Team, Environment, Documentation)
- Leverages the existing `x-entity-ref` / `EntityPicker` infrastructure in `SchemaForm` — no new API endpoints needed

Closes #34

## Changes

- **`ActionInputDef`** (`types.ts`): Added optional `entityKind` field
- **`action.json` schema**: Added `entityKind` property to input items
- **`ActionFormBuilder.tsx`**: Added Manual List / Entity List toggle with entity kind picker
- **`ActionWizard.tsx`**: Persists `entityKind` when saving action inputs
- **`Actions.tsx`**: Maps `entityKind` → `x-entity-ref` in the generated JSON schema so `SchemaForm` renders the `EntityPicker`

## Test plan

- [ ] Create a new Action with a dropdown field → select "Entity List" → pick "Service" → save
- [ ] Execute the action → verify the dropdown shows all Service entities from the catalog
- [ ] Switch back to "Manual List" → verify manual options work as before
- [ ] Edit an existing action with entity-kind dropdown → verify it loads correctly
- [ ] Verify `go build ./...`, `npx tsc --noEmit`, and `npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)