### PR TITLE
Chore: topology scroll animation

### DIFF
--- a/web/src/pages/TopologyExplorer.tsx
+++ b/web/src/pages/TopologyExplorer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import {
   RefreshCw,
@@ -573,6 +573,7 @@ function EntityCard({
   depth: number;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
 
   const Icon = KIND_ICON[node.kind] || Box;
   const iconStyle = KIND_COLOR_LIGHT[node.kind] || 'bg-gray-500/10 text-gray-600 dark:text-gray-400';
@@ -580,6 +581,12 @@ function EntityCard({
   const statusDot = status ? STATUS_DOT[status.status] || STATUS_DOT.unknown : null;
   const statusTip = status ? STATUS_LABEL[status.status] || status.status : '';
   const selected = selectedNode === node.id;
+
+  useEffect(() => {
+    if (selected && cardRef.current) {
+      cardRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }, [selected]);
 
   // Filter children to only those deployed in this environment
   const envChildren = useMemo(() => {
@@ -593,7 +600,7 @@ function EntityCard({
   const hasChildren = envChildren.length > 0;
 
   return (
-    <div>
+    <div ref={cardRef}>
       <div
         className={`flex w-full items-center gap-1.5 rounded-lg px-2 py-1.5 text-left transition-colors ${
           selected

--- a/web/src/pages/TopologyExplorer.tsx
+++ b/web/src/pages/TopologyExplorer.tsx
@@ -584,7 +584,25 @@ function EntityCard({
 
   useEffect(() => {
     if (selected && cardRef.current) {
-      cardRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      const card = cardRef.current;
+      // Find nearest scrollable ancestor (the lane's overflow-y-auto container)
+      let scrollParent: HTMLElement | null = card.parentElement;
+      while (scrollParent) {
+        const style = window.getComputedStyle(scrollParent);
+        if (/(auto|scroll)/.test(style.overflow + style.overflowY) && scrollParent.scrollHeight > scrollParent.clientHeight) {
+          break;
+        }
+        scrollParent = scrollParent.parentElement;
+      }
+      if (scrollParent) {
+        const cardRect = card.getBoundingClientRect();
+        const containerRect = scrollParent.getBoundingClientRect();
+        const relativeTop = cardRect.top - containerRect.top + scrollParent.scrollTop;
+        scrollParent.scrollTo({
+          top: relativeTop - scrollParent.clientHeight / 2 + card.offsetHeight / 2,
+          behavior: 'smooth',
+        });
+      }
     }
   }, [selected]);
 

--- a/web/src/pages/TopologyExplorer.tsx
+++ b/web/src/pages/TopologyExplorer.tsx
@@ -105,8 +105,18 @@ export default function TopologyExplorer() {
   const [search, setSearch] = useState('');
   const [kindFilter, setKindFilter] = useState<string[]>([]);
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
   const [laneOrder, setLaneOrder] = useState<string[]>([]);
   const [hideUnassigned, setHideUnassigned] = useState(false);
+
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
 
   const fetchData = useCallback(
     async (showRefresh = false) => {
@@ -369,6 +379,8 @@ export default function TopologyExplorer() {
               selectedNode={selectedNode}
               onSelectNode={setSelectedNode}
               entityEnvMap={entityEnvMap}
+              expandedNodes={expandedNodes}
+              onToggleExpand={toggleExpand}
             />
           ))}
           {unassignedNodes.length > 0 && !hideUnassigned && (
@@ -393,6 +405,8 @@ export default function TopologyExplorer() {
                     selectedNode={selectedNode}
                     onSelectNode={setSelectedNode}
                     entityEnvMap={entityEnvMap}
+                    expandedNodes={expandedNodes}
+                    onToggleExpand={toggleExpand}
                     depth={0}
                   />
                 ))}
@@ -450,6 +464,8 @@ function EnvironmentColumn({
   selectedNode,
   onSelectNode,
   entityEnvMap,
+  expandedNodes,
+  onToggleExpand,
 }: {
   env: TopologyEnvironment;
   nodes: TopologyNode[];
@@ -457,6 +473,8 @@ function EnvironmentColumn({
   selectedNode: string | null;
   onSelectNode: (id: string | null) => void;
   entityEnvMap: Map<string, string[]>;
+  expandedNodes: Set<string>;
+  onToggleExpand: (id: string) => void;
 }) {
   // Group nodes by kind within the column
   const grouped = useMemo(() => {
@@ -540,6 +558,8 @@ function EnvironmentColumn({
                       selectedNode={selectedNode}
                       onSelectNode={onSelectNode}
                       entityEnvMap={entityEnvMap}
+                      expandedNodes={expandedNodes}
+                      onToggleExpand={onToggleExpand}
                       depth={0}
                     />
                   ))}
@@ -562,6 +582,8 @@ function EntityCard({
   selectedNode,
   onSelectNode,
   entityEnvMap,
+  expandedNodes,
+  onToggleExpand,
   depth,
 }: {
   node: TopologyNode;
@@ -570,9 +592,11 @@ function EntityCard({
   selectedNode: string | null;
   onSelectNode: (id: string | null) => void;
   entityEnvMap: Map<string, string[]>;
+  expandedNodes: Set<string>;
+  onToggleExpand: (id: string) => void;
   depth: number;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const expanded = expandedNodes.has(node.id);
   const cardRef = useRef<HTMLDivElement>(null);
 
   const Icon = KIND_ICON[node.kind] || Box;
@@ -630,7 +654,7 @@ function EntityCard({
         {/* Expand/collapse chevron */}
         {hasChildren ? (
           <button
-            onClick={(e) => { e.stopPropagation(); setExpanded(!expanded); }}
+            onClick={(e) => { e.stopPropagation(); onToggleExpand(node.id); }}
             className="flex h-4 w-4 shrink-0 items-center justify-center rounded text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]"
           >
             {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
@@ -673,6 +697,8 @@ function EntityCard({
               selectedNode={selectedNode}
               onSelectNode={onSelectNode}
               entityEnvMap={entityEnvMap}
+              expandedNodes={expandedNodes}
+              onToggleExpand={onToggleExpand}
               depth={depth + 1}
             />
           ))}


### PR DESCRIPTION
This pull request enhances the `TopologyExplorer` page by improving the expand/collapse behavior of entity cards and ensuring a better user experience when navigating and selecting nodes. The most significant changes are the introduction of a global expand/collapse state for nodes and automatic scrolling to selected nodes.

**Expand/collapse state management:**

* Added an `expandedNodes` state (a `Set<string>`) in `TopologyExplorer` to track which nodes are expanded, replacing the previous local state in each `EntityCard`. The `toggleExpand` callback modifies this set and is passed down through components. [[1]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR108-R120) [[2]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR382-R383) [[3]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR408-R409) [[4]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR467-R477) [[5]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR561-R562) [[6]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR585-R586) [[7]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR595-R600) [[8]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR700-R701)

* Updated the expand/collapse button in `EntityCard` to use the new `onToggleExpand` handler, ensuring expand/collapse state is consistent across the entire explorer.

**User experience improvements:**

* Implemented automatic scrolling to bring the selected node into view by using a `ref` in `EntityCard` and a `useEffect` that scrolls the containing lane when the node is selected. [[1]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR595-R600) [[2]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR609-R632) [[3]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fL596-R645)

**Codebase updates:**

* Updated component props and signatures throughout `TopologyExplorer.tsx` to support the new expand/collapse and scrolling logic, including passing `expandedNodes` and `onToggleExpand` through relevant components. [[1]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR467-R477) [[2]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR561-R562) [[3]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR585-R586) [[4]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR595-R600) [[5]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR700-R701)

* Added `useRef` import to support the new scrolling logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity cards now automatically scroll into view when selected in the topology explorer.

* **Bug Fixes**
  * Improved consistency of entity card expansion behavior across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->