### PR TITLE
feat: add Nexus Repository Manager explorer

### DIFF
--- a/internal/api/handlers/nexus.go
+++ b/internal/api/handlers/nexus.go
@@ -117,6 +117,7 @@ func nexusRequest(ctx context.Context, baseURL, username, password, path string)
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "Gantry/1.0 NexusRepositoryManager")
+	req.Header.Set("Accept", "application/json")
 	if username != "" && password != "" {
 		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
 	}
@@ -226,6 +227,40 @@ func (h *Handlers) ensureNexusConfig(w http.ResponseWriter, r *http.Request) (ne
 	return cfg, nil
 }
 
+// NexusRepository represents a Nexus repository from the repositories API.
+type NexusRepository struct {
+	Name   string `json:"name"`
+	Format string `json:"format"`
+	Type   string `json:"type"`
+	URL    string `json:"url"`
+	Online bool   `json:"online"`
+}
+
+// GetNexusRepositories lists all repositories from Nexus Repository Manager.
+func (h *Handlers) GetNexusRepositories(w http.ResponseWriter, r *http.Request) {
+	cfg, err := h.ensureNexusConfig(w, r)
+	if err != nil {
+		return
+	}
+
+	body, err := nexusRequest(r.Context(), cfg.URL, cfg.Username, cfg.Password, "/service/rest/v1/repositories")
+	if err != nil {
+		log.Printf("[nexus] failed to fetch repositories: %v", err)
+		writeError(w, http.StatusBadGateway, "failed to fetch repositories from Nexus")
+		return
+	}
+
+	var repos []NexusRepository
+	if err := json.Unmarshal(body, &repos); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to parse repositories response")
+		return
+	}
+	if repos == nil {
+		repos = []NexusRepository{}
+	}
+	writeJSON(w, http.StatusOK, repos)
+}
+
 // GetNexusComponents searches for components in Nexus Repository Manager.
 func (h *Handlers) GetNexusComponents(w http.ResponseWriter, r *http.Request) {
 	cfg, err := h.ensureNexusConfig(w, r)
@@ -242,32 +277,37 @@ func (h *Handlers) GetNexusComponents(w http.ResponseWriter, r *http.Request) {
 		repository = cfg.DefaultRepository
 	}
 
-	params := url.Values{}
-	if name != "" {
-		// Wrap in wildcards for partial matching — the Nexus name field may
-		// include a group prefix (e.g. "goodville/report-claims-module" or
-		// "gbiz/claims-elements-0.0.0.zip") so *name* matches regardless of
-		// prefix/suffix. This is much more precise than the "q" keyword param
-		// which splits on word boundaries and returns unrelated components.
-		if name[0] != '*' {
-			name = "*" + name
+	// If only a repository filter is set (no search criteria), use the
+	// /components browse endpoint which works without credentials and doesn't
+	// require any additional filters. Fall back to /search when name/group/format
+	// are provided so wildcard matching still works.
+	var basePath string
+	if name == "" && group == "" && format == "" && repository != "" {
+		basePath = "/service/rest/v1/components?repository=" + url.QueryEscape(repository)
+	} else {
+		params := url.Values{}
+		if name != "" {
+			// Wrap in wildcards for partial matching.
+			if name[0] != '*' {
+				name = "*" + name
+			}
+			if name[len(name)-1] != '*' {
+				name = name + "*"
+			}
+			params.Set("name", name)
 		}
-		if name[len(name)-1] != '*' {
-			name = name + "*"
+		if repository != "" {
+			params.Set("repository", repository)
 		}
-		params.Set("name", name)
-	}
-	if repository != "" {
-		params.Set("repository", repository)
-	}
-	if group != "" {
-		params.Set("group", group)
-	}
-	if format != "" {
-		params.Set("format", format)
+		if group != "" {
+			params.Set("group", group)
+		}
+		if format != "" {
+			params.Set("format", format)
+		}
+		basePath = "/service/rest/v1/search?" + params.Encode()
 	}
 
-	basePath := "/service/rest/v1/search?" + params.Encode()
 	allItems, err := nexusPaginatedSearch(r.Context(), cfg, basePath)
 	if err != nil {
 		log.Printf("[nexus] failed to fetch components (path=%s): %v", basePath, err)

--- a/internal/api/handlers/nexus.go
+++ b/internal/api/handlers/nexus.go
@@ -228,12 +228,12 @@ func (h *Handlers) ensureNexusConfig(w http.ResponseWriter, r *http.Request) (ne
 }
 
 // NexusRepository represents a Nexus repository from the repositories API.
+// Note: the v1/repositories list endpoint does not include online status.
 type NexusRepository struct {
 	Name   string `json:"name"`
 	Format string `json:"format"`
 	Type   string `json:"type"`
 	URL    string `json:"url"`
-	Online bool   `json:"online"`
 }
 
 // GetNexusRepositories lists all repositories from Nexus Repository Manager.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -215,6 +215,7 @@ func NewServer(cfg *config.Config, database *db.DB, authSvc *auth.Service, event
 			protected.Get("/plugins/harbor/vulnerabilities", h.GetHarborVulnerabilities)
 			protected.Get("/plugins/harbor/summary", h.GetHarborSummary)
 			// Nexus Repository Manager plugin endpoints.
+			protected.Get("/plugins/nexus-repository-manager/repositories", h.GetNexusRepositories)
 			protected.Get("/plugins/nexus-repository-manager/components", h.GetNexusComponents)
 			protected.Get("/plugins/nexus-repository-manager/assets", h.GetNexusAssets)
 			// ArgoCD-specific plugin endpoints.

--- a/internal/plugins/bundled/registry.json
+++ b/internal/plugins/bundled/registry.json
@@ -746,6 +746,12 @@
           "type": "string",
           "title": "Default Repository",
           "description": "Default repository to search when no repository annotation is set on the entity."
+        },
+        "showInSidebar": {
+          "type": "boolean",
+          "title": "Show Nexus in Sidebar",
+          "description": "Add the Nexus explorer page to the main sidebar navigation when the plugin is enabled.",
+          "default": true
         }
       },
       "required": ["url"]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import Plugins from './pages/Plugins';
 import StatusMonitor from './pages/StatusMonitor';
 import GitOps from './pages/GitOps';
 import Harbor from './pages/Harbor';
+import Nexus from './pages/Nexus';
 import RBAC from './pages/RBAC';
 
 function AuthenticatedLayout() {
@@ -50,6 +51,7 @@ function AuthenticatedLayout() {
               <Route path="/status" element={<StatusMonitor />} />
               <Route path="/gitops" element={<GitOps />} />
               <Route path="/harbor" element={<Harbor />} />
+              <Route path="/nexus" element={<Nexus />} />
               <Route path="/rbac" element={<RBAC />} />
               <Route path="/settings" element={<Settings />} />
             </Routes>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   GitBranch,
   Shield,
   Package,
+  Archive,
   X,
 } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
@@ -73,6 +74,7 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
   const [statusMonitorEnabled, setStatusMonitorEnabled] = useState(false);
   const [gitopsEnabled, setGitopsEnabled] = useState(false);
   const [harborEnabled, setHarborEnabled] = useState(false);
+  const [nexusEnabled, setNexusEnabled] = useState(false);
   const location = useLocation();
   const { user, logout } = useAuth();
   const { theme } = useTheme();
@@ -99,22 +101,36 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
         const harborPlugin = plugins.find((p) => p.name === 'harbor');
         if (!harborPlugin?.enabled) {
           setHarborEnabled(false);
-          return;
+        } else {
+          try {
+            const harborConfig = await api.getPluginConfig('harbor');
+            if (!active) return;
+            setHarborEnabled(harborConfig.values?.showInSidebar !== false);
+          } catch {
+            if (!active) return;
+            setHarborEnabled(true);
+          }
         }
 
-        try {
-          const harborConfig = await api.getPluginConfig('harbor');
-          if (!active) return;
-          setHarborEnabled(harborConfig.values?.showInSidebar !== false);
-        } catch {
-          if (!active) return;
-          setHarborEnabled(true);
+        const nexusPlugin = plugins.find((p) => p.name === 'nexus-repository-manager');
+        if (!nexusPlugin?.enabled) {
+          setNexusEnabled(false);
+        } else {
+          try {
+            const nexusConfig = await api.getPluginConfig('nexus-repository-manager');
+            if (!active) return;
+            setNexusEnabled(nexusConfig.values?.showInSidebar !== false);
+          } catch {
+            if (!active) return;
+            setNexusEnabled(true);
+          }
         }
       } catch {
         if (!active) return;
         setStatusMonitorEnabled(false);
         setGitopsEnabled(false);
         setHarborEnabled(false);
+        setNexusEnabled(false);
       }
     };
 
@@ -278,6 +294,22 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
                 >
                   <Package className="h-5 w-5 shrink-0" />
                   {!collapsed && <span className="truncate">Harbor</span>}
+                </Link>
+              </li>
+            )}
+            {nexusEnabled && (
+              <li>
+                <Link
+                  to="/nexus"
+                  className={`flex flex-1 items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                    isActive('/nexus')
+                      ? 'bg-[var(--gantry-accent)]/10 text-[var(--gantry-accent)]'
+                      : 'text-[var(--gantry-text-secondary)] hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-text-primary)]'
+                  }`}
+                  title={collapsed ? 'Nexus' : undefined}
+                >
+                  <Archive className="h-5 w-5 shrink-0" />
+                  {!collapsed && <span className="truncate">Nexus</span>}
                 </Link>
               </li>
             )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse, NexusComponent, NexusAsset } from './types';
+import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse, NexusComponent, NexusAsset, NexusRepository } from './types';
 
 export const AUTH_UNAUTHORIZED_EVENT = 'auth:unauthorized';
 export const PLUGINS_UPDATED_EVENT = 'gantry:plugins-updated';
