### PR TITLE
fix(kubernetes): update linkInfrastructureToService to prevent circular dependencies

### DIFF
--- a/internal/plugins/kubernetes/sync.go
+++ b/internal/plugins/kubernetes/sync.go
@@ -445,9 +445,12 @@ func containsStr(slice []string, s string) bool {
 }
 
 // linkInfrastructureToService updates Service entities that are referenced in
-// the Infrastructure's spec.dependsOn by:
-//  1. Adding the Infrastructure to the Service's spec.dependsOn.
-//  2. Merging the Infrastructure's spec.deployedIn into the Service's spec.deployedIn.
+// the Infrastructure's spec.dependsOn by merging the Infrastructure's
+// spec.deployedIn into the Service's spec.deployedIn.
+//
+// Note: we intentionally do NOT add the Infrastructure back into the Service's
+// dependsOn — the Infrastructure already dependsOn the Service, and adding the
+// reverse would create a circular dependency that breaks topology nesting.
 //
 // This keeps Service entities automatically up to date when infrastructure
 // components are discovered or updated by the Kubernetes sync.
@@ -455,7 +458,10 @@ func linkInfrastructureToService(ctx context.Context, store EntityStore, infra *
 	dependsOn, _ := infra.Spec["dependsOn"].([]any)
 	deployedIn, _ := infra.Spec["deployedIn"].([]any)
 
-	infraRef := []any{map[string]any{"kind": "Infrastructure", "name": infra.Metadata.Name}}
+	// Nothing to propagate if the infrastructure has no deployedIn.
+	if len(deployedIn) == 0 {
+		return nil
+	}
 
 	var errs []error
 	for _, dep := range dependsOn {
@@ -485,13 +491,8 @@ func linkInfrastructureToService(ctx context.Context, store EntityStore, infra *
 			svc.Spec = make(map[string]any)
 		}
 
-		// 1. Add this Infrastructure to the Service's dependsOn.
-		svc.Spec["dependsOn"] = mergeDeployedIn(svc.Spec["dependsOn"], infraRef)
-
-		// 2. Propagate the Infrastructure's deployedIn environments to the Service.
-		if len(deployedIn) > 0 {
-			svc.Spec["deployedIn"] = mergeDeployedIn(svc.Spec["deployedIn"], deployedIn)
-		}
+		// Propagate the Infrastructure's deployedIn environments to the Service.
+		svc.Spec["deployedIn"] = mergeDeployedIn(svc.Spec["deployedIn"], deployedIn)
 
 		if err := store.UpdateEntity(ctx, svc); err != nil {
 			errs = append(errs, fmt.Errorf("update service %s: %w", svcName, err))


### PR DESCRIPTION
This pull request clarifies and corrects the logic for updating Service entities when linking them to Infrastructure entities in the Kubernetes sync plugin. The main change is to avoid introducing circular dependencies between Infrastructure and Service entities by no longer adding the Infrastructure to the Service's `dependsOn` field. Instead, only the `deployedIn` environments are merged as needed.

**Dependency management improvements:**

* Updated the `linkInfrastructureToService` function to only merge the Infrastructure's `deployedIn` environments into the Service's `deployedIn`, and explicitly avoid adding the Infrastructure to the Service's `dependsOn` field to prevent circular dependencies. [[1]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073L448-R464) [[2]](diffhunk://#diff-412c4e376f25210ed2070f2ba8a6986050a63b996ff305ade9f5a5bd49f06073L488-L494)
* Improved code comments to clarify the reasoning behind not modifying the Service's `dependsOn` field and to document the intended behavior.

**Logic simplification:**

* Added an early return if the Infrastructure has no `deployedIn` environments, since there is nothing to propagate in that case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined Infrastructure deployment information propagation to Services. The system now exclusively propagates Infrastructure deployment location details to associated Services, removing the previous mechanism that also merged Infrastructure references into Service dependency lists. This change establishes clearer, more streamlined unidirectional dependency relationships throughout the Kubernetes infrastructure management and synchronization layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->