### PR TITLE
fix(kubernetes): track touched entities during sync for GitOps integration

### DIFF
--- a/internal/api/handlers/plugins.go
+++ b/internal/api/handlers/plugins.go
@@ -306,9 +306,18 @@ func (h *Handlers) SyncPlugin(w http.ResponseWriter, r *http.Request) {
 			combined.Created += result.Created
 			combined.Updated += result.Updated
 			combined.Errors = append(combined.Errors, result.Errors...)
+			combined.TouchedEntities = append(combined.TouchedEntities, result.TouchedEntities...)
 		}
 		for _, e := range combined.Errors {
 			log.Printf("[kubernetes-sync] error: %s", e)
+		}
+		// Queue GitOps writes for every entity the sync created or updated so
+		// that the K8s-enriched state (dependsOn, deployedIn, etc.) is committed
+		// to Git before the next pull can overwrite it.
+		if h.GitOps != nil {
+			for _, ref := range combined.TouchedEntities {
+				h.GitOps.QueueChange(ref.Kind, ref.Namespace, ref.Name, "write")
+			}
 		}
 		writeJSON(w, http.StatusOK, combined)
 	case "github":

--- a/internal/api/handlers/plugins.go
+++ b/internal/api/handlers/plugins.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go2engle/gantry/internal/gitops"
 	"github.com/go2engle/gantry/internal/plugins"
 	argocd "github.com/go2engle/gantry/internal/plugins/argocd"
 	ghplugin "github.com/go2engle/gantry/internal/plugins/github"
@@ -313,11 +314,14 @@ func (h *Handlers) SyncPlugin(w http.ResponseWriter, r *http.Request) {
 		}
 		// Queue GitOps writes for every entity the sync created or updated so
 		// that the K8s-enriched state (dependsOn, deployedIn, etc.) is committed
