### PR TITLE
Feature: topology upgrades

### DIFF
--- a/web/src/pages/TopologyExplorer.tsx
+++ b/web/src/pages/TopologyExplorer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import {
   RefreshCw,
@@ -573,6 +573,7 @@ function EntityCard({
   depth: number;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
 
   const Icon = KIND_ICON[node.kind] || Box;
   const iconStyle = KIND_COLOR_LIGHT[node.kind] || 'bg-gray-500/10 text-gray-600 dark:text-gray-400';
@@ -580,6 +581,12 @@ function EntityCard({
   const statusDot = status ? STATUS_DOT[status.status] || STATUS_DOT.unknown : null;
   const statusTip = status ? STATUS_LABEL[status.status] || status.status : '';
   const selected = selectedNode === node.id;
+
+  useEffect(() => {
+    if (selected && cardRef.current) {
+      cardRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }, [selected]);
 
   // Filter children to only those deployed in this environment
   const envChildren = useMemo(() => {
@@ -593,7 +600,7 @@ function EntityCard({
   const hasChildren = envChildren.length > 0;
 
   return (
-    <div>
+    <div ref={cardRef}>
       <div
         className={`flex w-full items-center gap-1.5 rounded-lg px-2 py-1.5 text-left transition-colors ${
           selected

--- a/web/src/pages/TopologyExplorer.tsx
+++ b/web/src/pages/TopologyExplorer.tsx
@@ -584,7 +584,25 @@ function EntityCard({
 
   useEffect(() => {
     if (selected && cardRef.current) {
-      cardRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      const card = cardRef.current;
+      // Find nearest scrollable ancestor (the lane's overflow-y-auto container)
+      let scrollParent: HTMLElement | null = card.parentElement;
+      while (scrollParent) {
+        const style = window.getComputedStyle(scrollParent);
+        if (/(auto|scroll)/.test(style.overflow + style.overflowY) && scrollParent.scrollHeight > scrollParent.clientHeight) {
+          break;
+        }
+        scrollParent = scrollParent.parentElement;
+      }
+      if (scrollParent) {
+        const cardRect = card.getBoundingClientRect();
+        const containerRect = scrollParent.getBoundingClientRect();
+        const relativeTop = cardRect.top - containerRect.top + scrollParent.scrollTop;
+        scrollParent.scrollTo({
+          top: relativeTop - scrollParent.clientHeight / 2 + card.offsetHeight / 2,
+          behavior: 'smooth',
+        });
+      }
     }
   }, [selected]);
 

--- a/web/src/pages/TopologyExplorer.tsx
+++ b/web/src/pages/TopologyExplorer.tsx
@@ -105,8 +105,18 @@ export default function TopologyExplorer() {
   const [search, setSearch] = useState('');
   const [kindFilter, setKindFilter] = useState<string[]>([]);
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
   const [laneOrder, setLaneOrder] = useState<string[]>([]);
   const [hideUnassigned, setHideUnassigned] = useState(false);
+
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
 
   const fetchData = useCallback(
     async (showRefresh = false) => {
@@ -369,6 +379,8 @@ export default function TopologyExplorer() {
               selectedNode={selectedNode}
               onSelectNode={setSelectedNode}
               entityEnvMap={entityEnvMap}
+              expandedNodes={expandedNodes}
+              onToggleExpand={toggleExpand}
             />
           ))}
           {unassignedNodes.length > 0 && !hideUnassigned && (
@@ -393,6 +405,8 @@ export default function TopologyExplorer() {
                     selectedNode={selectedNode}
                     onSelectNode={setSelectedNode}
                     entityEnvMap={entityEnvMap}
+                    expandedNodes={expandedNodes}
+                    onToggleExpand={toggleExpand}
                     depth={0}
                   />
                 ))}
@@ -450,6 +464,8 @@ function EnvironmentColumn({
   selectedNode,
   onSelectNode,
   entityEnvMap,
+  expandedNodes,
+  onToggleExpand,
 }: {
   env: TopologyEnvironment;
   nodes: TopologyNode[];
@@ -457,6 +473,8 @@ function EnvironmentColumn({
   selectedNode: string | null;
   onSelectNode: (id: string | null) => void;
   entityEnvMap: Map<string, string[]>;
+  expandedNodes: Set<string>;
+  onToggleExpand: (id: string) => void;
 }) {
   // Group nodes by kind within the column
   const grouped = useMemo(() => {
@@ -540,6 +558,8 @@ function EnvironmentColumn({
                       selectedNode={selectedNode}
                       onSelectNode={onSelectNode}
                       entityEnvMap={entityEnvMap}
+                      expandedNodes={expandedNodes}
+                      onToggleExpand={onToggleExpand}
                       depth={0}
                     />
                   ))}
@@ -562,6 +582,8 @@ function EntityCard({
   selectedNode,
   onSelectNode,
   entityEnvMap,
+  expandedNodes,
+  onToggleExpand,
   depth,
 }: {
   node: TopologyNode;
@@ -570,9 +592,11 @@ function EntityCard({
   selectedNode: string | null;
   onSelectNode: (id: string | null) => void;
   entityEnvMap: Map<string, string[]>;
+  expandedNodes: Set<string>;
+  onToggleExpand: (id: string) => void;
   depth: number;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const expanded = expandedNodes.has(node.id);
   const cardRef = useRef<HTMLDivElement>(null);
 
   const Icon = KIND_ICON[node.kind] || Box;
@@ -630,7 +654,7 @@ function EntityCard({
         {/* Expand/collapse chevron */}
         {hasChildren ? (
           <button
-            onClick={(e) => { e.stopPropagation(); setExpanded(!expanded); }}
+            onClick={(e) => { e.stopPropagation(); onToggleExpand(node.id); }}
             className="flex h-4 w-4 shrink-0 items-center justify-center rounded text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]"
           >
             {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
@@ -673,6 +697,8 @@ function EntityCard({
               selectedNode={selectedNode}
               onSelectNode={onSelectNode}
               entityEnvMap={entityEnvMap}
+              expandedNodes={expandedNodes}
+              onToggleExpand={onToggleExpand}
               depth={depth + 1}
             />
           ))}


### PR DESCRIPTION
This pull request enhances the `TopologyExplorer` page by introducing a unified expand/collapse state for entity cards, improving the user experience when navigating hierarchical data. Previously, each card managed its own expanded state, but now expansion is managed at the parent component level, allowing for consistent behavior across the entire topology. Additionally, the selected node is automatically scrolled into view for better usability.

Key improvements:

**Expand/Collapse State Management:**
* Introduced a shared `expandedNodes` state (as a `Set<string>`) in `TopologyExplorer`, along with a `toggleExpand` callback, to centrally manage which entity cards are expanded. This state and handler are passed down through `EnvironmentColumn` and `EntityCard` components, replacing the previous local state approach. [[1]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR108-R120) [[2]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR382-R383) [[3]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR408-R409) [[4]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR467-R477) [[5]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR561-R562) [[6]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR585-R586) [[7]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR595-R600) [[8]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR700-R701)

* The expand/collapse button in `EntityCard` now calls the centralized `onToggleExpand` handler, ensuring expansion state is consistent across the UI.

**Usability Enhancements:**
* When a node is selected, its card is automatically scrolled into view within its scrollable container, improving navigation in large topologies. [[1]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fR609-R632) [[2]](diffhunk://#diff-fcaef430ada7093aa556d2e6e3195ac6fc83df3d82e6bea5451351dd389c0d9fL596-R645)

**Codebase Improvements:**
* Removed the local `expanded` state from `EntityCard` in favor of the shared `expandedNodes` state, simplifying state management and making expansion behavior more predictable.

**Technical Updates:**
* Added the `useRef` import to support the new scroll-into-view logic.

Overall, these changes make the topology explorer more intuitive and maintainable, especially when dealing with complex, nested structures.