### PR TITLE
fix(auth): redirect to login screen on session expiry

### DIFF
--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -51,6 +51,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .finally(() => setLoading(false));
   }, []);
 
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      setToken(null);
+      setTokenState(null);
+      setUser(null);
+    };
+    window.addEventListener('auth:unauthorized', handleUnauthorized);
+    return () => window.removeEventListener('auth:unauthorized', handleUnauthorized);
+  }, []);
+
   const login = useCallback(async (username: string, password: string) => {
     const result = await api.login(username, password);
     setToken(result.token);

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
-import { api, setToken, getToken } from '../lib/api';
+import { api, setToken, getToken, AUTH_UNAUTHORIZED_EVENT } from '../lib/api';
 import type { User } from '../lib/types';
 
 interface AuthContextValue {
@@ -57,8 +57,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setTokenState(null);
       setUser(null);
     };
-    window.addEventListener('auth:unauthorized', handleUnauthorized);
-    return () => window.removeEventListener('auth:unauthorized', handleUnauthorized);
+    window.addEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized);
+    return () => window.removeEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized);
   }, []);
 
   const login = useCallback(async (username: string, password: string) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -15,6 +15,10 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) {
+    if (res.status === 401) {
+      setToken(null);
+      window.dispatchEvent(new CustomEvent('auth:unauthorized'));
+    }
     const err = await res.json().catch(() => ({ error: res.statusText }));
     throw new Error(err.error || res.statusText);
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,7 @@
 import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse, NexusComponent, NexusAsset } from './types';
 
+export const AUTH_UNAUTHORIZED_EVENT = 'auth:unauthorized';
+
 let authToken: string | null = localStorage.getItem('gantry_token');
 
 function headers(): Record<string, string> {
@@ -15,9 +17,9 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) {
-    if (res.status === 401) {
+    if (res.status === 401 && authToken) {
       setToken(null);
-      window.dispatchEvent(new CustomEvent('auth:unauthorized'));
+      window.dispatchEvent(new CustomEvent(AUTH_UNAUTHORIZED_EVENT));
     }
     const err = await res.json().catch(() => ({ error: res.statusText }));
     throw new Error(err.error || res.statusText);


### PR DESCRIPTION
## Summary
- Any API call returning a 401 now clears the stored token and dispatches an `auth:unauthorized` custom event
- `AuthProvider` listens for that event and resets user state to `null`
- `App.tsx` then renders `<Login />` immediately instead of showing error banners on the dashboard

## Test plan
- [ ] Log in, wait for the JWT to expire (or manually clear/invalidate it), then navigate — should land on the login screen
- [ ] Confirm no "missing authentication credentials" error is shown on the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling: when the server reports unauthorized access, the app now clears session data and updates login status immediately, preventing stale auth UI.
  * Session clearance now propagates across open windows/tabs so all views reflect the updated signed-out state in real time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->