### PR TITLE
feat: add Harbor sidebar toggle

### DIFF
--- a/internal/plugins/bundled/registry.json
+++ b/internal/plugins/bundled/registry.json
@@ -691,8 +691,14 @@
         "defaultProject": {
           "type": "string",
           "title": "Default Project",
-          "description": "Default Harbor project for the sidebar browser and dashboard widget.",
+          "description": "Default Harbor project for the Harbor page and dashboard widget.",
           "default": "library"
+        },
+        "showInSidebar": {
+          "type": "boolean",
+          "title": "Show Harbor in Sidebar",
+          "description": "Add the Harbor page to the main sidebar navigation when the plugin is enabled.",
+          "default": true
         }
       },
       "required": ["url", "username", "password"]

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ import {
 } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { useTheme } from '../hooks/useTheme';
-import { api } from '../lib/api';
+import { api, PLUGINS_UPDATED_EVENT } from '../lib/api';
 import ThemeToggle from './ThemeToggle';
 import { ENTITY_KINDS } from '../lib/types';
 
@@ -82,23 +82,53 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
     onCloseMobile?.();
   }, [location.pathname, onCloseMobile]);
 
-  // Check if the status-monitor plugin is enabled (once on mount).
   useEffect(() => {
-    api.listPlugins().then(async (plugins) => {
-      const sm = plugins.find((p) => p.name === 'status-monitor');
-      if (sm?.enabled) setStatusMonitorEnabled(true);
-      const gops = plugins.find((p) => p.name === 'gitops');
-      if (gops?.enabled) setGitopsEnabled(true);
-      const hbr = plugins.find((p) => p.name === 'harbor');
-      if (!hbr?.enabled) return;
+    let active = true;
 
+    const refreshPluginState = async () => {
       try {
-        const harborConfig = await api.getPluginConfig('harbor');
-        setHarborEnabled(harborConfig.values?.showInSidebar !== false);
+        const plugins = await api.listPlugins();
+        if (!active) return;
+
+        const statusMonitorPlugin = plugins.find((p) => p.name === 'status-monitor');
+        setStatusMonitorEnabled(Boolean(statusMonitorPlugin?.enabled));
+
+        const gitopsPlugin = plugins.find((p) => p.name === 'gitops');
+        setGitopsEnabled(Boolean(gitopsPlugin?.enabled));
+
+        const harborPlugin = plugins.find((p) => p.name === 'harbor');
+        if (!harborPlugin?.enabled) {
+          setHarborEnabled(false);
+          return;
+        }
+
+        try {
+          const harborConfig = await api.getPluginConfig('harbor');
+          if (!active) return;
+          setHarborEnabled(harborConfig.values?.showInSidebar !== false);
+        } catch {
+          if (!active) return;
+          setHarborEnabled(true);
+        }
       } catch {
-        setHarborEnabled(true);
+        if (!active) return;
+        setStatusMonitorEnabled(false);
+        setGitopsEnabled(false);
+        setHarborEnabled(false);
       }
-    }).catch(() => {});
+    };
+
+    const handlePluginsUpdated = () => {
+      void refreshPluginState();
+    };
+
+    void refreshPluginState();
+    window.addEventListener(PLUGINS_UPDATED_EVENT, handlePluginsUpdated);
+
+    return () => {
+      active = false;
+      window.removeEventListener(PLUGINS_UPDATED_EVENT, handlePluginsUpdated);
+    };
   }, []);
 
   const isActive = (path: string) => {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -84,13 +84,20 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
 
   // Check if the status-monitor plugin is enabled (once on mount).
   useEffect(() => {
-    api.listPlugins().then((plugins) => {
+    api.listPlugins().then(async (plugins) => {
       const sm = plugins.find((p) => p.name === 'status-monitor');
       if (sm?.enabled) setStatusMonitorEnabled(true);
       const gops = plugins.find((p) => p.name === 'gitops');
       if (gops?.enabled) setGitopsEnabled(true);
       const hbr = plugins.find((p) => p.name === 'harbor');
-      if (hbr?.enabled) setHarborEnabled(true);
+      if (!hbr?.enabled) return;
+
+      try {
+        const harborConfig = await api.getPluginConfig('harbor');
+        setHarborEnabled(harborConfig.values?.showInSidebar !== false);
+      } catch {
+        setHarborEnabled(true);
+      }
     }).catch(() => {});
   }, []);
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse, NexusComponent, NexusAsset } from './types';
 
 export const AUTH_UNAUTHORIZED_EVENT = 'auth:unauthorized';
+export const PLUGINS_UPDATED_EVENT = 'gantry:plugins-updated';
 
 let authToken: string | null = localStorage.getItem('gantry_token');
 
@@ -126,11 +127,15 @@ export const api = {
   // Plugin marketplace
   listPlugins: () => request<PluginRegistryEntry[]>('GET', '/plugins'),
   getPlugin: (name: string) => request<PluginDetail>('GET', `/plugins/${name}`),
-  enablePlugin: (name: string, enabled: boolean) =>
-    request<void>('PUT', `/plugins/${name}/enable`, { enabled }),
+  enablePlugin: async (name: string, enabled: boolean) => {
+    await request<void>('PUT', `/plugins/${name}/enable`, { enabled });
+    window.dispatchEvent(new CustomEvent(PLUGINS_UPDATED_EVENT, { detail: { name, enabled } }));
+  },
   getPluginConfig: (name: string) => request<PluginConfig>('GET', `/plugins/${name}/config`),
-  updatePluginConfig: (name: string, values: Record<string, any>) =>
-    request<void>('PUT', `/plugins/${name}/config`, values),
+  updatePluginConfig: async (name: string, values: Record<string, any>) => {
+    await request<void>('PUT', `/plugins/${name}/config`, values);
+    window.dispatchEvent(new CustomEvent(PLUGINS_UPDATED_EVENT, { detail: { name } }));
+  },
 
   syncPlugin: (name: string) => request<PluginSyncResult>('POST', `/plugins/${name}/sync`, {}),
 


### PR DESCRIPTION
## Summary
Add a Harbor plugin setting that controls whether the Harbor page appears in the main sidebar.

## Changes
- Add a `showInSidebar` Harbor plugin setting, defaulting to `true`.
- Make the sidebar respect that setting while still honoring Harbor plugin enablement.
- Refresh Harbor sidebar visibility after plugin and settings saves so the UI updates immediately.
- Update the default project description text to refer to the Harbor page.

## Validation
- `npm run build` ✅
- `npm run lint` ⚠️ currently fails in this repo because the script references `eslint`, but `eslint` is not installed in `web/package.json`.

Closes #46

@Go2Engle, would you mind taking a look when you have a chance?