-		// to Git before the next pull can overwrite it.
-		if h.GitOps != nil {
-			for _, ref := range combined.TouchedEntities {
-				h.GitOps.QueueChange(ref.Kind, ref.Namespace, ref.Name, "write")
+		// to Git before the next pull can overwrite it. Use QueueChanges to
+		// acquire the lock and reset the debounce timer only once.
+		if h.GitOps != nil && len(combined.TouchedEntities) > 0 {
+			refs := make([]gitops.ChangeRef, len(combined.TouchedEntities))
+			for i, ref := range combined.TouchedEntities {
+				refs[i] = gitops.ChangeRef{Kind: ref.Kind, Namespace: ref.Namespace, Name: ref.Name, Action: "write"}
 			}
+			h.GitOps.QueueChanges(refs)
 		}
 		writeJSON(w, http.StatusOK, combined)
 	case "github":

--- a/internal/gitops/service.go
+++ b/internal/gitops/service.go
@@ -84,6 +84,15 @@ type batchItem struct {
 	Action    string // "write" or "delete"
 }
 
+// ChangeRef identifies an entity change to be queued for GitOps processing.
+// Used with QueueChanges for batch enqueue operations.
+type ChangeRef struct {
+	Kind      string
+	Namespace string
+	Name      string
+	Action    string // "write" or "delete"
+}
+
 const (
 	maxHistory          = 100
 	batchDelay          = 2 * time.Second
@@ -573,6 +582,35 @@ func (s *Service) QueueChange(kind, namespace, name, action string) {
 		Namespace: namespace,
 		Name:      name,
 		Action:    action,
+	}
+	s.status.PendingFiles = len(s.batchItems)
+
+	if s.batchTimer != nil {
+		s.batchTimer.Stop()
+	}
+	s.batchTimer = time.AfterFunc(batchDelay, s.flushBatch)
+}
+
+// QueueChanges adds multiple entity changes to the batch in a single lock
+// acquisition, resetting the debounce timer only once. Prefer this over
+// calling QueueChange in a loop when many entities are touched at once
+// (e.g., after a Kubernetes sync).
+func (s *Service) QueueChanges(refs []ChangeRef) {
+	if s.syncing || len(refs) == 0 {
+		return
+	}
+
+	s.batchMu.Lock()
+	defer s.batchMu.Unlock()
+
+	for _, ref := range refs {
+		key := ref.Kind + "/" + ref.Namespace + "/" + ref.Name
+		s.batchItems[key] = batchItem{
+			Kind:      ref.Kind,
+			Namespace: ref.Namespace,
+			Name:      ref.Name,
+			Action:    ref.Action,
+		}
 	}
 	s.status.PendingFiles = len(s.batchItems)
 

--- a/internal/plugins/kubernetes/sync.go
+++ b/internal/plugins/kubernetes/sync.go
@@ -280,9 +280,17 @@ func upsert(ctx context.Context, store EntityStore, e *entity.Entity, res *SyncR
 	existing.Metadata.Tags = mergeTags(existing.Metadata.Tags, e.Metadata.Tags)
 	existing.Spec = mergeSpec(existing.Spec, e.Spec)
 	if err := store.UpdateEntity(ctx, existing); err != nil {
-		// If UpdateEntity returns ErrEntityNotFound we should CreateEntity.
+		// If UpdateEntity returns ErrEntityNotFound, fall back to create with
+		// proper CreatedAt/CreatedBy and correct counter bookkeeping.
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			return store.CreateEntity(ctx, e)
+			e.Metadata.CreatedBy = "kubernetes-plugin"
+			e.Metadata.CreatedAt = time.Now().UTC()
+			if cerr := store.CreateEntity(ctx, e); cerr != nil {
+				return fmt.Errorf("create entity (fallback): %w", cerr)
+			}
+			res.Created++
+			res.TouchedEntities = append(res.TouchedEntities, EntityRef{Kind: e.Kind, Namespace: e.Metadata.Namespace, Name: e.Metadata.Name})
+			return nil
 		}
 		return fmt.Errorf("update entity: %w", err)
 	}
@@ -488,7 +496,7 @@ func linkInfrastructureToService(ctx context.Context, store EntityStore, infra *
 		if err := store.UpdateEntity(ctx, svc); err != nil {
 			errs = append(errs, fmt.Errorf("update service %s: %w", svcName, err))
 		} else {
-			res.TouchedEntities = append(res.TouchedEntities, EntityRef{Kind: "Service", Namespace: svc.Metadata.Namespace, Name: svcName})
+			res.TouchedEntities = append(res.TouchedEntities, EntityRef{Kind: svc.Kind, Namespace: svc.Metadata.Namespace, Name: svc.Metadata.Name})
 		}
 	}
 	return errors.Join(errs...)

--- a/internal/plugins/kubernetes/sync.go
+++ b/internal/plugins/kubernetes/sync.go
@@ -17,14 +17,22 @@ type EntityStore interface {
 	UpdateEntity(ctx context.Context, e *entity.Entity) error
 }
 
+// EntityRef identifies a single Gantry entity by its primary key.
+type EntityRef struct {
+	Kind      string
+	Namespace string
+	Name      string
+}
+
 // SyncResult summarises what happened during a sync run.
 type SyncResult struct {
-	Namespaces  int      `json:"namespaces"`
-	Deployments int      `json:"deployments"`
-	Services    int      `json:"services"`
-	Created     int      `json:"created"`
-	Updated     int      `json:"updated"`
-	Errors      []string `json:"errors,omitempty"`
+	Namespaces      int         `json:"namespaces"`
+	Deployments     int         `json:"deployments"`
+	Services        int         `json:"services"`
+	Created         int         `json:"created"`
+	Updated         int         `json:"updated"`
+	Errors          []string    `json:"errors,omitempty"`
+	TouchedEntities []EntityRef `json:"-"` // not exposed in API; used to queue GitOps writes
 }
 
 // Sync discovers resources from a Kubernetes cluster and upserts them as
@@ -111,7 +119,7 @@ func Sync(ctx context.Context, config map[string]any, store EntityStore) (*SyncR
 			e := kserviceToInfrastructure(svc, clusterName)
 			if err := upsert(ctx, store, e, res); err != nil {
 				res.Errors = append(res.Errors, fmt.Sprintf("service %s/%s: %v", ns, svc.Metadata.Name, err))
-			} else if linkErr := linkInfrastructureToService(ctx, store, e); linkErr != nil {
+			} else if linkErr := linkInfrastructureToService(ctx, store, e, res); linkErr != nil {
 				res.Errors = append(res.Errors, fmt.Sprintf("link infra %s/%s to service: %v", ns, svc.Metadata.Name, linkErr))
 			}
 			res.Services++
@@ -263,6 +271,7 @@ func upsert(ctx context.Context, store EntityStore, e *entity.Entity, res *SyncR
 			return fmt.Errorf("create entity: %w", err)
 		}
 		res.Created++
+		res.TouchedEntities = append(res.TouchedEntities, EntityRef{Kind: e.Kind, Namespace: e.Metadata.Namespace, Name: e.Metadata.Name})
 		return nil
 	}
 
@@ -278,6 +287,7 @@ func upsert(ctx context.Context, store EntityStore, e *entity.Entity, res *SyncR
 		return fmt.Errorf("update entity: %w", err)
 	}
 	res.Updated++
+	res.TouchedEntities = append(res.TouchedEntities, EntityRef{Kind: existing.Kind, Namespace: existing.Metadata.Namespace, Name: existing.Metadata.Name})
 	return nil
 }
 
@@ -433,7 +443,7 @@ func containsStr(slice []string, s string) bool {
 //
 // This keeps Service entities automatically up to date when infrastructure
 // components are discovered or updated by the Kubernetes sync.
-func linkInfrastructureToService(ctx context.Context, store EntityStore, infra *entity.Entity) error {
+func linkInfrastructureToService(ctx context.Context, store EntityStore, infra *entity.Entity, res *SyncResult) error {
 	dependsOn, _ := infra.Spec["dependsOn"].([]any)
 	deployedIn, _ := infra.Spec["deployedIn"].([]any)
 
@@ -477,6 +487,8 @@ func linkInfrastructureToService(ctx context.Context, store EntityStore, infra *
 
 		if err := store.UpdateEntity(ctx, svc); err != nil {
 			errs = append(errs, fmt.Errorf("update service %s: %w", svcName, err))
+		} else {
+			res.TouchedEntities = append(res.TouchedEntities, EntityRef{Kind: "Service", Namespace: svc.Metadata.Namespace, Name: svcName})
 		}
 	}
 	return errors.Join(errs...)


### PR DESCRIPTION
This pull request enhances the Kubernetes plugin sync process to better track and propagate changes to entities, ensuring that any updates or creations are properly queued for GitOps writes. The main improvements involve tracking all entities touched during a sync and making sure their state is committed to Git before any subsequent pull operations.

**Entity Tracking and GitOps Integration:**

* Introduced a new `EntityRef` struct to uniquely identify entities by kind, namespace, and name, and added a `TouchedEntities` field to the `SyncResult` struct to collect these references during sync operations. (`internal/plugins/kubernetes/sync.go`) [[1]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073R20-R26) [[2]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073R35)
* Modified the `upsert` function to record every created or updated entity in the `TouchedEntities` list. (`internal/plugins/kubernetes/sync.go`) [[1]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073R274) [[2]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073R290)
* Updated the `linkInfrastructureToService` function to also record touched service entities when their links are updated. (`internal/plugins/kubernetes/sync.go`) [[1]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073L436-R446) [[2]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073R490-R491)
* In the API handler, after a sync, all touched entities are now queued for GitOps writes to ensure their state is committed before the next sync. (`internal/api/handlers/plugins.go`)

**Internal API and Function Signature Updates:**

* Updated the signature of `linkInfrastructureToService` to accept the `SyncResult` so it can record touched entities, and adjusted its usage accordingly. (`internal/plugins/kubernetes/sync.go`) [[1]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073L114-R122) [[2]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073L436-R446)

These changes make the sync process more robust by ensuring all relevant entity state changes are tracked and persisted, reducing the risk of state drift between Kubernetes and GitOps sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes plugin now automatically queues synced entities for GitOps commits, ensuring K8s-enriched resource state is persisted to Git after synchronization
  * Added batch change queueing to handle multiple entity updates more efficiently

* **Improvements**
  * Enhanced entity synchronization tracking to identify which resources were created or modified during each sync operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->