@@ -171,6 +171,8 @@ export const api = {
     request<HarborSummaryResponse>('GET', '/plugins/harbor/summary'),
 
   // Nexus Repository Manager
+  getNexusRepositories: () =>
+    request<NexusRepository[]>('GET', '/plugins/nexus-repository-manager/repositories'),
   getNexusComponents: (name: string, repository?: string, group?: string, format?: string) => {
     const params = new URLSearchParams();
     if (name) params.set('name', name);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -485,7 +485,6 @@ export interface NexusRepository {
   format: string;
   type: string;
   url: string;
-  online: boolean;
 }
 
 export interface NexusComponent {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -480,6 +480,14 @@ export interface NexusAsset {
   fileSize: number;
 }
 
+export interface NexusRepository {
+  name: string;
+  format: string;
+  type: string;
+  url: string;
+  online: boolean;
+}
+
 export interface NexusComponent {
   id: string;
   repository: string;

--- a/web/src/pages/Nexus.tsx
+++ b/web/src/pages/Nexus.tsx
@@ -14,12 +14,12 @@ type Filters = {
 };
 
 const FORMAT_BADGE: Record<string, string> = {
-  maven2: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
-  npm: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-  docker: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-  pypi: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
-  nuget: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
-  raw: 'bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400',
+  maven2: 'border border-[var(--gantry-accent)] bg-[var(--gantry-accent)]/10 text-[var(--gantry-accent)]',
+  npm: 'border border-[var(--gantry-danger)] bg-[var(--gantry-danger)]/10 text-[var(--gantry-danger)]',
+  docker: 'border border-[var(--gantry-accent)] bg-[var(--gantry-bg-secondary)] text-[var(--gantry-text-primary)]',
+  pypi: 'border border-[var(--gantry-border)] bg-[var(--gantry-bg-tertiary)] text-[var(--gantry-text-primary)]',
+  nuget: 'border border-[var(--gantry-accent)] bg-[var(--gantry-accent)] text-[var(--gantry-bg-primary)]',
+  raw: 'border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] text-[var(--gantry-text-secondary)]',
 };
 
 const EMPTY_FILTERS: Filters = {
@@ -39,7 +39,7 @@ function formatBytes(bytes: number): string {
 
 function formatDate(ts: string): string {
   if (!ts) return '—';
-  return new Date(ts).toLocaleDateString('en-US', {
+  return new Date(ts).toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/web/src/pages/Nexus.tsx
+++ b/web/src/pages/Nexus.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, Fragment, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, Fragment, type KeyboardEvent } from 'react';
 import { Archive, ChevronDown, ChevronRight, ChevronUp, Package, RefreshCw, Search, AlertCircle, FileDown, ArrowLeft, Database } from 'lucide-react';
 import { api } from '../lib/api';
 import type { NexusAsset, NexusComponent, NexusRepository } from '../lib/types';
@@ -65,8 +65,42 @@ function latestModified(component: NexusComponent): string {
 function SortIcon({ column, sortKey, sortDir }: { column: SortKey; sortKey: SortKey; sortDir: SortDir }) {
   if (column !== sortKey) return null;
   return sortDir === 'asc'
-    ? <ChevronUp className="ml-0.5 inline h-3 w-3" />
-    : <ChevronDown className="ml-0.5 inline h-3 w-3" />;
+    ? <ChevronUp className="ml-0.5 inline h-3 w-3" aria-hidden="true" />
+    : <ChevronDown className="ml-0.5 inline h-3 w-3" aria-hidden="true" />;
+}
+
+function sortAriaValue(column: SortKey, sortKey: SortKey, sortDir: SortDir): 'none' | 'ascending' | 'descending' {
+  if (column !== sortKey) return 'none';
+  return sortDir === 'asc' ? 'ascending' : 'descending';
+}
+
+function SortableHeader({
+  column,
+  label,
+  sortKey,
+  sortDir,
+  onToggle,
+  className,
+}: {
+  column: SortKey;
+  label: string;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onToggle: (column: SortKey) => void;
+  className: string;
+}) {
+  return (
+    <th className={className} aria-sort={sortAriaValue(column, sortKey, sortDir)}>
+      <button
+        type="button"
+        onClick={() => onToggle(column)}
+        className="flex w-full items-center gap-1 text-left focus:outline-none focus-visible:text-[var(--gantry-text-primary)]"
+      >
+        <span>{label}</span>
+        <SortIcon column={column} sortKey={sortKey} sortDir={sortDir} />
+      </button>
+    </th>
+  );
 }
 
 function AssetRow({ asset }: { asset: NexusAsset }) {
@@ -187,6 +221,7 @@ export default function Nexus() {
   const [compSearch, setCompSearch] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('modified');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const latestFetchIdRef = useRef(0);
 
   const inComponentView = selectedRepo !== null;
 
@@ -198,16 +233,23 @@ export default function Nexus() {
   }, []);
 
   const fetchComponents = useCallback(async (repository: string, showRefresh = false) => {
+    const requestId = latestFetchIdRef.current + 1;
+    latestFetchIdRef.current = requestId;
+
     if (showRefresh) setCompRefreshing(true);
     else setCompLoading(true);
     setCompError('');
+
     try {
       const data = await api.getNexusComponents('', repository);
+      if (requestId !== latestFetchIdRef.current) return;
       setComponents(data);
     } catch (err: any) {
+      if (requestId !== latestFetchIdRef.current) return;
       setCompError(err.message || 'Failed to fetch components');
       setComponents([]);
     } finally {
+      if (requestId !== latestFetchIdRef.current) return;
       setCompLoading(false);
       setCompRefreshing(false);
     }
@@ -224,9 +266,12 @@ export default function Nexus() {
   }
 
   function handleBackToRepos() {
+    latestFetchIdRef.current += 1;
     setSelectedRepo(null);
     setComponents([]);
     setCompError('');
+    setCompLoading(false);
+    setCompRefreshing(false);
     setCompSearch('');
   }
 
@@ -276,7 +321,7 @@ export default function Nexus() {
     });
   }, [components, compSearch, sortKey, sortDir]);
 
-  const thClass = 'cursor-pointer select-none px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)] transition-colors hover:text-[var(--gantry-text-primary)]';
+  const thClass = 'px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]';
   const totalAssets = filteredComponents.reduce((sum, c) => sum + c.assets.length, 0);
 
   return (
@@ -447,24 +492,12 @@ export default function Nexus() {
                     <thead>
                       <tr className="bg-[var(--gantry-bg-secondary)]">
                         <th className="w-8 px-4 py-3" />
-                        <th className={thClass} onClick={() => toggleSort('name')}>
-                          Component <SortIcon column="name" sortKey={sortKey} sortDir={sortDir} />
-                        </th>
-                        <th className={thClass} onClick={() => toggleSort('version')}>
-                          Version <SortIcon column="version" sortKey={sortKey} sortDir={sortDir} />
-                        </th>
-                        <th className={thClass} onClick={() => toggleSort('format')}>
-                          Format <SortIcon column="format" sortKey={sortKey} sortDir={sortDir} />
-                        </th>
-                        <th className={thClass} onClick={() => toggleSort('repository')}>
-                          Repository <SortIcon column="repository" sortKey={sortKey} sortDir={sortDir} />
-                        </th>
-                        <th className={thClass} onClick={() => toggleSort('assets')}>
-                          Assets <SortIcon column="assets" sortKey={sortKey} sortDir={sortDir} />
-                        </th>
-                        <th className={thClass} onClick={() => toggleSort('modified')}>
-                          Modified <SortIcon column="modified" sortKey={sortKey} sortDir={sortDir} />
-                        </th>
+                        <SortableHeader column="name" label="Component" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} className={thClass} />
+                        <SortableHeader column="version" label="Version" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} className={thClass} />
+                        <SortableHeader column="format" label="Format" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} className={thClass} />
+                        <SortableHeader column="repository" label="Repository" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} className={thClass} />
+                        <SortableHeader column="assets" label="Assets" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} className={thClass} />
+                        <SortableHeader column="modified" label="Modified" sortKey={sortKey} sortDir={sortDir} onToggle={toggleSort} className={thClass} />
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-[var(--gantry-border)]">

--- a/web/src/pages/Nexus.tsx
+++ b/web/src/pages/Nexus.tsx
@@ -328,7 +328,6 @@ export default function Nexus() {
                       <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Name</th>
                       <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Type</th>
                       <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Format</th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Status</th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-[var(--gantry-border)]">
@@ -352,12 +351,6 @@ export default function Nexus() {
                           </td>
                           <td className="px-4 py-3">
                             <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${formatCls}`}>{repo.format}</span>
-                          </td>
-                          <td className="px-4 py-3">
-                            <span className={`flex items-center gap-1.5 text-xs ${repo.online ? 'text-[var(--gantry-accent)]' : 'text-[var(--gantry-text-secondary)]'}`}>
-                              <span className={`inline-block h-1.5 w-1.5 rounded-full ${repo.online ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-text-secondary)]'}`} />
-                              {repo.online ? 'Online' : 'Offline'}
-                            </span>
                           </td>
                         </tr>
                       );

--- a/web/src/pages/Nexus.tsx
+++ b/web/src/pages/Nexus.tsx
@@ -47,7 +47,9 @@ function handleInteractiveRowKeyDown(event: KeyboardEvent<HTMLElement>, onActiva
 
 function formatDate(ts: string): string {
   if (!ts) return '—';
-  return new Date(ts).toLocaleDateString(undefined, {
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString(undefined, {
     month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit',
   });
 }

--- a/web/src/pages/Nexus.tsx
+++ b/web/src/pages/Nexus.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, Fragment } from 'react';
+import { useCallback, useEffect, useMemo, useState, Fragment, type KeyboardEvent } from 'react';
 import { Archive, ChevronDown, ChevronRight, ChevronUp, Package, RefreshCw, Search, AlertCircle, FileDown, ArrowLeft, Database } from 'lucide-react';
 import { api } from '../lib/api';
 import type { NexusAsset, NexusComponent, NexusRepository } from '../lib/types';
@@ -24,9 +24,25 @@ const REPO_TYPE_BADGE: Record<string, string> = {
 function formatBytes(bytes: number): string {
   if (!bytes || bytes === 0) return '—';
   const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
   return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+function isSafeExternalUrl(url?: string): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function handleInteractiveRowKeyDown(event: KeyboardEvent<HTMLElement>, onActivate: () => void) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  event.preventDefault();
+  onActivate();
 }
 
 function formatDate(ts: string): string {
@@ -53,14 +69,16 @@ function SortIcon({ column, sortKey, sortDir }: { column: SortKey; sortKey: Sort
 
 function AssetRow({ asset }: { asset: NexusAsset }) {
   const fileName = asset.path?.split('/').pop() || asset.path || '—';
+  const safeDownloadUrl = isSafeExternalUrl(asset.downloadUrl) ? asset.downloadUrl : '';
+
   return (
     <tr className="text-xs">
       <td className="py-1.5 pr-4 text-[var(--gantry-text-primary)]">
         <div className="flex items-center gap-1.5">
           <FileDown className="h-3 w-3 text-[var(--gantry-text-secondary)]" />
-          {asset.downloadUrl ? (
+          {safeDownloadUrl ? (
             <a
-              href={asset.downloadUrl}
+              href={safeDownloadUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-[var(--gantry-accent)] hover:text-[var(--gantry-accent-hover)]"
@@ -85,11 +103,17 @@ function ComponentRow({ component }: { component: NexusComponent }) {
   const formatCls = FORMAT_BADGE[component.format] || FORMAT_BADGE.raw;
   const modified = latestModified(component);
 
+  const toggleExpanded = () => setExpanded((value) => !value);
+
   return (
     <Fragment>
       <tr
-        className="cursor-pointer hover:bg-[var(--gantry-bg-secondary)]"
-        onClick={() => setExpanded((v) => !v)}
+        className="cursor-pointer hover:bg-[var(--gantry-bg-secondary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--gantry-accent)]"
+        onClick={toggleExpanded}
+        onKeyDown={(event) => handleInteractiveRowKeyDown(event, toggleExpanded)}
+        tabIndex={0}
+        role="button"
+        aria-expanded={expanded}
       >
         <td className="px-4 py-3">
           {expanded
@@ -191,6 +215,10 @@ export default function Nexus() {
     setSelectedRepo(repo.name);
     setCompSearch('');
     void fetchComponents(repo.name);
+  }
+
+  function handleRepoKeyDown(event: KeyboardEvent<HTMLTableRowElement>, repo: NexusRepository) {
+    handleInteractiveRowKeyDown(event, () => handleRepoClick(repo));
   }
 
   function handleBackToRepos() {
@@ -337,8 +365,12 @@ export default function Nexus() {
                       return (
                         <tr
                           key={repo.name}
-                          className="cursor-pointer hover:bg-[var(--gantry-bg-secondary)]"
+                          className="cursor-pointer hover:bg-[var(--gantry-bg-secondary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--gantry-accent)]"
                           onClick={() => handleRepoClick(repo)}
+                          onKeyDown={(event) => handleRepoKeyDown(event, repo)}
+                          tabIndex={0}
+                          role="button"
+                          aria-label={`Open repository ${repo.name}`}
                         >
                           <td className="px-4 py-3">
                             <div className="flex items-center gap-2">

--- a/web/src/pages/Nexus.tsx
+++ b/web/src/pages/Nexus.tsx
@@ -1,17 +1,10 @@
 import { useCallback, useEffect, useMemo, useState, Fragment } from 'react';
-import { Archive, ChevronDown, ChevronRight, ChevronUp, Package, RefreshCw, Search, AlertCircle, FileDown } from 'lucide-react';
+import { Archive, ChevronDown, ChevronRight, ChevronUp, Package, RefreshCw, Search, AlertCircle, FileDown, ArrowLeft, Database } from 'lucide-react';
 import { api } from '../lib/api';
-import type { NexusAsset, NexusComponent } from '../lib/types';
+import type { NexusAsset, NexusComponent, NexusRepository } from '../lib/types';
 
 type SortKey = 'name' | 'version' | 'format' | 'repository' | 'assets' | 'modified';
 type SortDir = 'asc' | 'desc';
-
-type Filters = {
-  name: string;
-  repository: string;
-  group: string;
-  format: string;
-};
 
 const FORMAT_BADGE: Record<string, string> = {
   maven2: 'border border-[var(--gantry-accent)] bg-[var(--gantry-accent)]/10 text-[var(--gantry-accent)]',
@@ -22,11 +15,10 @@ const FORMAT_BADGE: Record<string, string> = {
   raw: 'border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] text-[var(--gantry-text-secondary)]',
 };
 
-const EMPTY_FILTERS: Filters = {
-  name: '',
-  repository: '',
-  group: '',
-  format: '',
+const REPO_TYPE_BADGE: Record<string, string> = {
+  hosted: 'bg-[var(--gantry-accent)]/10 text-[var(--gantry-accent)] border border-[var(--gantry-accent)]',
+  proxy: 'bg-[var(--gantry-bg-tertiary)] text-[var(--gantry-text-secondary)] border border-[var(--gantry-border)]',
+  group: 'bg-[var(--gantry-danger)]/10 text-[var(--gantry-danger)] border border-[var(--gantry-danger)]',
 };
 
 function formatBytes(bytes: number): string {
@@ -40,11 +32,7 @@ function formatBytes(bytes: number): string {
 function formatDate(ts: string): string {
   if (!ts) return '—';
   return new Date(ts).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
+    month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit',
   });
 }
 
@@ -65,7 +53,6 @@ function SortIcon({ column, sortKey, sortDir }: { column: SortKey; sortKey: Sort
 
 function AssetRow({ asset }: { asset: NexusAsset }) {
   const fileName = asset.path?.split('/').pop() || asset.path || '—';
-
   return (
     <tr className="text-xs">
       <td className="py-1.5 pr-4 text-[var(--gantry-text-primary)]">
@@ -102,14 +89,12 @@ function ComponentRow({ component }: { component: NexusComponent }) {
     <Fragment>
       <tr
         className="cursor-pointer hover:bg-[var(--gantry-bg-secondary)]"
-        onClick={() => setExpanded((value) => !value)}
+        onClick={() => setExpanded((v) => !v)}
       >
         <td className="px-4 py-3">
-          {expanded ? (
-            <ChevronDown className="h-3.5 w-3.5 text-[var(--gantry-text-secondary)]" />
-          ) : (
-            <ChevronRight className="h-3.5 w-3.5 text-[var(--gantry-text-secondary)]" />
-          )}
+          {expanded
+            ? <ChevronDown className="h-3.5 w-3.5 text-[var(--gantry-text-secondary)]" />
+            : <ChevronRight className="h-3.5 w-3.5 text-[var(--gantry-text-secondary)]" />}
         </td>
         <td className="px-4 py-3 text-xs font-medium text-[var(--gantry-text-primary)]">
           {component.group ? `${component.group}/${component.name}` : component.name}
@@ -161,328 +146,321 @@ function ComponentRow({ component }: { component: NexusComponent }) {
 }
 
 export default function Nexus() {
-  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
-  const [appliedFilters, setAppliedFilters] = useState<Filters>(EMPTY_FILTERS);
+  // Repository browse state
+  const [repositories, setRepositories] = useState<NexusRepository[]>([]);
+  const [repoLoading, setRepoLoading] = useState(true);
+  const [repoError, setRepoError] = useState('');
+  const [repoSearch, setRepoSearch] = useState('');
+
+  // Component browse state
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
   const [components, setComponents] = useState<NexusComponent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState('');
-  const [search, setSearch] = useState('');
+  const [compLoading, setCompLoading] = useState(false);
+  const [compRefreshing, setCompRefreshing] = useState(false);
+  const [compError, setCompError] = useState('');
+  const [compSearch, setCompSearch] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('modified');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const [initialized, setInitialized] = useState(false);
 
-  const fetchComponents = useCallback(async (nextFilters: Filters, showRefresh = false) => {
-    if (showRefresh) {
-      setRefreshing(true);
-    } else {
-      setLoading(true);
-    }
-    setError('');
+  const inComponentView = selectedRepo !== null;
 
+  useEffect(() => {
+    api.getNexusRepositories()
+      .then((data) => setRepositories(data))
+      .catch((err) => setRepoError(err.message || 'Failed to fetch repositories'))
+      .finally(() => setRepoLoading(false));
+  }, []);
+
+  const fetchComponents = useCallback(async (repository: string, showRefresh = false) => {
+    if (showRefresh) setCompRefreshing(true);
+    else setCompLoading(true);
+    setCompError('');
     try {
-      const data = await api.getNexusComponents(
-        nextFilters.name,
-        nextFilters.repository || undefined,
-        nextFilters.group || undefined,
-        nextFilters.format || undefined,
-      );
+      const data = await api.getNexusComponents('', repository);
       setComponents(data);
-      setAppliedFilters(nextFilters);
     } catch (err: any) {
-      setError(err.message || 'Failed to fetch Nexus components');
+      setCompError(err.message || 'Failed to fetch components');
       setComponents([]);
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      setCompLoading(false);
+      setCompRefreshing(false);
     }
   }, []);
 
-  useEffect(() => {
-    let active = true;
+  function handleRepoClick(repo: NexusRepository) {
+    setSelectedRepo(repo.name);
+    setCompSearch('');
+    void fetchComponents(repo.name);
+  }
 
-    api.getPluginConfig('nexus-repository-manager')
-      .then((cfg) => {
-        if (!active) return;
-        const defaultRepository = (cfg.values?.defaultRepository as string) || '';
-        const nextFilters = { ...EMPTY_FILTERS, repository: defaultRepository };
-        setFilters(nextFilters);
-        return fetchComponents(nextFilters);
-      })
-      .catch(() => {
-        if (!active) return;
-        setLoading(false);
-      })
-      .finally(() => {
-        if (!active) return;
-        setInitialized(true);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [fetchComponents]);
-
-  const filteredComponents = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    const base = query
-      ? components.filter((component) => {
-        const haystack = [
-          component.name,
-          component.group,
-          component.version,
-          component.repository,
-          component.format,
-          ...component.assets.map((asset) => asset.path),
-        ]
-          .filter(Boolean)
-          .join(' ')
-          .toLowerCase();
-        return haystack.includes(query);
-      })
-      : components;
-
-    const sorted = [...base];
-    sorted.sort((a, b) => {
-      let cmp = 0;
-      switch (sortKey) {
-        case 'name':
-          cmp = (a.name || '').localeCompare(b.name || '');
-          break;
-        case 'version':
-          cmp = (a.version || '').localeCompare(b.version || '');
-          break;
-        case 'format':
-          cmp = (a.format || '').localeCompare(b.format || '');
-          break;
-        case 'repository':
-          cmp = (a.repository || '').localeCompare(b.repository || '');
-          break;
-        case 'assets':
-          cmp = a.assets.length - b.assets.length;
-          break;
-        case 'modified':
-          cmp = (latestModified(a) || '').localeCompare(latestModified(b) || '');
-          break;
-      }
-      return sortDir === 'asc' ? cmp : -cmp;
-    });
-
-    return sorted;
-  }, [components, search, sortDir, sortKey]);
-
-  const thClass = 'cursor-pointer select-none px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)] transition-colors hover:text-[var(--gantry-text-primary)]';
-
-  function updateFilter<K extends keyof Filters>(key: K, value: Filters[K]) {
-    setFilters((current) => ({ ...current, [key]: value }));
+  function handleBackToRepos() {
+    setSelectedRepo(null);
+    setComponents([]);
+    setCompError('');
+    setCompSearch('');
   }
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) {
-      setSortDir((current) => (current === 'asc' ? 'desc' : 'asc'));
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
       return;
     }
     setSortKey(key);
     setSortDir(key === 'modified' ? 'desc' : 'asc');
   }
 
-  function handleLoad() {
-    void fetchComponents(filters);
-  }
+  const filteredRepos = useMemo(() => {
+    const q = repoSearch.trim().toLowerCase();
+    return q
+      ? repositories.filter((r) =>
+          r.name.toLowerCase().includes(q) ||
+          r.format.toLowerCase().includes(q) ||
+          r.type.toLowerCase().includes(q)
+        )
+      : repositories;
+  }, [repositories, repoSearch]);
 
-  function handleReset() {
-    setFilters(EMPTY_FILTERS);
-    setAppliedFilters(EMPTY_FILTERS);
-    setComponents([]);
-    setError('');
-    setSearch('');
-    setLoading(false);
-    setRefreshing(false);
-  }
+  const filteredComponents = useMemo(() => {
+    const q = compSearch.trim().toLowerCase();
+    const base = q
+      ? components.filter((c) => {
+          const haystack = [
+            c.name, c.group, c.version, c.repository, c.format,
+            ...c.assets.map((a) => a.path),
+          ].filter(Boolean).join(' ').toLowerCase();
+          return haystack.includes(q);
+        })
+      : components;
 
-  const totalAssets = filteredComponents.reduce((sum, component) => sum + component.assets.length, 0);
-  const hasAppliedFilters = Object.values(appliedFilters).some(Boolean);
+    return [...base].sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case 'name':       cmp = (a.name || '').localeCompare(b.name || ''); break;
+        case 'version':    cmp = (a.version || '').localeCompare(b.version || ''); break;
+        case 'format':     cmp = (a.format || '').localeCompare(b.format || ''); break;
+        case 'repository': cmp = (a.repository || '').localeCompare(b.repository || ''); break;
+        case 'assets':     cmp = a.assets.length - b.assets.length; break;
+        case 'modified':   cmp = (latestModified(a) || '').localeCompare(latestModified(b) || ''); break;
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [components, compSearch, sortKey, sortDir]);
+
+  const thClass = 'cursor-pointer select-none px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)] transition-colors hover:text-[var(--gantry-text-primary)]';
+  const totalAssets = filteredComponents.reduce((sum, c) => sum + c.assets.length, 0);
 
   return (
     <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-[var(--gantry-text-primary)]">
-            <Archive className="mr-2 inline h-7 w-7" />
-            Nexus Repository Manager
-          </h1>
-          <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
-            Explore components, package versions, and downloadable assets across your Nexus repositories.
-          </p>
+        <div className="flex items-center gap-3">
+          {inComponentView && (
+            <button
+              onClick={handleBackToRepos}
+              className="flex items-center gap-1.5 rounded-lg border border-[var(--gantry-border)] px-3 py-1.5 text-sm text-[var(--gantry-text-secondary)] hover:border-[var(--gantry-accent)] hover:text-[var(--gantry-accent)]"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Repositories
+            </button>
+          )}
+          <div>
+            <h1 className="text-2xl font-bold text-[var(--gantry-text-primary)]">
+              <Archive className="mr-2 inline h-7 w-7" />
+              Nexus Repository Manager
+              {inComponentView && (
+                <span className="ml-3 text-lg font-normal text-[var(--gantry-text-secondary)]">
+                  / {selectedRepo}
+                </span>
+              )}
+            </h1>
+            <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
+              {inComponentView
+                ? 'Browse components and downloadable assets in this repository.'
+                : 'Browse repositories and components across your Nexus instance.'}
+            </p>
+          </div>
         </div>
-        {(components.length > 0 || hasAppliedFilters) && (
+        {inComponentView && (
           <button
-            onClick={() => void fetchComponents(appliedFilters, true)}
-            disabled={refreshing}
+            onClick={() => void fetchComponents(selectedRepo!, true)}
+            disabled={compRefreshing}
             className="flex items-center gap-2 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-4 py-2 text-sm font-medium text-[var(--gantry-text-primary)] transition-colors hover:border-[var(--gantry-accent)] hover:text-[var(--gantry-accent)] disabled:opacity-50"
           >
-            <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+            <RefreshCw className={`h-4 w-4 ${compRefreshing ? 'animate-spin' : ''}`} />
             Refresh
           </button>
         )}
       </div>
 
-      <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-4 sm:p-5">
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium text-[var(--gantry-text-primary)]">Component name</span>
-            <input
-              type="text"
-              value={filters.name}
-              onChange={(e) => updateFilter('name', e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
-              placeholder="payments-api"
-              className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-            />
-          </label>
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium text-[var(--gantry-text-primary)]">Repository</span>
-            <input
-              type="text"
-              value={filters.repository}
-              onChange={(e) => updateFilter('repository', e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
-              placeholder="maven-releases"
-              className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-            />
-          </label>
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium text-[var(--gantry-text-primary)]">Group / namespace</span>
-            <input
-              type="text"
-              value={filters.group}
-              onChange={(e) => updateFilter('group', e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
-              placeholder="com.example"
-              className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-            />
-          </label>
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium text-[var(--gantry-text-primary)]">Format</span>
-            <input
-              type="text"
-              value={filters.format}
-              onChange={(e) => updateFilter('format', e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
-              placeholder="docker"
-              className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-            />
-          </label>
-        </div>
-
-        <div className="mt-4 flex flex-wrap items-center gap-3">
-          <button
-            onClick={handleLoad}
-            className="rounded-lg bg-[var(--gantry-accent)] px-4 py-2 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)]"
-          >
-            Load components
-          </button>
-          <button
-            onClick={handleReset}
-            className="rounded-lg border border-[var(--gantry-border)] px-4 py-2 text-sm font-medium text-[var(--gantry-text-primary)] hover:border-[var(--gantry-accent)] hover:text-[var(--gantry-accent)]"
-          >
-            Reset
-          </button>
-          {hasAppliedFilters && (
-            <div className="text-xs text-[var(--gantry-text-secondary)]">
-              Loaded with
-              {appliedFilters.name && <span className="ml-1 font-medium text-[var(--gantry-text-primary)]">name={appliedFilters.name}</span>}
-              {appliedFilters.repository && <span className="ml-1 font-medium text-[var(--gantry-text-primary)]">repo={appliedFilters.repository}</span>}
-              {appliedFilters.group && <span className="ml-1 font-medium text-[var(--gantry-text-primary)]">group={appliedFilters.group}</span>}
-              {appliedFilters.format && <span className="ml-1 font-medium text-[var(--gantry-text-primary)]">format={appliedFilters.format}</span>}
+      {/* ── Repository browser ── */}
+      {!inComponentView && (
+        <>
+          {repoError && (
+            <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-8 text-center">
+              <AlertCircle className="mx-auto mb-3 h-10 w-10 text-[var(--gantry-danger)]" />
+              <h2 className="text-lg font-semibold text-[var(--gantry-text-primary)]">Error</h2>
+              <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">{repoError}</p>
             </div>
           )}
-        </div>
-      </div>
 
-      {error && (
-        <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-8 text-center">
-          <AlertCircle className="mx-auto mb-3 h-10 w-10 text-[var(--gantry-danger)]" />
-          <h2 className="text-lg font-semibold text-[var(--gantry-text-primary)]">Error</h2>
-          <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">{error}</p>
-        </div>
+          {repoLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--gantry-accent)] border-t-transparent" />
+            </div>
+          ) : !repoError && (
+            <>
+              {repositories.length > 6 && (
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--gantry-text-secondary)]" />
+                  <input
+                    type="text"
+                    value={repoSearch}
+                    onChange={(e) => setRepoSearch(e.target.value)}
+                    placeholder="Filter repositories..."
+                    className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] py-2 pl-9 pr-3 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none md:max-w-sm"
+                  />
+                </div>
+              )}
+              <div className="overflow-hidden rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]">
+                <table className="min-w-full divide-y divide-[var(--gantry-border)]">
+                  <thead>
+                    <tr className="bg-[var(--gantry-bg-secondary)]">
+                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Name</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Type</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Format</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-[var(--gantry-border)]">
+                    {filteredRepos.map((repo) => {
+                      const typeCls = REPO_TYPE_BADGE[repo.type] || REPO_TYPE_BADGE.proxy;
+                      const formatCls = FORMAT_BADGE[repo.format] || FORMAT_BADGE.raw;
+                      return (
+                        <tr
+                          key={repo.name}
+                          className="cursor-pointer hover:bg-[var(--gantry-bg-secondary)]"
+                          onClick={() => handleRepoClick(repo)}
+                        >
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <Database className="h-4 w-4 shrink-0 text-[var(--gantry-text-secondary)]" />
+                              <span className="text-sm font-medium text-[var(--gantry-accent)]">{repo.name}</span>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${typeCls}`}>{repo.type}</span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${formatCls}`}>{repo.format}</span>
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className={`flex items-center gap-1.5 text-xs ${repo.online ? 'text-[var(--gantry-accent)]' : 'text-[var(--gantry-text-secondary)]'}`}>
+                              <span className={`inline-block h-1.5 w-1.5 rounded-full ${repo.online ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-text-secondary)]'}`} />
+                              {repo.online ? 'Online' : 'Offline'}
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+                {filteredRepos.length === 0 && (
+                  <p className="py-10 text-center text-sm text-[var(--gantry-text-secondary)]">No repositories found.</p>
+                )}
+              </div>
+            </>
+          )}
+        </>
       )}
 
-      {loading ? (
-        <div className="flex items-center justify-center py-20">
-          <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--gantry-accent)] border-t-transparent" />
-        </div>
-      ) : components.length > 0 ? (
+      {/* ── Component browser ── */}
+      {inComponentView && (
         <>
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div className="flex items-center gap-3 rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-5 py-4">
-              <Package className="h-5 w-5 shrink-0 text-[var(--gantry-accent)]" />
-              <div>
-                <p className="text-sm font-semibold text-[var(--gantry-text-primary)]">
-                  {filteredComponents.length} {filteredComponents.length === 1 ? 'component' : 'components'}
-                </p>
-                <p className="text-xs text-[var(--gantry-text-secondary)]">
-                  {totalAssets} total {totalAssets === 1 ? 'asset' : 'assets'}
-                </p>
-              </div>
+          {compError && (
+            <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-8 text-center">
+              <AlertCircle className="mx-auto mb-3 h-10 w-10 text-[var(--gantry-danger)]" />
+              <h2 className="text-lg font-semibold text-[var(--gantry-text-primary)]">Error</h2>
+              <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">{compError}</p>
             </div>
+          )}
 
-            {components.length > 5 && (
-              <div className="relative w-full md:max-w-sm">
-                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--gantry-text-secondary)]" />
-                <input
-                  type="text"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Filter loaded components..."
-                  className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] py-2 pl-9 pr-3 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-                />
+          {compLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--gantry-accent)] border-t-transparent" />
+            </div>
+          ) : !compError && (
+            <>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3 rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-5 py-4">
+                  <Package className="h-5 w-5 shrink-0 text-[var(--gantry-accent)]" />
+                  <div>
+                    <p className="text-sm font-semibold text-[var(--gantry-text-primary)]">
+                      {filteredComponents.length}{components.length !== filteredComponents.length && ` of ${components.length}`} {filteredComponents.length === 1 ? 'component' : 'components'}
+                    </p>
+                    <p className="text-xs text-[var(--gantry-text-secondary)]">
+                      {totalAssets} total {totalAssets === 1 ? 'asset' : 'assets'}
+                    </p>
+                  </div>
+                </div>
+                <div className="relative w-full sm:max-w-sm">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--gantry-text-secondary)]" />
+                  <input
+                    type="text"
+                    value={compSearch}
+                    onChange={(e) => setCompSearch(e.target.value)}
+                    placeholder="Search by name, group, version, format..."
+                    className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] py-2 pl-9 pr-3 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+                  />
+                </div>
               </div>
-            )}
-          </div>
 
-          <div className="overflow-hidden rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]">
-            <table className="min-w-full divide-y divide-[var(--gantry-border)]">
-              <thead>
-                <tr className="bg-[var(--gantry-bg-secondary)]">
-                  <th className="w-8 px-4 py-3" />
-                  <th className={thClass} onClick={() => toggleSort('name')}>
-                    Component <SortIcon column="name" sortKey={sortKey} sortDir={sortDir} />
-                  </th>
-                  <th className={thClass} onClick={() => toggleSort('version')}>
-                    Version <SortIcon column="version" sortKey={sortKey} sortDir={sortDir} />
-                  </th>
-                  <th className={thClass} onClick={() => toggleSort('format')}>
-                    Format <SortIcon column="format" sortKey={sortKey} sortDir={sortDir} />
-                  </th>
-                  <th className={thClass} onClick={() => toggleSort('repository')}>
-                    Repository <SortIcon column="repository" sortKey={sortKey} sortDir={sortDir} />
-                  </th>
-                  <th className={thClass} onClick={() => toggleSort('assets')}>
-                    Assets <SortIcon column="assets" sortKey={sortKey} sortDir={sortDir} />
-                  </th>
-                  <th className={thClass} onClick={() => toggleSort('modified')}>
-                    Modified <SortIcon column="modified" sortKey={sortKey} sortDir={sortDir} />
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[var(--gantry-border)]">
-                {filteredComponents.map((component) => (
-                  <ComponentRow key={component.id || `${component.name}-${component.version}`} component={component} />
-                ))}
-              </tbody>
-            </table>
-          </div>
+              {components.length > 0 ? (
+                <div className="overflow-hidden rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]">
+                  <table className="min-w-full divide-y divide-[var(--gantry-border)]">
+                    <thead>
+                      <tr className="bg-[var(--gantry-bg-secondary)]">
+                        <th className="w-8 px-4 py-3" />
+                        <th className={thClass} onClick={() => toggleSort('name')}>
+                          Component <SortIcon column="name" sortKey={sortKey} sortDir={sortDir} />
+                        </th>
+                        <th className={thClass} onClick={() => toggleSort('version')}>
+                          Version <SortIcon column="version" sortKey={sortKey} sortDir={sortDir} />
+                        </th>
+                        <th className={thClass} onClick={() => toggleSort('format')}>
+                          Format <SortIcon column="format" sortKey={sortKey} sortDir={sortDir} />
+                        </th>
+                        <th className={thClass} onClick={() => toggleSort('repository')}>
+                          Repository <SortIcon column="repository" sortKey={sortKey} sortDir={sortDir} />
+                        </th>
+                        <th className={thClass} onClick={() => toggleSort('assets')}>
+                          Assets <SortIcon column="assets" sortKey={sortKey} sortDir={sortDir} />
+                        </th>
+                        <th className={thClass} onClick={() => toggleSort('modified')}>
+                          Modified <SortIcon column="modified" sortKey={sortKey} sortDir={sortDir} />
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-[var(--gantry-border)]">
+                      {filteredComponents.map((component) => (
+                        <ComponentRow key={component.id || `${component.name}-${component.version}`} component={component} />
+                      ))}
+                    </tbody>
+                  </table>
+                  {filteredComponents.length === 0 && (
+                    <p className="py-10 text-center text-sm text-[var(--gantry-text-secondary)]">No components match your search.</p>
+                  )}
+                </div>
+              ) : (
+                <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-10 text-center">
+                  <Archive className="mx-auto mb-3 h-10 w-10 text-[var(--gantry-text-secondary)]" />
+                  <h2 className="text-lg font-semibold text-[var(--gantry-text-primary)]">No components found</h2>
+                  <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">This repository appears to be empty.</p>
+                </div>
+              )}
+            </>
+          )}
         </>
-      ) : initialized ? (
-        <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-10 text-center">
-          <Archive className="mx-auto mb-3 h-10 w-10 text-[var(--gantry-text-secondary)]" />
-          <h2 className="text-lg font-semibold text-[var(--gantry-text-primary)]">No components loaded</h2>
-          <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
-            Use the filters above to browse packages in Nexus Repository Manager, or load everything in your default repository.
-          </p>
-        </div>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/web/src/pages/Nexus.tsx
+++ b/web/src/pages/Nexus.tsx
@@ -1,0 +1,488 @@
+import { useCallback, useEffect, useMemo, useState, Fragment } from 'react';
+import { Archive, ChevronDown, ChevronRight, ChevronUp, Package, RefreshCw, Search, AlertCircle, FileDown } from 'lucide-react';
+import { api } from '../lib/api';
+import type { NexusAsset, NexusComponent } from '../lib/types';
+
+type SortKey = 'name' | 'version' | 'format' | 'repository' | 'assets' | 'modified';
+type SortDir = 'asc' | 'desc';
+
+type Filters = {
+  name: string;
+  repository: string;
+  group: string;
+  format: string;
+};
+
+const FORMAT_BADGE: Record<string, string> = {
+  maven2: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  npm: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  docker: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  pypi: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  nuget: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  raw: 'bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400',
+};
+
+const EMPTY_FILTERS: Filters = {
+  name: '',
+  repository: '',
+  group: '',
+  format: '',
+};
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes === 0) return '—';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+function formatDate(ts: string): string {
+  if (!ts) return '—';
+  return new Date(ts).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function latestModified(component: NexusComponent): string {
+  let latest = '';
+  for (const asset of component.assets) {
+    if (asset.lastModified && asset.lastModified > latest) latest = asset.lastModified;
+  }
+  return latest;
+}
+
+function SortIcon({ column, sortKey, sortDir }: { column: SortKey; sortKey: SortKey; sortDir: SortDir }) {
+  if (column !== sortKey) return null;
+  return sortDir === 'asc'
+    ? <ChevronUp className="ml-0.5 inline h-3 w-3" />
+    : <ChevronDown className="ml-0.5 inline h-3 w-3" />;
+}
+
+function AssetRow({ asset }: { asset: NexusAsset }) {
+  const fileName = asset.path?.split('/').pop() || asset.path || '—';
+
+  return (
+    <tr className="text-xs">
+      <td className="py-1.5 pr-4 text-[var(--gantry-text-primary)]">
+        <div className="flex items-center gap-1.5">
+          <FileDown className="h-3 w-3 text-[var(--gantry-text-secondary)]" />
+          {asset.downloadUrl ? (
+            <a
+              href={asset.downloadUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-[var(--gantry-accent)] hover:text-[var(--gantry-accent-hover)]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {fileName}
+            </a>
+          ) : (
+            <span>{fileName}</span>
+          )}
+        </div>
+      </td>
+      <td className="py-1.5 pr-4 font-mono text-[var(--gantry-text-secondary)]">{asset.contentType || '—'}</td>
+      <td className="py-1.5 pr-4 text-[var(--gantry-text-secondary)]">{formatBytes(asset.fileSize)}</td>
+      <td className="py-1.5 text-[var(--gantry-text-secondary)]">{formatDate(asset.lastModified)}</td>
+    </tr>
+  );
+}
+
+function ComponentRow({ component }: { component: NexusComponent }) {
+  const [expanded, setExpanded] = useState(false);
+  const formatCls = FORMAT_BADGE[component.format] || FORMAT_BADGE.raw;
+  const modified = latestModified(component);
+
+  return (
+    <Fragment>
+      <tr
+        className="cursor-pointer hover:bg-[var(--gantry-bg-secondary)]"
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <td className="px-4 py-3">
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-[var(--gantry-text-secondary)]" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-[var(--gantry-text-secondary)]" />
+          )}
+        </td>
+        <td className="px-4 py-3 text-xs font-medium text-[var(--gantry-text-primary)]">
+          {component.group ? `${component.group}/${component.name}` : component.name}
+        </td>
+        <td className="px-4 py-3 font-mono text-xs text-[var(--gantry-text-primary)]">{component.version || '—'}</td>
+        <td className="px-4 py-3">
+          <span className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${formatCls}`}>
+            {component.format}
+          </span>
+        </td>
+        <td className="px-4 py-3 text-xs text-[var(--gantry-text-secondary)]">{component.repository || '—'}</td>
+        <td className="px-4 py-3 text-xs text-[var(--gantry-text-secondary)]">
+          {component.assets.length} {component.assets.length === 1 ? 'asset' : 'assets'}
+        </td>
+        <td className="px-4 py-3 text-xs text-[var(--gantry-text-secondary)]">
+          {modified ? formatDate(modified) : '—'}
+        </td>
+      </tr>
+      {expanded && component.assets.length > 0 && (
+        <tr>
+          <td colSpan={7} className="bg-[var(--gantry-bg-secondary)] px-8 pb-4 pt-2">
+            <table className="min-w-full text-xs">
+              <thead>
+                <tr className="text-left text-[var(--gantry-text-secondary)]">
+                  <th className="pb-1 pr-4 font-medium">File</th>
+                  <th className="pb-1 pr-4 font-medium">Content Type</th>
+                  <th className="pb-1 pr-4 font-medium">Size</th>
+                  <th className="pb-1 font-medium">Modified</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--gantry-border)]">
+                {component.assets.map((asset) => (
+                  <AssetRow key={asset.id || asset.path} asset={asset} />
+                ))}
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      )}
+      {expanded && component.assets.length === 0 && (
+        <tr>
+          <td colSpan={7} className="bg-[var(--gantry-bg-secondary)] px-8 pb-4 pt-2">
+            <p className="py-2 text-xs text-[var(--gantry-text-secondary)]">No assets found for this component.</p>
+          </td>
+        </tr>
+      )}
+    </Fragment>
+  );
+}
+
+export default function Nexus() {
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [appliedFilters, setAppliedFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [components, setComponents] = useState<NexusComponent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('modified');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [initialized, setInitialized] = useState(false);
+
+  const fetchComponents = useCallback(async (nextFilters: Filters, showRefresh = false) => {
+    if (showRefresh) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setError('');
+
+    try {
+      const data = await api.getNexusComponents(
+        nextFilters.name,
+        nextFilters.repository || undefined,
+        nextFilters.group || undefined,
+        nextFilters.format || undefined,
+      );
+      setComponents(data);
+      setAppliedFilters(nextFilters);
+    } catch (err: any) {
+      setError(err.message || 'Failed to fetch Nexus components');
+      setComponents([]);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    api.getPluginConfig('nexus-repository-manager')
+      .then((cfg) => {
+        if (!active) return;
+        const defaultRepository = (cfg.values?.defaultRepository as string) || '';
+        const nextFilters = { ...EMPTY_FILTERS, repository: defaultRepository };
+        setFilters(nextFilters);
+        return fetchComponents(nextFilters);
+      })
+      .catch(() => {
+        if (!active) return;
+        setLoading(false);
+      })
+      .finally(() => {
+        if (!active) return;
+        setInitialized(true);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [fetchComponents]);
+
+  const filteredComponents = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const base = query
+      ? components.filter((component) => {
+        const haystack = [
+          component.name,
+          component.group,
+          component.version,
+          component.repository,
+          component.format,
+          ...component.assets.map((asset) => asset.path),
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
+        return haystack.includes(query);
+      })
+      : components;
+
+    const sorted = [...base];
+    sorted.sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case 'name':
+          cmp = (a.name || '').localeCompare(b.name || '');
+          break;
+        case 'version':
+          cmp = (a.version || '').localeCompare(b.version || '');
+          break;
+        case 'format':
+          cmp = (a.format || '').localeCompare(b.format || '');
+          break;
+        case 'repository':
+          cmp = (a.repository || '').localeCompare(b.repository || '');
+          break;
+        case 'assets':
+          cmp = a.assets.length - b.assets.length;
+          break;
+        case 'modified':
+          cmp = (latestModified(a) || '').localeCompare(latestModified(b) || '');
+          break;
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+
+    return sorted;
+  }, [components, search, sortDir, sortKey]);
+
+  const thClass = 'cursor-pointer select-none px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)] transition-colors hover:text-[var(--gantry-text-primary)]';
+
+  function updateFilter<K extends keyof Filters>(key: K, value: Filters[K]) {
+    setFilters((current) => ({ ...current, [key]: value }));
+  }
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((current) => (current === 'asc' ? 'desc' : 'asc'));
+      return;
+    }
+    setSortKey(key);
+    setSortDir(key === 'modified' ? 'desc' : 'asc');
+  }
+
+  function handleLoad() {
+    void fetchComponents(filters);
+  }
+
+  function handleReset() {
+    setFilters(EMPTY_FILTERS);
+    setAppliedFilters(EMPTY_FILTERS);
+    setComponents([]);
+    setError('');
+    setSearch('');
+    setLoading(false);
+    setRefreshing(false);
+  }
+
+  const totalAssets = filteredComponents.reduce((sum, component) => sum + component.assets.length, 0);
+  const hasAppliedFilters = Object.values(appliedFilters).some(Boolean);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-[var(--gantry-text-primary)]">
+            <Archive className="mr-2 inline h-7 w-7" />
+            Nexus Repository Manager
+          </h1>
+          <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
+            Explore components, package versions, and downloadable assets across your Nexus repositories.
+          </p>
+        </div>
+        {(components.length > 0 || hasAppliedFilters) && (
+          <button
+            onClick={() => void fetchComponents(appliedFilters, true)}
+            disabled={refreshing}
+            className="flex items-center gap-2 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-4 py-2 text-sm font-medium text-[var(--gantry-text-primary)] transition-colors hover:border-[var(--gantry-accent)] hover:text-[var(--gantry-accent)] disabled:opacity-50"
+          >
+            <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-4 sm:p-5">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium text-[var(--gantry-text-primary)]">Component name</span>
+            <input
+              type="text"
+              value={filters.name}
+              onChange={(e) => updateFilter('name', e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
+              placeholder="payments-api"
+              className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium text-[var(--gantry-text-primary)]">Repository</span>
+            <input
+              type="text"
+              value={filters.repository}
+              onChange={(e) => updateFilter('repository', e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
+              placeholder="maven-releases"
+              className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium text-[var(--gantry-text-primary)]">Group / namespace</span>
+            <input
+              type="text"
+              value={filters.group}
+              onChange={(e) => updateFilter('group', e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
+              placeholder="com.example"
+              className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium text-[var(--gantry-text-primary)]">Format</span>
+            <input
+              type="text"
+              value={filters.format}
+              onChange={(e) => updateFilter('format', e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleLoad(); }}
+              placeholder="docker"
+              className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+            />
+          </label>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            onClick={handleLoad}
+            className="rounded-lg bg-[var(--gantry-accent)] px-4 py-2 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)]"
+          >
+            Load components
+          </button>
+          <button
+            onClick={handleReset}
+            className="rounded-lg border border-[var(--gantry-border)] px-4 py-2 text-sm font-medium text-[var(--gantry-text-primary)] hover:border-[var(--gantry-accent)] hover:text-[var(--gantry-accent)]"
+          >
+            Reset
+          </button>
+          {hasAppliedFilters && (
+            <div className="text-xs text-[var(--gantry-text-secondary)]">
+              Loaded with
+              {appliedFilters.name && <span className="ml-1 font-medium text-[var(--gantry-text-primary)]">name={appliedFilters.name}</span>}
+              {appliedFilters.repository && <span className="ml-1 font-medium text-[var(--gantry-text-primary)]">repo={appliedFilters.repository}</span>}
+              {appliedFilters.group && <span className="ml-1 font-medium text-[var(--gantry-text-primary)]">group={appliedFilters.group}</span>}
+              {appliedFilters.format && <span className="ml-1 font-medium text-[var(--gantry-text-primary)]">format={appliedFilters.format}</span>}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-8 text-center">
+          <AlertCircle className="mx-auto mb-3 h-10 w-10 text-[var(--gantry-danger)]" />
+          <h2 className="text-lg font-semibold text-[var(--gantry-text-primary)]">Error</h2>
+          <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">{error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--gantry-accent)] border-t-transparent" />
+        </div>
+      ) : components.length > 0 ? (
+        <>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-center gap-3 rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-5 py-4">
+              <Package className="h-5 w-5 shrink-0 text-[var(--gantry-accent)]" />
+              <div>
+                <p className="text-sm font-semibold text-[var(--gantry-text-primary)]">
+                  {filteredComponents.length} {filteredComponents.length === 1 ? 'component' : 'components'}
+                </p>
+                <p className="text-xs text-[var(--gantry-text-secondary)]">
+                  {totalAssets} total {totalAssets === 1 ? 'asset' : 'assets'}
+                </p>
+              </div>
+            </div>
+
+            {components.length > 5 && (
+              <div className="relative w-full md:max-w-sm">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--gantry-text-secondary)]" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Filter loaded components..."
+                  className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] py-2 pl-9 pr-3 text-sm text-[var(--gantry-text-primary)] placeholder:text-[var(--gantry-text-secondary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]">
+            <table className="min-w-full divide-y divide-[var(--gantry-border)]">
+              <thead>
+                <tr className="bg-[var(--gantry-bg-secondary)]">
+                  <th className="w-8 px-4 py-3" />
+                  <th className={thClass} onClick={() => toggleSort('name')}>
+                    Component <SortIcon column="name" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('version')}>
+                    Version <SortIcon column="version" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('format')}>
+                    Format <SortIcon column="format" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('repository')}>
+                    Repository <SortIcon column="repository" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('assets')}>
+                    Assets <SortIcon column="assets" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                  <th className={thClass} onClick={() => toggleSort('modified')}>
+                    Modified <SortIcon column="modified" sortKey={sortKey} sortDir={sortDir} />
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--gantry-border)]">
+                {filteredComponents.map((component) => (
+                  <ComponentRow key={component.id || `${component.name}-${component.version}`} component={component} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : initialized ? (
+        <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-10 text-center">
+          <Archive className="mx-auto mb-3 h-10 w-10 text-[var(--gantry-text-secondary)]" />
+          <h2 className="text-lg font-semibold text-[var(--gantry-text-primary)]">No components loaded</h2>
+          <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
+            Use the filters above to browse packages in Nexus Repository Manager, or load everything in your default repository.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated Nexus Repository Manager explorer page with filters, sorting, and expandable asset details
- wire the new page into app routing and sidebar navigation
- add a Nexus plugin `showInSidebar` toggle, matching Harbor's sidebar behavior

## Changes
- created `/nexus` explorer page for browsing Nexus components, repositories, versions, and assets
- added sidebar visibility checks for the Nexus plugin config
- extended the bundled Nexus plugin schema with a `showInSidebar` option

## Validation
- `cd web && npx tsc --noEmit`
- `cd web && npm run build`

Closes #51

@Go2Engle could you please review this?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nexus Repository Manager integration with a dedicated browsing page for repositories and components (list, search, filter, sort, refresh, expandable rows, asset details and safe download links).
  * Sidebar link to the Nexus explorer, controllable via plugin configuration (visible by default).
  * Backend endpoint added to provide repository listings for the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->