### PR TITLE
fix: Unhide refactor section in release config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -14,7 +14,7 @@
         { "type": "docs",     "section": "Documentation",           "hidden": true },
         { "type": "style",    "section": "Styles",                  "hidden": true },
         { "type": "chore",    "section": "Miscellaneous Chores",    "hidden": true },
-        { "type": "refactor", "section": "Code Refactoring",        "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring" },
         { "type": "test",     "section": "Tests",                   "hidden": true },
         { "type": "build",    "section": "Build System",            "hidden": true },
         { "type": "ai",       "section": "AI",                      "hidden": true },


### PR DESCRIPTION
This pull request makes a small configuration change to the release notes generation. Refactor-type changes will now be visible in the release notes instead of being hidden.

- Changed the `.github/release-please-config.json` file so that changes with type `refactor` are no longer hidden in the release notes.