### PR TITLE
feat: add Microsoft Azure authentication plugin

### DIFF
--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -18,9 +19,8 @@ func (h *Handlers) GetAzureSSOConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
-	clientID, _ := p.Config["clientId"].(string)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"ssoEnabled": ssoEnabled && clientID != "",
+		"ssoEnabled": azureSSOConfigured(p.Config, ssoEnabled),
 	})
 }
 
@@ -34,7 +34,7 @@ func (h *Handlers) AzureOAuthBegin(w http.ResponseWriter, r *http.Request) {
 
 	ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
 	clientID, _ := p.Config["clientId"].(string)
-	if !ssoEnabled || clientID == "" {
+	if !azureSSOConfigured(p.Config, ssoEnabled) {
 		writeError(w, http.StatusBadRequest, "Microsoft Azure SSO is not configured")
 		return
 	}
@@ -106,9 +106,14 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	clientSecret, _ := p.Config["clientSecret"].(string)
 	tenantID, _ := p.Config["tenantId"].(string)
 	scopes, _ := p.Config["scopes"].(string)
+	ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
 	defaultRole, _ := p.Config["defaultRole"].(string)
 	if defaultRole == "" {
 		defaultRole = "viewer"
+	}
+	if !azureSSOConfigured(p.Config, ssoEnabled) {
+		writeError(w, http.StatusBadRequest, "Microsoft Azure SSO is not configured")
+		return
 	}
 
 	redirectURI := requestOrigin(r) + "/api/v1/auth/azure/callback"
@@ -118,7 +123,7 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	claims, err := azplugin.ParseIdentityClaims(tokenResp.IDToken)
+	claims, err := azplugin.ParseIdentityClaims(tokenResp.IDToken, tenantID, clientID)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "failed to parse id token: "+err.Error())
 		return
@@ -136,7 +141,16 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 
 	email := azureEmail(claims, msUser)
 	if gantryUser == nil && email != "" {
-		gantryUser, _ = h.DB.GetUserByEmail(ctx, email)
+		usersByEmail, err := h.DB.GetUsersByEmail(ctx, email)
+		if err == nil {
+			switch len(usersByEmail) {
+			case 1:
+				gantryUser = usersByEmail[0]
+			case 0:
+			default:
+				log.Printf("azure auth: email %q matched %d Gantry users; refusing ambiguous SSO lookup", email, len(usersByEmail))
+			}
+		}
 	}
 
 	returnTo := ""
@@ -261,4 +275,13 @@ func azureDisplayName(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftU
 		return email
 	}
 	return "Microsoft Azure User"
+}
+
+func azureSSOConfigured(config map[string]any, ssoEnabled bool) bool {
+	if !ssoEnabled {
+		return false
+	}
+	clientID, _ := config["clientId"].(string)
+	clientSecret, _ := config["clientSecret"].(string)
+	return strings.TrimSpace(clientID) != "" && strings.TrimSpace(clientSecret) != ""
 }

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
@@ -148,7 +150,7 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 				gantryUser = usersByEmail[0]
 			case 0:
 			default:
-				log.Printf("azure auth: email %q matched %d Gantry users; refusing ambiguous SSO lookup", email, len(usersByEmail))
+				log.Printf("azure auth: email hash %s matched %d Gantry users; refusing ambiguous SSO lookup", hashEmailForLog(email), len(usersByEmail))
 			}
 		}
 	}
@@ -275,6 +277,11 @@ func azureDisplayName(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftU
 		return email
 	}
 	return "Microsoft Azure User"
+}
+
+func hashEmailForLog(email string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(email))))
+	return hex.EncodeToString(sum[:8])
 }
 
 func azureSSOConfigured(config map[string]any, ssoEnabled bool) bool {

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -202,7 +202,7 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if gantryUser == nil {
-				writeError(w, http.StatusInternalServerError, "failed to create user: "+createErr.Error())
+				writeSSOProviderError(w, "Microsoft Azure", "create Gantry user", createErr)
 				return
 			}
 		} else {

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -1,11 +1,12 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
-	"net/mail"
 	"net/http"
+	"net/mail"
 	"strings"
 
 	"github.com/go2engle/gantry/internal/auth"
@@ -191,7 +192,7 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 			PasswordHash: "",
 			DisplayName:  azureDisplayName(claims, msUser),
 			Email:        email,
-			Role:         defaultRole,
+			Role:         "viewer",
 			SSOOnly:      true,
 		}
 		if createErr := h.DB.CreateUser(ctx, newUser); createErr != nil {
@@ -207,6 +208,15 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 		} else {
 			gantryUser = newUser
 		}
+	}
+
+	if err := h.syncAzureUserProfile(ctx, gantryUser, azureDisplayName(claims, msUser), email); err != nil {
+		writeSSOProviderError(w, "Microsoft Azure", "sync Gantry user profile", err)
+		return
+	}
+	if err := h.ensureAzureDefaultAccess(ctx, gantryUser, defaultRole); err != nil {
+		writeSSOProviderError(w, "Microsoft Azure", "apply default access", err)
+		return
 	}
 
 	token, err := h.Auth.GenerateToken(&auth.User{
@@ -272,6 +282,83 @@ func azureDisplayName(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftU
 		return email
 	}
 	return "Microsoft Azure User"
+}
+
+func (h *Handlers) syncAzureUserProfile(ctx context.Context, user *db.User, displayName, email string) error {
+	if user == nil {
+		return nil
+	}
+
+	displayName = strings.TrimSpace(displayName)
+	email = strings.TrimSpace(email)
+	updated := false
+
+	if displayName != "" && user.DisplayName != displayName {
+		user.DisplayName = displayName
+		updated = true
+	}
+	if email != "" && !strings.EqualFold(user.Email, email) {
+		user.Email = email
+		updated = true
+	}
+	if !updated {
+		return nil
+	}
+	return h.DB.UpdateUser(ctx, user)
+}
+
+func (h *Handlers) ensureAzureDefaultAccess(ctx context.Context, user *db.User, defaultRole string) error {
+	if user == nil || !user.SSOOnly || !strings.HasPrefix(strings.ToLower(user.Username), "azure:") {
+		return nil
+	}
+
+	groupRole, fallbackRole := azureDefaultAccess(defaultRole)
+	if groupRole == "" && fallbackRole == "viewer" {
+		return nil
+	}
+
+	groups, err := h.DB.ListUserGroups(ctx, user.ID)
+	if err != nil {
+		return err
+	}
+	if len(groups) > 0 || auth.RoleLevel(user.Role) > auth.RoleLevel("viewer") {
+		return nil
+	}
+
+	if groupRole != "" {
+		if err := h.DB.AddUserToGroupByName(ctx, user.ID, groupRole); err == nil {
+			return nil
+		}
+	}
+
+	if fallbackRole == "" || user.Role == fallbackRole {
+		return nil
+	}
+	user.Role = fallbackRole
+	return h.DB.UpdateUser(ctx, user)
+}
+
+func azureDefaultAccess(defaultRole string) (groupName, fallbackRole string) {
+	role := strings.ToLower(strings.TrimSpace(defaultRole))
+	if role == "" {
+		role = "viewer"
+	}
+
+	switch role {
+	case "admin":
+		return "admins", role
+	case "platform-engineer":
+		return "platform-engineers", role
+	case "developer":
+		return "developers", role
+	case "viewer":
+		return "", role
+	default:
+		if auth.IsValidRole(role) {
+			return "", role
+		}
+		return "", "viewer"
+	}
 }
 
 func azureSSOConfigured(ssoEnabled bool, clientID, clientSecret string) bool {

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -101,8 +101,12 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p, err := h.DB.GetPlugin(r.Context(), "microsoft-azure")
-	if err != nil || p == nil || !p.Enabled {
-		writeError(w, http.StatusInternalServerError, "Microsoft Azure plugin unavailable")
+	if err != nil {
+		writeSSOProviderError(w, "Microsoft Azure", "load plugin configuration", err)
+		return
+	}
+	if p == nil || !p.Enabled {
+		writeError(w, http.StatusBadRequest, "Microsoft Azure plugin not installed or not enabled")
 		return
 	}
 

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -88,7 +88,8 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	clearAzureOAuthCookies(w, r)
 
 	stateCookie, err := r.Cookie("az_oauth_state")
-	if err != nil || r.URL.Query().Get("state") != stateCookie.Value {
+	queryState := strings.TrimSpace(r.URL.Query().Get("state"))
+	if err != nil || strings.TrimSpace(stateCookie.Value) == "" || queryState == "" || queryState != stateCookie.Value {
 		writeError(w, http.StatusBadRequest, "invalid or missing oauth state")
 		return
 	}

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -1,0 +1,264 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go2engle/gantry/internal/auth"
+	"github.com/go2engle/gantry/internal/db"
+	azplugin "github.com/go2engle/gantry/internal/plugins/azure"
+)
+
+// GetAzureSSOConfig returns whether Microsoft Azure SSO is enabled.
+func (h *Handlers) GetAzureSSOConfig(w http.ResponseWriter, r *http.Request) {
+	p, err := h.DB.GetPlugin(r.Context(), "microsoft-azure")
+	if err != nil || p == nil || !p.Enabled {
+		writeJSON(w, http.StatusOK, map[string]any{"ssoEnabled": false})
+		return
+	}
+	ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
+	clientID, _ := p.Config["clientId"].(string)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ssoEnabled": ssoEnabled && clientID != "",
+	})
+}
+
+// AzureOAuthBegin redirects the browser to the Microsoft identity platform.
+func (h *Handlers) AzureOAuthBegin(w http.ResponseWriter, r *http.Request) {
+	p, err := h.DB.GetPlugin(r.Context(), "microsoft-azure")
+	if err != nil || p == nil || !p.Enabled {
+		writeError(w, http.StatusNotFound, "Microsoft Azure plugin not installed or not enabled")
+		return
+	}
+
+	ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
+	clientID, _ := p.Config["clientId"].(string)
+	if !ssoEnabled || clientID == "" {
+		writeError(w, http.StatusBadRequest, "Microsoft Azure SSO is not configured")
+		return
+	}
+
+	state, err := randomHex16()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate state")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     "az_oauth_state",
+		Value:    state,
+		Path:     "/",
+		MaxAge:   600,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   isHTTPSRequest(r),
+	})
+
+	if returnTo := normalizeReturnTo(r, r.URL.Query().Get("return_to")); returnTo != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "az_oauth_return_to",
+			Value:    returnTo,
+			Path:     "/",
+			MaxAge:   600,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   isHTTPSRequest(r),
+		})
+	}
+
+	tenantID, _ := p.Config["tenantId"].(string)
+	scopes, _ := p.Config["scopes"].(string)
+	redirectURI := requestOrigin(r) + "/api/v1/auth/azure/callback"
+	authURL := azplugin.AuthorizationURL(tenantID, clientID, redirectURI, state, scopes)
+	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
+}
+
+// AzureOAuthCallback handles the Microsoft OAuth redirect back to Gantry.
+func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	stateCookie, err := r.Cookie("az_oauth_state")
+	if err != nil || r.URL.Query().Get("state") != stateCookie.Value {
+		writeError(w, http.StatusBadRequest, "invalid or missing oauth state")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     "az_oauth_state",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   isHTTPSRequest(r),
+	})
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		writeError(w, http.StatusBadRequest, "missing oauth code")
+		return
+	}
+
+	p, err := h.DB.GetPlugin(r.Context(), "microsoft-azure")
+	if err != nil || p == nil || !p.Enabled {
+		writeError(w, http.StatusInternalServerError, "Microsoft Azure plugin unavailable")
+		return
+	}
+
+	clientID, _ := p.Config["clientId"].(string)
+	clientSecret, _ := p.Config["clientSecret"].(string)
+	tenantID, _ := p.Config["tenantId"].(string)
+	scopes, _ := p.Config["scopes"].(string)
+	defaultRole, _ := p.Config["defaultRole"].(string)
+	if defaultRole == "" {
+		defaultRole = "viewer"
+	}
+
+	redirectURI := requestOrigin(r) + "/api/v1/auth/azure/callback"
+	tokenResp, err := azplugin.ExchangeOAuthCode(code, clientID, clientSecret, tenantID, redirectURI, scopes)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to exchange oauth code: "+err.Error())
+		return
+	}
+
+	claims, err := azplugin.ParseIdentityClaims(tokenResp.IDToken)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to parse id token: "+err.Error())
+		return
+	}
+
+	msUser, err := azplugin.FetchUserWithToken(tokenResp.AccessToken)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch Microsoft Graph user: "+err.Error())
+		return
+	}
+
+	ctx := r.Context()
+	username := azureUsername(claims, msUser, tenantID)
+	gantryUser, _ := h.DB.GetUserByUsername(ctx, username)
+
+	email := azureEmail(claims, msUser)
+	if gantryUser == nil && email != "" {
+		gantryUser, _ = h.DB.GetUserByEmail(ctx, email)
+	}
+
+	returnTo := ""
+	if c, err := r.Cookie("az_oauth_return_to"); err == nil && c.Value != "" {
+		returnTo = normalizeReturnTo(r, c.Value)
+		http.SetCookie(w, &http.Cookie{
+			Name:     "az_oauth_return_to",
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   isHTTPSRequest(r),
+		})
+	}
+
+	if gantryUser == nil {
+		autoProvision := false
+		if v, ok := p.Config["autoProvision"].(bool); ok {
+			autoProvision = v
+		}
+
+		if !autoProvision {
+			errorURL := "/login?error=sso_not_authorized"
+			if returnTo != "" {
+				errorURL = returnTo + "/login?error=sso_not_authorized"
+			}
+			http.Redirect(w, r, errorURL, http.StatusTemporaryRedirect)
+			return
+		}
+
+		newUser := &db.User{
+			Username:     username,
+			PasswordHash: "",
+			DisplayName:  azureDisplayName(claims, msUser),
+			Email:        email,
+			Role:         defaultRole,
+			SSOOnly:      true,
+		}
+		if err := h.DB.CreateUser(ctx, newUser); err != nil {
+			gantryUser, _ = h.DB.GetUserByUsername(ctx, username)
+			if gantryUser == nil {
+				writeError(w, http.StatusInternalServerError, "failed to create user: "+err.Error())
+				return
+			}
+		} else {
+			gantryUser = newUser
+		}
+	}
+
+	token, err := h.Auth.GenerateToken(&auth.User{
+		ID:       gantryUser.ID,
+		Username: gantryUser.Username,
+		Role:     gantryUser.Role,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+	http.SetCookie(w, sessionCookie(r, token))
+
+	redirectURL := "/"
+	if returnTo != "" {
+		redirectURL = returnTo + "/"
+	}
+	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+}
+
+func azureUsername(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftUser, configuredTenant string) string {
+	if claims != nil && claims.TID != "" && claims.OID != "" {
+		return fmt.Sprintf("azure:%s:%s", strings.ToLower(claims.TID), strings.ToLower(claims.OID))
+	}
+	if user != nil && user.ID != "" {
+		tenant := strings.TrimSpace(configuredTenant)
+		if claims != nil && claims.TID != "" {
+			tenant = claims.TID
+		}
+		if tenant != "" && !strings.EqualFold(tenant, "common") && !strings.EqualFold(tenant, "organizations") && !strings.EqualFold(tenant, "consumers") {
+			return fmt.Sprintf("azure:%s:%s", strings.ToLower(tenant), strings.ToLower(user.ID))
+		}
+		return "azure:" + strings.ToLower(user.ID)
+	}
+	if email := azureEmail(claims, user); email != "" {
+		return "azure:" + strings.ToLower(email)
+	}
+	if claims != nil && claims.PreferredUsername != "" {
+		return "azure:" + strings.ToLower(claims.PreferredUsername)
+	}
+	if user != nil && user.UserPrincipalName != "" {
+		return "azure:" + strings.ToLower(user.UserPrincipalName)
+	}
+	return "azure:unknown"
+}
+
+func azureEmail(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftUser) string {
+	if user != nil && strings.TrimSpace(user.Mail) != "" {
+		return strings.TrimSpace(user.Mail)
+	}
+	if claims != nil && strings.TrimSpace(claims.Email) != "" {
+		return strings.TrimSpace(claims.Email)
+	}
+	if user != nil && strings.TrimSpace(user.UserPrincipalName) != "" {
+		return strings.TrimSpace(user.UserPrincipalName)
+	}
+	if claims != nil {
+		return strings.TrimSpace(claims.PreferredUsername)
+	}
+	return ""
+}
+
+func azureDisplayName(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftUser) string {
+	if user != nil && strings.TrimSpace(user.DisplayName) != "" {
+		return strings.TrimSpace(user.DisplayName)
+	}
+	if claims != nil && strings.TrimSpace(claims.Name) != "" {
+		return strings.TrimSpace(claims.Name)
+	}
+	if user != nil && strings.TrimSpace(user.UserPrincipalName) != "" {
+		return strings.TrimSpace(user.UserPrincipalName)
+	}
+	if email := azureEmail(claims, user); email != "" {
+		return email
+	}
+	return "Microsoft Azure User"
+}

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
@@ -121,19 +119,19 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	redirectURI := requestOrigin(r) + "/api/v1/auth/azure/callback"
 	tokenResp, err := azplugin.ExchangeOAuthCode(code, clientID, clientSecret, tenantID, redirectURI, scopes)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to exchange oauth code: "+err.Error())
+		writeSSOProviderError(w, "Microsoft Azure", "exchange oauth code", err)
 		return
 	}
 
 	claims, err := azplugin.ParseIdentityClaims(tokenResp.IDToken, tenantID, clientID)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to parse id token: "+err.Error())
+		writeSSOProviderError(w, "Microsoft Azure", "parse id token", err)
 		return
 	}
 
 	msUser, err := azplugin.FetchUserWithToken(tokenResp.AccessToken)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to fetch Microsoft Graph user: "+err.Error())
+		writeSSOProviderError(w, "Microsoft Azure", "fetch Microsoft Graph user", err)
 		return
 	}
 
@@ -277,11 +275,6 @@ func azureDisplayName(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftU
 		return email
 	}
 	return "Microsoft Azure User"
-}
-
-func hashEmailForLog(email string) string {
-	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(email))))
-	return hex.EncodeToString(sum[:8])
 }
 
 func azureSSOConfigured(config map[string]any, ssoEnabled bool) bool {

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -1,13 +1,16 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"net/mail"
 	"net/http"
 	"strings"
 
 	"github.com/go2engle/gantry/internal/auth"
 	"github.com/go2engle/gantry/internal/db"
+	"github.com/go2engle/gantry/internal/entity"
 	azplugin "github.com/go2engle/gantry/internal/plugins/azure"
 )
 
@@ -19,8 +22,10 @@ func (h *Handlers) GetAzureSSOConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
+	clientID, _ := p.Config["clientId"].(string)
+	clientSecret, _ := p.Config["clientSecret"].(string)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"ssoEnabled": azureSSOConfigured(p.Config, ssoEnabled),
+		"ssoEnabled": azureSSOConfigured(ssoEnabled, clientID, clientSecret),
 	})
 }
 
@@ -34,7 +39,8 @@ func (h *Handlers) AzureOAuthBegin(w http.ResponseWriter, r *http.Request) {
 
 	ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
 	clientID, _ := p.Config["clientId"].(string)
-	if !azureSSOConfigured(p.Config, ssoEnabled) {
+	clientSecret, _ := p.Config["clientSecret"].(string)
+	if !azureSSOConfigured(ssoEnabled, clientID, clientSecret) {
 		writeError(w, http.StatusBadRequest, "Microsoft Azure SSO is not configured")
 		return
 	}
@@ -75,20 +81,17 @@ func (h *Handlers) AzureOAuthBegin(w http.ResponseWriter, r *http.Request) {
 
 // AzureOAuthCallback handles the Microsoft OAuth redirect back to Gantry.
 func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	returnTo := ""
+	if c, err := r.Cookie("az_oauth_return_to"); err == nil && c.Value != "" {
+		returnTo = normalizeReturnTo(r, c.Value)
+	}
+	clearAzureOAuthCookies(w, r)
+
 	stateCookie, err := r.Cookie("az_oauth_state")
 	if err != nil || r.URL.Query().Get("state") != stateCookie.Value {
 		writeError(w, http.StatusBadRequest, "invalid or missing oauth state")
 		return
 	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     "az_oauth_state",
-		Value:    "",
-		Path:     "/",
-		MaxAge:   -1,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Secure:   isHTTPSRequest(r),
-	})
 
 	code := r.URL.Query().Get("code")
 	if code == "" {
@@ -111,7 +114,7 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	if defaultRole == "" {
 		defaultRole = "viewer"
 	}
-	if !azureSSOConfigured(p.Config, ssoEnabled) {
+	if !azureSSOConfigured(ssoEnabled, clientID, clientSecret) {
 		writeError(w, http.StatusBadRequest, "Microsoft Azure SSO is not configured")
 		return
 	}
@@ -141,34 +144,26 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 		writeSSOProviderError(w, "Microsoft Azure", "derive identity", err)
 		return
 	}
-	gantryUser, _ := h.DB.GetUserByUsername(ctx, username)
+	gantryUser, err := h.DB.GetUserByUsername(ctx, username)
+	if err != nil && !errors.Is(err, entity.ErrEntityNotFound) {
+		writeSSOProviderError(w, "Microsoft Azure", "lookup Gantry user by username", err)
+		return
+	}
 
 	email := azureEmail(claims, msUser)
 	if gantryUser == nil && email != "" {
 		usersByEmail, err := h.DB.GetUsersByEmail(ctx, email)
-		if err == nil {
-			switch len(usersByEmail) {
-			case 1:
-				gantryUser = usersByEmail[0]
-			case 0:
-			default:
-				log.Printf("azure auth: email hash %s matched %d Gantry users; refusing ambiguous SSO lookup", hashEmailForLog(email), len(usersByEmail))
-			}
+		if err != nil {
+			writeSSOProviderError(w, "Microsoft Azure", "lookup Gantry users by email", err)
+			return
 		}
-	}
-
-	returnTo := ""
-	if c, err := r.Cookie("az_oauth_return_to"); err == nil && c.Value != "" {
-		returnTo = normalizeReturnTo(r, c.Value)
-		http.SetCookie(w, &http.Cookie{
-			Name:     "az_oauth_return_to",
-			Value:    "",
-			Path:     "/",
-			MaxAge:   -1,
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			Secure:   isHTTPSRequest(r),
-		})
+		switch len(usersByEmail) {
+		case 1:
+			gantryUser = usersByEmail[0]
+		case 0:
+		default:
+			log.Printf("azure auth: email hash %s matched %d Gantry users; refusing ambiguous SSO lookup", hashEmailForLog(email), len(usersByEmail))
+		}
 	}
 
 	if gantryUser == nil {
@@ -194,10 +189,14 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 			Role:         defaultRole,
 			SSOOnly:      true,
 		}
-		if err := h.DB.CreateUser(ctx, newUser); err != nil {
-			gantryUser, _ = h.DB.GetUserByUsername(ctx, username)
+		if createErr := h.DB.CreateUser(ctx, newUser); createErr != nil {
+			gantryUser, err = h.DB.GetUserByUsername(ctx, username)
+			if err != nil && !errors.Is(err, entity.ErrEntityNotFound) {
+				writeSSOProviderError(w, "Microsoft Azure", "lookup Gantry user after create conflict", err)
+				return
+			}
 			if gantryUser == nil {
-				writeError(w, http.StatusInternalServerError, "failed to create user: "+err.Error())
+				writeError(w, http.StatusInternalServerError, "failed to create user: "+createErr.Error())
 				return
 			}
 		} else {
@@ -231,17 +230,25 @@ func azureUsername(claims *azplugin.IdentityClaims) (string, error) {
 }
 
 func azureEmail(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftUser) string {
-	if user != nil && strings.TrimSpace(user.Mail) != "" {
-		return strings.TrimSpace(user.Mail)
-	}
-	if claims != nil && strings.TrimSpace(claims.Email) != "" {
-		return strings.TrimSpace(claims.Email)
-	}
-	if user != nil && strings.TrimSpace(user.UserPrincipalName) != "" {
-		return strings.TrimSpace(user.UserPrincipalName)
+	if user != nil {
+		if email := normalizeAzureEmail(user.Mail); email != "" {
+			return email
+		}
 	}
 	if claims != nil {
-		return strings.TrimSpace(claims.PreferredUsername)
+		if email := normalizeAzureEmail(claims.Email); email != "" {
+			return email
+		}
+	}
+	if user != nil {
+		if email := normalizeAzureEmail(user.UserPrincipalName); email != "" {
+			return email
+		}
+	}
+	if claims != nil {
+		if email := normalizeAzureEmail(claims.PreferredUsername); email != "" {
+			return email
+		}
 	}
 	return ""
 }
@@ -262,11 +269,35 @@ func azureDisplayName(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftU
 	return "Microsoft Azure User"
 }
 
-func azureSSOConfigured(config map[string]any, ssoEnabled bool) bool {
+func azureSSOConfigured(ssoEnabled bool, clientID, clientSecret string) bool {
 	if !ssoEnabled {
 		return false
 	}
-	clientID, _ := config["clientId"].(string)
-	clientSecret, _ := config["clientSecret"].(string)
 	return strings.TrimSpace(clientID) != "" && strings.TrimSpace(clientSecret) != ""
+}
+
+func normalizeAzureEmail(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	addr, err := mail.ParseAddress(value)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(addr.Address)
+}
+
+func clearAzureOAuthCookies(w http.ResponseWriter, r *http.Request) {
+	for _, name := range []string{"az_oauth_state", "az_oauth_return_to"} {
+		http.SetCookie(w, &http.Cookie{
+			Name:     name,
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   isHTTPSRequest(r),
+		})
+	}
 }

--- a/internal/api/handlers/azure.go
+++ b/internal/api/handlers/azure.go
@@ -136,7 +136,11 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	username := azureUsername(claims, msUser, tenantID)
+	username, err := azureUsername(claims)
+	if err != nil {
+		writeSSOProviderError(w, "Microsoft Azure", "derive identity", err)
+		return
+	}
 	gantryUser, _ := h.DB.GetUserByUsername(ctx, username)
 
 	email := azureEmail(claims, msUser)
@@ -219,30 +223,11 @@ func (h *Handlers) AzureOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
-func azureUsername(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftUser, configuredTenant string) string {
+func azureUsername(claims *azplugin.IdentityClaims) (string, error) {
 	if claims != nil && claims.TID != "" && claims.OID != "" {
-		return fmt.Sprintf("azure:%s:%s", strings.ToLower(claims.TID), strings.ToLower(claims.OID))
+		return fmt.Sprintf("azure:%s:%s", strings.ToLower(claims.TID), strings.ToLower(claims.OID)), nil
 	}
-	if user != nil && user.ID != "" {
-		tenant := strings.TrimSpace(configuredTenant)
-		if claims != nil && claims.TID != "" {
-			tenant = claims.TID
-		}
-		if tenant != "" && !strings.EqualFold(tenant, "common") && !strings.EqualFold(tenant, "organizations") && !strings.EqualFold(tenant, "consumers") {
-			return fmt.Sprintf("azure:%s:%s", strings.ToLower(tenant), strings.ToLower(user.ID))
-		}
-		return "azure:" + strings.ToLower(user.ID)
-	}
-	if email := azureEmail(claims, user); email != "" {
-		return "azure:" + strings.ToLower(email)
-	}
-	if claims != nil && claims.PreferredUsername != "" {
-		return "azure:" + strings.ToLower(claims.PreferredUsername)
-	}
-	if user != nil && user.UserPrincipalName != "" {
-		return "azure:" + strings.ToLower(user.UserPrincipalName)
-	}
-	return "azure:unknown"
+	return "", fmt.Errorf("validated Microsoft Azure identity is missing tenant or object identifier")
 }
 
 func azureEmail(claims *azplugin.IdentityClaims, user *azplugin.MicrosoftUser) string {

--- a/internal/api/handlers/azure_test.go
+++ b/internal/api/handlers/azure_test.go
@@ -43,7 +43,9 @@ func TestAzureSSOConfigured(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := azureSSOConfigured(tt.config, tt.ssoEnabled); got != tt.want {
+			clientID, _ := tt.config["clientId"].(string)
+			clientSecret, _ := tt.config["clientSecret"].(string)
+			if got := azureSSOConfigured(tt.ssoEnabled, clientID, clientSecret); got != tt.want {
 				t.Fatalf("azureSSOConfigured() = %v, want %v", got, tt.want)
 			}
 		})
@@ -64,6 +66,28 @@ func TestAzureUsername(t *testing.T) {
 	t.Run("fails closed when immutable identifiers are missing", func(t *testing.T) {
 		if _, err := azureUsername(&azplugin.IdentityClaims{PreferredUsername: "user@example.com"}); err == nil {
 			t.Fatal("azureUsername() error = nil, want failure when oid/tid are missing")
+		}
+	})
+}
+
+func TestAzureEmail(t *testing.T) {
+	t.Run("prefers validated primary email fields", func(t *testing.T) {
+		email := azureEmail(
+			&azplugin.IdentityClaims{Email: "claims@example.com", PreferredUsername: "preferred@example.com"},
+			&azplugin.MicrosoftUser{Mail: "graph@example.com", UserPrincipalName: "upn@example.com"},
+		)
+		if want := "graph@example.com"; email != want {
+			t.Fatalf("azureEmail() = %q, want %q", email, want)
+		}
+	})
+
+	t.Run("rejects non email fallback values", func(t *testing.T) {
+		email := azureEmail(
+			&azplugin.IdentityClaims{PreferredUsername: "not-an-email"},
+			&azplugin.MicrosoftUser{UserPrincipalName: "also-not-an-email"},
+		)
+		if email != "" {
+			t.Fatalf("azureEmail() = %q, want empty string", email)
 		}
 	})
 }

--- a/internal/api/handlers/azure_test.go
+++ b/internal/api/handlers/azure_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	azplugin "github.com/go2engle/gantry/internal/plugins/azure"
@@ -90,4 +92,41 @@ func TestAzureEmail(t *testing.T) {
 			t.Fatalf("azureEmail() = %q, want empty string", email)
 		}
 	})
+}
+
+func TestAzureOAuthCallbackRejectsEmptyStateValues(t *testing.T) {
+	h := &Handlers{}
+	tests := []struct {
+		name        string
+		queryState  string
+		cookieState string
+	}{
+		{
+			name:        "rejects empty query state",
+			queryState:  "",
+			cookieState: "generated-state",
+		},
+		{
+			name:        "rejects empty cookie state",
+			queryState:  "generated-state",
+			cookieState: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/azure/callback?state="+tt.queryState, nil)
+			req.AddCookie(&http.Cookie{Name: "az_oauth_state", Value: tt.cookieState})
+
+			rr := httptest.NewRecorder()
+			h.AzureOAuthCallback(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("AzureOAuthCallback() status = %d, want %d", rr.Code, http.StatusBadRequest)
+			}
+			if body := rr.Body.String(); body != "invalid or missing oauth state\n" {
+				t.Fatalf("AzureOAuthCallback() body = %q, want %q", body, "invalid or missing oauth state\n")
+			}
+		})
+	}
 }

--- a/internal/api/handlers/azure_test.go
+++ b/internal/api/handlers/azure_test.go
@@ -1,10 +1,14 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
+	"github.com/go2engle/gantry/internal/config"
+	"github.com/go2engle/gantry/internal/db"
 	azplugin "github.com/go2engle/gantry/internal/plugins/azure"
 )
 
@@ -128,5 +132,42 @@ func TestAzureOAuthCallbackRejectsEmptyStateValues(t *testing.T) {
 				t.Fatalf("AzureOAuthCallback() body = %q, want %q", body, "invalid or missing oauth state\n")
 			}
 		})
+	}
+}
+
+func TestAzureOAuthCallbackRejectsUnavailablePlugin(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := &config.Config{
+		Port:          8080,
+		DBType:        "sqlite",
+		DBDSN:         filepath.Join(dataDir, "gantry.db"),
+		JWTSecret:     "test-secret",
+		DataDir:       dataDir,
+		EncryptionKey: "test-encryption-key",
+	}
+
+	database, err := db.New(cfg)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	if err := database.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	h := &Handlers{DB: database}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/azure/callback?state=generated-state&code=test-code", nil)
+	req = req.WithContext(context.Background())
+	req.AddCookie(&http.Cookie{Name: "az_oauth_state", Value: "generated-state"})
+
+	rr := httptest.NewRecorder()
+	h.AzureOAuthCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("AzureOAuthCallback() status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+	if body := rr.Body.String(); body != "Microsoft Azure plugin not installed or not enabled\n" {
+		t.Fatalf("AzureOAuthCallback() body = %q, want %q", body, "Microsoft Azure plugin not installed or not enabled\n")
 	}
 }

--- a/internal/api/handlers/azure_test.go
+++ b/internal/api/handlers/azure_test.go
@@ -188,7 +188,7 @@ func TestAzureOAuthCallbackRejectsUnavailablePlugin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("db.New: %v", err)
 	}
-	defer func() { _ = database.Close() }()
+	t.Cleanup(func() { _ = database.Close() })
 
 	if err := database.Migrate(); err != nil {
 		t.Fatalf("Migrate: %v", err)

--- a/internal/api/handlers/azure_test.go
+++ b/internal/api/handlers/azure_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import "testing"
+
+func TestAzureSSOConfigured(t *testing.T) {
+	tests := []struct {
+		name       string
+		ssoEnabled bool
+		config     map[string]any
+		want       bool
+	}{
+		{
+			name:       "disabled plugin config is not ready",
+			ssoEnabled: false,
+			config: map[string]any{
+				"clientId":     "client-id",
+				"clientSecret": "client-secret",
+			},
+			want: false,
+		},
+		{
+			name:       "missing client secret is not ready",
+			ssoEnabled: true,
+			config: map[string]any{
+				"clientId": "client-id",
+			},
+			want: false,
+		},
+		{
+			name:       "full oauth client config is ready",
+			ssoEnabled: true,
+			config: map[string]any{
+				"clientId":     "client-id",
+				"clientSecret": "client-secret",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := azureSSOConfigured(tt.config, tt.ssoEnabled); got != tt.want {
+				t.Fatalf("azureSSOConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/azure_test.go
+++ b/internal/api/handlers/azure_test.go
@@ -98,6 +98,44 @@ func TestAzureEmail(t *testing.T) {
 	})
 }
 
+func TestAzureDisplayName(t *testing.T) {
+	t.Run("prefers microsoft graph display name", func(t *testing.T) {
+		name := azureDisplayName(
+			&azplugin.IdentityClaims{Name: "Claims Name", PreferredUsername: "claims@example.com"},
+			&azplugin.MicrosoftUser{DisplayName: "Graph Name", UserPrincipalName: "graph@example.com"},
+		)
+		if want := "Graph Name"; name != want {
+			t.Fatalf("azureDisplayName() = %q, want %q", name, want)
+		}
+	})
+
+	t.Run("falls back to email style identifiers only when needed", func(t *testing.T) {
+		name := azureDisplayName(
+			&azplugin.IdentityClaims{PreferredUsername: "claims@example.com"},
+			&azplugin.MicrosoftUser{},
+		)
+		if want := "claims@example.com"; name != want {
+			t.Fatalf("azureDisplayName() = %q, want %q", name, want)
+		}
+	})
+}
+
+func TestAzureDefaultAccess(t *testing.T) {
+	t.Run("maps built in roles to default groups", func(t *testing.T) {
+		group, fallback := azureDefaultAccess("developer")
+		if group != "developers" || fallback != "developer" {
+			t.Fatalf("azureDefaultAccess() = (%q, %q), want (%q, %q)", group, fallback, "developers", "developer")
+		}
+	})
+
+	t.Run("falls back to viewer for unknown roles", func(t *testing.T) {
+		group, fallback := azureDefaultAccess("mystery-role")
+		if group != "" || fallback != "viewer" {
+			t.Fatalf("azureDefaultAccess() = (%q, %q), want (%q, %q)", group, fallback, "", "viewer")
+		}
+	})
+}
+
 func TestAzureOAuthCallbackRejectsEmptyStateValues(t *testing.T) {
 	h := &Handlers{}
 	tests := []struct {
@@ -128,8 +166,8 @@ func TestAzureOAuthCallbackRejectsEmptyStateValues(t *testing.T) {
 			if rr.Code != http.StatusBadRequest {
 				t.Fatalf("AzureOAuthCallback() status = %d, want %d", rr.Code, http.StatusBadRequest)
 			}
-			if body := rr.Body.String(); body != "invalid or missing oauth state\n" {
-				t.Fatalf("AzureOAuthCallback() body = %q, want %q", body, "invalid or missing oauth state\n")
+			if body := rr.Body.String(); body != "{\"error\":\"invalid or missing oauth state\"}\n" {
+				t.Fatalf("AzureOAuthCallback() body = %q, want %q", body, "{\"error\":\"invalid or missing oauth state\"}\n")
 			}
 		})
 	}
@@ -167,7 +205,99 @@ func TestAzureOAuthCallbackRejectsUnavailablePlugin(t *testing.T) {
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("AzureOAuthCallback() status = %d, want %d", rr.Code, http.StatusBadRequest)
 	}
-	if body := rr.Body.String(); body != "Microsoft Azure plugin not installed or not enabled\n" {
-		t.Fatalf("AzureOAuthCallback() body = %q, want %q", body, "Microsoft Azure plugin not installed or not enabled\n")
+	if body := rr.Body.String(); body != "{\"error\":\"Microsoft Azure plugin not installed or not enabled\"}\n" {
+		t.Fatalf("AzureOAuthCallback() body = %q, want %q", body, "{\"error\":\"Microsoft Azure plugin not installed or not enabled\"}\n")
 	}
+}
+
+func TestEnsureAzureDefaultAccessAssignsBuiltInGroup(t *testing.T) {
+	database := newAzureTestDB(t)
+	h := &Handlers{DB: database}
+
+	user := &db.User{
+		Username: "azure:tenant:object",
+		Role:     "viewer",
+		SSOOnly:  true,
+	}
+	if err := database.CreateUser(context.Background(), user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if err := h.ensureAzureDefaultAccess(context.Background(), user, "developer"); err != nil {
+		t.Fatalf("ensureAzureDefaultAccess: %v", err)
+	}
+
+	groups, err := database.ListUserGroups(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("ListUserGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Name != "developers" {
+		t.Fatalf("ListUserGroups() = %#v, want developers membership", groups)
+	}
+
+	reloaded, err := database.GetUserByID(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("GetUserByID: %v", err)
+	}
+	if reloaded.Role != "viewer" {
+		t.Fatalf("user role = %q, want %q", reloaded.Role, "viewer")
+	}
+}
+
+func TestEnsureAzureDefaultAccessDoesNotOverrideExistingAssignments(t *testing.T) {
+	database := newAzureTestDB(t)
+	h := &Handlers{DB: database}
+
+	user := &db.User{
+		Username: "azure:tenant:object",
+		Role:     "viewer",
+		SSOOnly:  true,
+	}
+	if err := database.CreateUser(context.Background(), user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := database.AddUserToGroupByName(context.Background(), user.ID, "admins"); err != nil {
+		t.Fatalf("AddUserToGroupByName: %v", err)
+	}
+
+	if err := h.ensureAzureDefaultAccess(context.Background(), user, "developer"); err != nil {
+		t.Fatalf("ensureAzureDefaultAccess: %v", err)
+	}
+
+	groups, err := database.ListUserGroups(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("ListUserGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Name != "admins" {
+		t.Fatalf("ListUserGroups() = %#v, want existing admins membership to remain unchanged", groups)
+	}
+}
+
+func newAzureTestDB(t *testing.T) *db.DB {
+	t.Helper()
+
+	dataDir := t.TempDir()
+	cfg := &config.Config{
+		Port:          8080,
+		DBType:        "sqlite",
+		DBDSN:         filepath.Join(dataDir, "gantry.db"),
+		JWTSecret:     "test-secret",
+		DataDir:       dataDir,
+		EncryptionKey: "test-encryption-key",
+	}
+
+	database, err := db.New(cfg)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := database.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if err := database.SeedDefaultGroups(context.Background()); err != nil {
+		t.Fatalf("SeedDefaultGroups: %v", err)
+	}
+
+	return database
 }

--- a/internal/api/handlers/azure_test.go
+++ b/internal/api/handlers/azure_test.go
@@ -1,6 +1,10 @@
 package handlers
 
-import "testing"
+import (
+	"testing"
+
+	azplugin "github.com/go2engle/gantry/internal/plugins/azure"
+)
 
 func TestAzureSSOConfigured(t *testing.T) {
 	tests := []struct {
@@ -44,4 +48,22 @@ func TestAzureSSOConfigured(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAzureUsername(t *testing.T) {
+	t.Run("uses immutable tenant and object identifiers", func(t *testing.T) {
+		username, err := azureUsername(&azplugin.IdentityClaims{TID: "Tenant-ID", OID: "Object-ID"})
+		if err != nil {
+			t.Fatalf("azureUsername() error = %v, want nil", err)
+		}
+		if want := "azure:tenant-id:object-id"; username != want {
+			t.Fatalf("azureUsername() = %q, want %q", username, want)
+		}
+	})
+
+	t.Run("fails closed when immutable identifiers are missing", func(t *testing.T) {
+		if _, err := azureUsername(&azplugin.IdentityClaims{PreferredUsername: "user@example.com"}); err == nil {
+			t.Fatal("azureUsername() error = nil, want failure when oid/tid are missing")
+		}
+	})
 }

--- a/internal/api/handlers/github.go
+++ b/internal/api/handlers/github.go
@@ -122,14 +122,14 @@ func (h *Handlers) GitHubOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	// Exchange code → GitHub access token.
 	accessToken, err := ghplugin.ExchangeOAuthCode(code, clientID, clientSecret)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to exchange oauth code: "+err.Error())
+		writeSSOProviderError(w, "GitHub", "exchange oauth code", err)
 		return
 	}
 
 	// Fetch GitHub user profile.
 	ghUser, err := ghplugin.FetchUserWithToken(accessToken)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to fetch GitHub user: "+err.Error())
+		writeSSOProviderError(w, "GitHub", "fetch GitHub user", err)
 		return
 	}
 

--- a/internal/api/handlers/github.go
+++ b/internal/api/handlers/github.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -139,7 +140,16 @@ func (h *Handlers) GitHubOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	gantryUser, _ := h.DB.GetUserByUsername(ctx, username)
 
 	if gantryUser == nil && ghUser.Email != "" {
-		gantryUser, _ = h.DB.GetUserByEmail(ctx, ghUser.Email)
+		usersByEmail, err := h.DB.GetUsersByEmail(ctx, ghUser.Email)
+		if err == nil {
+			switch len(usersByEmail) {
+			case 1:
+				gantryUser = usersByEmail[0]
+			case 0:
+			default:
+				log.Printf("github auth: email hash %s matched %d Gantry users; refusing ambiguous SSO lookup", hashEmailForLog(ghUser.Email), len(usersByEmail))
+			}
+		}
 	}
 
 	// Determine the return URL for redirects (including error redirects).

--- a/internal/api/handlers/plugins.go
+++ b/internal/api/handlers/plugins.go
@@ -121,6 +121,11 @@ func (h *Handlers) EnablePlugin(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+		ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
+		if name == "microsoft-azure" && ssoEnabled && !azureSSOConfigured(p.Config, ssoEnabled) {
+			writeError(w, http.StatusBadRequest, "Microsoft Azure SSO requires both client ID and client secret before enabling")
+			return
+		}
 	}
 
 	if err := h.DB.UpdatePluginEnabled(r.Context(), name, body.Enabled); err != nil {

--- a/internal/api/handlers/plugins.go
+++ b/internal/api/handlers/plugins.go
@@ -122,7 +122,9 @@ func (h *Handlers) EnablePlugin(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		ssoEnabled, _ := p.Config["ssoEnabled"].(bool)
-		if name == "microsoft-azure" && ssoEnabled && !azureSSOConfigured(p.Config, ssoEnabled) {
+		clientID, _ := p.Config["clientId"].(string)
+		clientSecret, _ := p.Config["clientSecret"].(string)
+		if name == "microsoft-azure" && ssoEnabled && !azureSSOConfigured(ssoEnabled, clientID, clientSecret) {
 			writeError(w, http.StatusBadRequest, "Microsoft Azure SSO requires both client ID and client secret before enabling")
 			return
 		}

--- a/internal/api/handlers/sso_helpers.go
+++ b/internal/api/handlers/sso_helpers.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func hashEmailForLog(email string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(email))))
+	return hex.EncodeToString(sum[:8])
+}
+
+func writeSSOProviderError(w http.ResponseWriter, provider, operation string, err error) {
+	log.Printf("%s auth: %s: %v", provider, operation, err)
+	writeError(w, http.StatusBadGateway, fmt.Sprintf("%s authentication failed", provider))
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -98,10 +98,13 @@ func NewServer(cfg *config.Config, database *db.DB, authSvc *auth.Service, event
 		// Public endpoints.
 		api.Get("/version", h.GetVersion)
 		api.Post("/auth/login", h.Login)
-		// GitHub SSO — public; used by login page and OAuth redirect flow.
+		// GitHub and Microsoft Azure SSO — public; used by login page and OAuth redirect flow.
 		api.Get("/auth/github/config", h.GetGitHubSSOConfig)
 		api.Get("/auth/github", h.GitHubOAuthBegin)
 		api.Get("/auth/github/callback", h.GitHubOAuthCallback)
+		api.Get("/auth/azure/config", h.GetAzureSSOConfig)
+		api.Get("/auth/azure", h.AzureOAuthBegin)
+		api.Get("/auth/azure/callback", h.AzureOAuthCallback)
 
 		// Authenticated routes.
 		api.Group(func(protected chi.Router) {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -788,6 +788,9 @@ func (d *DB) GetUserByEmail(ctx context.Context, email string) (*User, error) {
 	if len(users) == 0 {
 		return nil, fmt.Errorf("user with email %q: %w", email, entity.ErrEntityNotFound)
 	}
+	if len(users) > 1 {
+		return nil, fmt.Errorf("multiple users with email %q: %w", email, entity.ErrEntityAmbiguous)
+	}
 	return users[0], nil
 }
 

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -798,7 +798,7 @@ func (d *DB) GetUserByEmail(ctx context.Context, email string) (*User, error) {
 func (d *DB) GetUsersByEmail(ctx context.Context, email string) ([]*User, error) {
 	rows, err := d.queryRows(ctx,
 		`SELECT id, username, password_hash, display_name, email, role, sso_only, created_at, updated_at
-		 FROM users WHERE email = ? ORDER BY created_at ASC, id ASC`, email)
+		 FROM users WHERE lower(trim(email)) = lower(trim(?)) ORDER BY created_at ASC, id ASC`, email)
 	if err != nil {
 		return nil, fmt.Errorf("querying users by email: %w", err)
 	}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -781,30 +781,50 @@ func (d *DB) InitializeBootstrapAdminPassword(ctx context.Context, authSvc *auth
 
 // GetUserByEmail retrieves a user by their email address.
 func (d *DB) GetUserByEmail(ctx context.Context, email string) (*User, error) {
-	row := d.queryRow(ctx,
-		`SELECT id, username, password_hash, display_name, email, role, sso_only, created_at, updated_at
-		 FROM users WHERE email = ? LIMIT 1`, email)
-	u := &User{}
-	var displayName, emailVal sql.NullString
-	var createdAt, updatedAt sql.NullTime
-	var ssoOnly int
-	err := row.Scan(&u.ID, &u.Username, &u.PasswordHash, &displayName, &emailVal, &u.Role, &ssoOnly, &createdAt, &updatedAt)
-	if err == sql.ErrNoRows {
+	users, err := d.GetUsersByEmail(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+	if len(users) == 0 {
 		return nil, fmt.Errorf("user with email %q: %w", email, entity.ErrEntityNotFound)
 	}
+	return users[0], nil
+}
+
+// GetUsersByEmail retrieves every user that matches an email address.
+func (d *DB) GetUsersByEmail(ctx context.Context, email string) ([]*User, error) {
+	rows, err := d.queryRows(ctx,
+		`SELECT id, username, password_hash, display_name, email, role, sso_only, created_at, updated_at
+		 FROM users WHERE email = ? ORDER BY created_at ASC, id ASC`, email)
 	if err != nil {
-		return nil, fmt.Errorf("querying user by email: %w", err)
+		return nil, fmt.Errorf("querying users by email: %w", err)
 	}
-	u.DisplayName = displayName.String
-	u.Email = emailVal.String
-	u.SSOOnly = ssoOnly != 0
-	if createdAt.Valid {
-		u.CreatedAt = createdAt.Time
+	defer rows.Close()
+
+	var users []*User
+	for rows.Next() {
+		u := &User{}
+		var displayName, emailVal sql.NullString
+		var createdAt, updatedAt sql.NullTime
+		var ssoOnly int
+		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash, &displayName, &emailVal, &u.Role, &ssoOnly, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("querying users by email: %w", err)
+		}
+		u.DisplayName = displayName.String
+		u.Email = emailVal.String
+		u.SSOOnly = ssoOnly != 0
+		if createdAt.Valid {
+			u.CreatedAt = createdAt.Time
+		}
+		if updatedAt.Valid {
+			u.UpdatedAt = updatedAt.Time
+		}
+		users = append(users, u)
 	}
-	if updatedAt.Valid {
-		u.UpdatedAt = updatedAt.Time
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("querying users by email: %w", err)
 	}
-	return u, nil
+	return users, nil
 }
 
 // DeleteUser removes a user by ID.

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -111,5 +111,8 @@ var ErrEntityNotFound = errors.New("entity not found")
 // ErrEntityAlreadyExists is returned when attempting to create a duplicate entity.
 var ErrEntityAlreadyExists = errors.New("entity already exists")
 
+// ErrEntityAmbiguous is returned when a lookup expected one entity but matched many.
+var ErrEntityAmbiguous = errors.New("entity lookup is ambiguous")
+
 // ErrInvalidEntity is returned when an entity fails validation.
 var ErrInvalidEntity = errors.New("invalid entity")

--- a/internal/plugins/azure/client.go
+++ b/internal/plugins/azure/client.go
@@ -1,18 +1,33 @@
 package azure
 
 import (
+	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
-const graphAPIBase = "https://graph.microsoft.com/v1.0"
+var (
+	graphAPIBase  = "https://graph.microsoft.com/v1.0"
+	loginBaseURL  = "https://login.microsoftonline.com"
+	azureHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+	jwksCache = struct {
+		sync.RWMutex
+		entries map[string]jwksCacheEntry
+	}{entries: map[string]jwksCacheEntry{}}
+)
+
+const jwksCacheTTL = time.Hour
 
 // MicrosoftUser is the subset of Microsoft Graph user fields Gantry needs for SSO.
 type MicrosoftUser struct {
@@ -29,6 +44,7 @@ type IdentityClaims struct {
 	Email             string `json:"email"`
 	Name              string `json:"name"`
 	PreferredUsername string `json:"preferred_username"`
+	jwt.RegisteredClaims
 }
 
 // OAuthTokenResponse is the token response from the Microsoft identity platform.
@@ -37,6 +53,24 @@ type OAuthTokenResponse struct {
 	IDToken          string `json:"id_token"`
 	Error            string `json:"error"`
 	ErrorDescription string `json:"error_description"`
+}
+
+type jwksResponse struct {
+	Keys []jsonWebKey `json:"keys"`
+}
+
+type jsonWebKey struct {
+	KID string `json:"kid"`
+	KTY string `json:"kty"`
+	ALG string `json:"alg"`
+	Use string `json:"use"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+type jwksCacheEntry struct {
+	keys      map[string]*rsa.PublicKey
+	expiresAt time.Time
 }
 
 func normalizeTenantID(tenantID string) string {
@@ -64,7 +98,7 @@ func AuthorizationURL(tenantID, clientID, redirectURI, state, scopes string) str
 	values.Set("response_mode", "query")
 	values.Set("scope", normalizeScopes(scopes))
 	values.Set("state", state)
-	return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/authorize?%s", url.PathEscape(normalizeTenantID(tenantID)), values.Encode())
+	return fmt.Sprintf("%s/%s/oauth2/v2.0/authorize?%s", strings.TrimRight(loginBaseURL, "/"), url.PathEscape(normalizeTenantID(tenantID)), values.Encode())
 }
 
 // ExchangeOAuthCode exchanges a Microsoft OAuth authorization code for tokens.
@@ -77,7 +111,7 @@ func ExchangeOAuthCode(code, clientID, clientSecret, tenantID, redirectURI, scop
 	values.Set("redirect_uri", redirectURI)
 	values.Set("scope", normalizeScopes(scopes))
 
-	endpoint := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", url.PathEscape(normalizeTenantID(tenantID)))
+	endpoint := fmt.Sprintf("%s/%s/oauth2/v2.0/token", strings.TrimRight(loginBaseURL, "/"), url.PathEscape(normalizeTenantID(tenantID)))
 	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(values.Encode()))
 	if err != nil {
 		return nil, err
@@ -86,7 +120,7 @@ func ExchangeOAuthCode(code, clientID, clientSecret, tenantID, redirectURI, scop
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", "gantry-azure-auth/1.0")
 
-	res, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	res, err := azureHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("exchange oauth code: %w", err)
 	}
@@ -123,7 +157,7 @@ func FetchUserWithToken(accessToken string) (*MicrosoftUser, error) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "gantry-azure-auth/1.0")
 
-	res, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	res, err := azureHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("microsoft graph request: %w", err)
 	}
@@ -144,16 +178,187 @@ func FetchUserWithToken(accessToken string) (*MicrosoftUser, error) {
 	return &user, nil
 }
 
-// ParseIdentityClaims extracts useful claims from the returned ID token without re-validating it.
-// The token comes directly from the Microsoft token endpoint over TLS after a successful code exchange.
-func ParseIdentityClaims(idToken string) (*IdentityClaims, error) {
+// ParseIdentityClaims verifies the Microsoft ID token signature and required claims before returning identity data.
+func ParseIdentityClaims(idToken, tenantID, clientID string) (*IdentityClaims, error) {
 	if strings.TrimSpace(idToken) == "" {
 		return &IdentityClaims{}, nil
 	}
 
-	var claims IdentityClaims
-	if _, _, err := new(jwt.Parser).ParseUnverified(idToken, &claims); err != nil {
+	claims := &IdentityClaims{}
+	parsedToken, err := jwt.ParseWithClaims(idToken, claims, func(token *jwt.Token) (any, error) {
+		if token.Method.Alg() != jwt.SigningMethodRS256.Alg() {
+			return nil, fmt.Errorf("unexpected signing method %q", token.Method.Alg())
+		}
+
+		kid, _ := token.Header["kid"].(string)
+		if strings.TrimSpace(kid) == "" {
+			return nil, fmt.Errorf("missing key id in token header")
+		}
+
+		keys, err := fetchJWKSKeys(tenantID)
+		if err != nil {
+			return nil, err
+		}
+
+		publicKey, ok := keys[kid]
+		if !ok {
+			return nil, fmt.Errorf("signing key %q not found in jwks", kid)
+		}
+		return publicKey, nil
+	})
+	if err != nil {
 		return nil, fmt.Errorf("parse id token claims: %w", err)
 	}
-	return &claims, nil
+	if !parsedToken.Valid {
+		return nil, fmt.Errorf("parse id token claims: token is invalid")
+	}
+
+	if err := validateIdentityClaims(claims, tenantID, clientID); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+func validateIdentityClaims(claims *IdentityClaims, tenantID, clientID string) error {
+	now := time.Now()
+	if claims.ExpiresAt == nil || !claims.ExpiresAt.After(now) {
+		return fmt.Errorf("parse id token claims: token expiration is invalid")
+	}
+	if claims.NotBefore != nil && claims.NotBefore.After(now) {
+		return fmt.Errorf("parse id token claims: token is not valid yet")
+	}
+	if strings.TrimSpace(clientID) == "" {
+		return fmt.Errorf("parse id token claims: missing client id for audience validation")
+	}
+	if !audienceContains(claims.Audience, clientID) {
+		return fmt.Errorf("parse id token claims: audience %q does not include client id", strings.Join(claims.Audience, ","))
+	}
+
+	expectedIssuer := expectedIssuer(tenantID, claims)
+	if claims.Issuer != expectedIssuer {
+		return fmt.Errorf("parse id token claims: issuer %q does not match expected %q", claims.Issuer, expectedIssuer)
+	}
+	return nil
+}
+
+func expectedIssuer(tenantID string, claims *IdentityClaims) string {
+	tenant := normalizeTenantID(tenantID)
+	if isMultiTenantAuthority(tenant) && claims != nil && strings.TrimSpace(claims.TID) != "" {
+		tenant = strings.TrimSpace(claims.TID)
+	}
+	return fmt.Sprintf("%s/%s/v2.0", strings.TrimRight(loginBaseURL, "/"), tenant)
+}
+
+func isMultiTenantAuthority(tenantID string) bool {
+	switch strings.ToLower(strings.TrimSpace(tenantID)) {
+	case "common", "organizations", "consumers":
+		return true
+	default:
+		return false
+	}
+}
+
+func audienceContains(audience jwt.ClaimStrings, clientID string) bool {
+	for _, aud := range audience {
+		if aud == clientID {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchJWKSKeys(tenantID string) (map[string]*rsa.PublicKey, error) {
+	tenant := normalizeTenantID(tenantID)
+
+	jwksCache.RLock()
+	entry, ok := jwksCache.entries[tenant]
+	jwksCache.RUnlock()
+	if ok && time.Now().Before(entry.expiresAt) {
+		return entry.keys, nil
+	}
+
+	keys, err := requestJWKSKeys(tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	jwksCache.Lock()
+	jwksCache.entries[tenant] = jwksCacheEntry{keys: keys, expiresAt: time.Now().Add(jwksCacheTTL)}
+	jwksCache.Unlock()
+	return keys, nil
+}
+
+func requestJWKSKeys(tenantID string) (map[string]*rsa.PublicKey, error) {
+	endpoint := fmt.Sprintf("%s/%s/discovery/v2.0/keys", strings.TrimRight(loginBaseURL, "/"), url.PathEscape(tenantID))
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build jwks request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "gantry-azure-auth/1.0")
+
+	res, err := azureHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch jwks: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read jwks response: %w", err)
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch jwks: HTTP %d: %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload jwksResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode jwks response: %w", err)
+	}
+
+	keys := make(map[string]*rsa.PublicKey, len(payload.Keys))
+	for _, key := range payload.Keys {
+		if strings.ToUpper(key.KTY) != "RSA" || strings.TrimSpace(key.KID) == "" {
+			continue
+		}
+		publicKey, err := rsaPublicKeyFromJWK(key)
+		if err != nil {
+			return nil, err
+		}
+		keys[key.KID] = publicKey
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("jwks response did not contain usable rsa keys")
+	}
+	return keys, nil
+}
+
+func rsaPublicKeyFromJWK(key jsonWebKey) (*rsa.PublicKey, error) {
+	modulus, err := base64.RawURLEncoding.DecodeString(key.N)
+	if err != nil {
+		return nil, fmt.Errorf("decode jwks modulus for key %q: %w", key.KID, err)
+	}
+	exponent, err := base64.RawURLEncoding.DecodeString(key.E)
+	if err != nil {
+		return nil, fmt.Errorf("decode jwks exponent for key %q: %w", key.KID, err)
+	}
+
+	e := 0
+	for _, b := range exponent {
+		e = (e << 8) | int(b)
+	}
+	if e == 0 {
+		return nil, fmt.Errorf("jwks exponent for key %q is invalid", key.KID)
+	}
+
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(modulus),
+		E: e,
+	}, nil
+}
+
+func clearJWKSCache() {
+	jwksCache.Lock()
+	defer jwksCache.Unlock()
+	jwksCache.entries = map[string]jwksCacheEntry{}
 }

--- a/internal/plugins/azure/client.go
+++ b/internal/plugins/azure/client.go
@@ -202,14 +202,9 @@ func ParseIdentityClaims(idToken, tenantID, clientID string) (*IdentityClaims, e
 			return nil, fmt.Errorf("missing key id in token header")
 		}
 
-		keys, err := fetchJWKSKeys(tenantID)
+		publicKey, err := fetchJWKSPublicKey(tenantID, kid)
 		if err != nil {
 			return nil, err
-		}
-
-		publicKey, ok := keys[kid]
-		if !ok {
-			return nil, fmt.Errorf("signing key %q not found in jwks", kid)
 		}
 		return publicKey, nil
 	})
@@ -275,13 +270,36 @@ func audienceContains(audience jwt.ClaimStrings, clientID string) bool {
 }
 
 func fetchJWKSKeys(tenantID string) (map[string]*rsa.PublicKey, error) {
+	return fetchJWKSKeysWithOptions(tenantID, false)
+}
+
+func fetchJWKSPublicKey(tenantID, kid string) (*rsa.PublicKey, error) {
+	keys, err := fetchJWKSKeysWithOptions(tenantID, false)
+	if err != nil {
+		return nil, err
+	}
+	if publicKey, ok := keys[kid]; ok {
+		return publicKey, nil
+	}
+
+	keys, err = fetchJWKSKeysWithOptions(tenantID, true)
+	if err != nil {
+		return nil, err
+	}
+	if publicKey, ok := keys[kid]; ok {
+		return publicKey, nil
+	}
+	return nil, fmt.Errorf("signing key %q not found in jwks", kid)
+}
+
+func fetchJWKSKeysWithOptions(tenantID string, forceRefresh bool) (map[string]*rsa.PublicKey, error) {
 	tenant := normalizeTenantID(tenantID)
 	now := time.Now()
 
 	jwksCache.RLock()
 	entry, ok := jwksCache.entries[tenant]
 	jwksCache.RUnlock()
-	if ok && now.Before(entry.expiresAt) {
+	if !forceRefresh && ok && now.Before(entry.expiresAt) {
 		return entry.keys, nil
 	}
 
@@ -292,8 +310,10 @@ func fetchJWKSKeys(tenantID string) (map[string]*rsa.PublicKey, error) {
 
 	jwksCache.Lock()
 	defer jwksCache.Unlock()
-	if entry, ok := jwksCache.entries[tenant]; ok && time.Now().Before(entry.expiresAt) {
-		return entry.keys, nil
+	if !forceRefresh {
+		if entry, ok := jwksCache.entries[tenant]; ok && time.Now().Before(entry.expiresAt) {
+			return entry.keys, nil
+		}
 	}
 	jwksCache.entries[tenant] = jwksCacheEntry{keys: keys, expiresAt: time.Now().Add(jwksCacheTTL)}
 	return keys, nil

--- a/internal/plugins/azure/client.go
+++ b/internal/plugins/azure/client.go
@@ -17,17 +17,24 @@ import (
 )
 
 var (
-	graphAPIBase  = "https://graph.microsoft.com/v1.0"
-	loginBaseURL  = "https://login.microsoftonline.com"
+	graphAPIBase   = "https://graph.microsoft.com/v1.0"
+	loginBaseURL   = "https://login.microsoftonline.com"
 	azureHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
 	jwksCache = struct {
 		sync.RWMutex
-		entries map[string]jwksCacheEntry
-	}{entries: map[string]jwksCacheEntry{}}
+		entries   map[string]jwksCacheEntry
+		refreshes map[string]chan struct{}
+	}{
+		entries:   map[string]jwksCacheEntry{},
+		refreshes: map[string]chan struct{}{},
+	}
 )
 
-const jwksCacheTTL = time.Hour
+const (
+	jwksCacheTTL            = time.Hour
+	jwksForceRefreshCooldown = time.Minute
+)
 
 // MicrosoftUser is the subset of Microsoft Graph user fields Gantry needs for SSO.
 type MicrosoftUser struct {
@@ -69,8 +76,9 @@ type jsonWebKey struct {
 }
 
 type jwksCacheEntry struct {
-	keys      map[string]*rsa.PublicKey
-	expiresAt time.Time
+	keys        map[string]*rsa.PublicKey
+	expiresAt   time.Time
+	refreshedAt time.Time
 }
 
 func normalizeTenantID(tenantID string) string {
@@ -294,29 +302,47 @@ func fetchJWKSPublicKey(tenantID, kid string) (*rsa.PublicKey, error) {
 
 func fetchJWKSKeysWithOptions(tenantID string, forceRefresh bool) (map[string]*rsa.PublicKey, error) {
 	tenant := normalizeTenantID(tenantID)
-	now := time.Now()
 
-	jwksCache.RLock()
-	entry, ok := jwksCache.entries[tenant]
-	jwksCache.RUnlock()
-	if !forceRefresh && ok && now.Before(entry.expiresAt) {
-		return entry.keys, nil
-	}
-
-	keys, err := requestJWKSKeys(tenant)
-	if err != nil {
-		return nil, err
-	}
-
-	jwksCache.Lock()
-	defer jwksCache.Unlock()
-	if !forceRefresh {
-		if entry, ok := jwksCache.entries[tenant]; ok && time.Now().Before(entry.expiresAt) {
+	for {
+		now := time.Now()
+		jwksCache.Lock()
+		entry, ok := jwksCache.entries[tenant]
+		if !forceRefresh && ok && now.Before(entry.expiresAt) {
+			jwksCache.Unlock()
 			return entry.keys, nil
 		}
+		if forceRefresh && ok && !entry.refreshedAt.IsZero() && now.Sub(entry.refreshedAt) < jwksForceRefreshCooldown {
+			jwksCache.Unlock()
+			return entry.keys, nil
+		}
+		if waitCh, refreshing := jwksCache.refreshes[tenant]; refreshing {
+			jwksCache.Unlock()
+			<-waitCh
+			continue
+		}
+
+		waitCh := make(chan struct{})
+		jwksCache.refreshes[tenant] = waitCh
+		jwksCache.Unlock()
+
+		keys, err := requestJWKSKeys(tenant)
+		fetchedAt := time.Now()
+
+		jwksCache.Lock()
+		delete(jwksCache.refreshes, tenant)
+		close(waitCh)
+		if err != nil {
+			jwksCache.Unlock()
+			return nil, err
+		}
+		jwksCache.entries[tenant] = jwksCacheEntry{
+			keys:        keys,
+			expiresAt:   fetchedAt.Add(jwksCacheTTL),
+			refreshedAt: fetchedAt,
+		}
+		jwksCache.Unlock()
+		return keys, nil
 	}
-	jwksCache.entries[tenant] = jwksCacheEntry{keys: keys, expiresAt: time.Now().Add(jwksCacheTTL)}
-	return keys, nil
 }
 
 func requestJWKSKeys(tenantID string) (map[string]*rsa.PublicKey, error) {
@@ -374,11 +400,12 @@ func rsaPublicKeyFromJWK(key jsonWebKey) (*rsa.PublicKey, error) {
 		return nil, fmt.Errorf("decode jwks exponent for key %q: %w", key.KID, err)
 	}
 
-	e := 0
-	for _, b := range exponent {
-		e = (e << 8) | int(b)
+	eBig := new(big.Int).SetBytes(exponent)
+	if eBig.Sign() <= 0 || !eBig.IsInt64() {
+		return nil, fmt.Errorf("jwks exponent for key %q is invalid", key.KID)
 	}
-	if e == 0 {
+	e := int(eBig.Int64())
+	if int64(e) != eBig.Int64() {
 		return nil, fmt.Errorf("jwks exponent for key %q is invalid", key.KID)
 	}
 
@@ -392,4 +419,5 @@ func clearJWKSCache() {
 	jwksCache.Lock()
 	defer jwksCache.Unlock()
 	jwksCache.entries = map[string]jwksCacheEntry{}
+	jwksCache.refreshes = map[string]chan struct{}{}
 }

--- a/internal/plugins/azure/client.go
+++ b/internal/plugins/azure/client.go
@@ -86,7 +86,14 @@ func normalizeScopes(scopes string) string {
 	if scopes == "" {
 		return "openid profile email User.Read"
 	}
-	return scopes
+
+	parts := strings.Fields(scopes)
+	for _, part := range parts {
+		if strings.EqualFold(part, "openid") {
+			return strings.Join(parts, " ")
+		}
+	}
+	return strings.Join(append([]string{"openid"}, parts...), " ")
 }
 
 // AuthorizationURL builds the Microsoft OAuth authorization URL for the configured tenant.
@@ -181,7 +188,7 @@ func FetchUserWithToken(accessToken string) (*MicrosoftUser, error) {
 // ParseIdentityClaims verifies the Microsoft ID token signature and required claims before returning identity data.
 func ParseIdentityClaims(idToken, tenantID, clientID string) (*IdentityClaims, error) {
 	if strings.TrimSpace(idToken) == "" {
-		return &IdentityClaims{}, nil
+		return nil, fmt.Errorf("parse id token claims: id token is empty")
 	}
 
 	claims := &IdentityClaims{}

--- a/internal/plugins/azure/client.go
+++ b/internal/plugins/azure/client.go
@@ -253,10 +253,18 @@ func validateIdentityClaims(claims *IdentityClaims, tenantID, clientID string) e
 
 func expectedIssuer(tenantID string, claims *IdentityClaims) string {
 	tenant := normalizeTenantID(tenantID)
-	if isMultiTenantAuthority(tenant) && claims != nil && strings.TrimSpace(claims.TID) != "" {
+	if shouldUseTokenTenantIssuer(tenant) && claims != nil && strings.TrimSpace(claims.TID) != "" {
 		tenant = strings.TrimSpace(claims.TID)
 	}
 	return fmt.Sprintf("%s/%s/v2.0", strings.TrimRight(loginBaseURL, "/"), tenant)
+}
+
+func shouldUseTokenTenantIssuer(tenantID string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	if isMultiTenantAuthority(tenantID) {
+		return true
+	}
+	return !looksLikeTenantGUID(tenantID)
 }
 
 func isMultiTenantAuthority(tenantID string) bool {
@@ -266,6 +274,25 @@ func isMultiTenantAuthority(tenantID string) bool {
 	default:
 		return false
 	}
+}
+
+func looksLikeTenantGUID(tenantID string) bool {
+	parts := strings.Split(strings.TrimSpace(tenantID), "-")
+	if len(parts) != 5 {
+		return false
+	}
+	segmentLengths := []int{8, 4, 4, 4, 12}
+	for i, part := range parts {
+		if len(part) != segmentLengths[i] {
+			return false
+		}
+		for _, r := range part {
+			if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func audienceContains(audience jwt.ClaimStrings, clientID string) bool {

--- a/internal/plugins/azure/client.go
+++ b/internal/plugins/azure/client.go
@@ -1,0 +1,159 @@
+package azure
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const graphAPIBase = "https://graph.microsoft.com/v1.0"
+
+// MicrosoftUser is the subset of Microsoft Graph user fields Gantry needs for SSO.
+type MicrosoftUser struct {
+	ID                string `json:"id"`
+	DisplayName       string `json:"displayName"`
+	Mail              string `json:"mail"`
+	UserPrincipalName string `json:"userPrincipalName"`
+}
+
+// IdentityClaims contains the subset of ID token claims Gantry uses for stable SSO identity mapping.
+type IdentityClaims struct {
+	OID               string `json:"oid"`
+	TID               string `json:"tid"`
+	Email             string `json:"email"`
+	Name              string `json:"name"`
+	PreferredUsername string `json:"preferred_username"`
+}
+
+// OAuthTokenResponse is the token response from the Microsoft identity platform.
+type OAuthTokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	IDToken          string `json:"id_token"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func normalizeTenantID(tenantID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return "common"
+	}
+	return tenantID
+}
+
+func normalizeScopes(scopes string) string {
+	scopes = strings.TrimSpace(scopes)
+	if scopes == "" {
+		return "openid profile email User.Read"
+	}
+	return scopes
+}
+
+// AuthorizationURL builds the Microsoft OAuth authorization URL for the configured tenant.
+func AuthorizationURL(tenantID, clientID, redirectURI, state, scopes string) string {
+	values := url.Values{}
+	values.Set("client_id", clientID)
+	values.Set("response_type", "code")
+	values.Set("redirect_uri", redirectURI)
+	values.Set("response_mode", "query")
+	values.Set("scope", normalizeScopes(scopes))
+	values.Set("state", state)
+	return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/authorize?%s", url.PathEscape(normalizeTenantID(tenantID)), values.Encode())
+}
+
+// ExchangeOAuthCode exchanges a Microsoft OAuth authorization code for tokens.
+func ExchangeOAuthCode(code, clientID, clientSecret, tenantID, redirectURI, scopes string) (*OAuthTokenResponse, error) {
+	values := url.Values{}
+	values.Set("grant_type", "authorization_code")
+	values.Set("code", code)
+	values.Set("client_id", clientID)
+	values.Set("client_secret", clientSecret)
+	values.Set("redirect_uri", redirectURI)
+	values.Set("scope", normalizeScopes(scopes))
+
+	endpoint := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", url.PathEscape(normalizeTenantID(tenantID)))
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "gantry-azure-auth/1.0")
+
+	res, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("exchange oauth code: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+
+	var tokenResp OAuthTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	if tokenResp.Error != "" {
+		return nil, fmt.Errorf("microsoft oauth: %s: %s", tokenResp.Error, tokenResp.ErrorDescription)
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("microsoft oauth token exchange failed: HTTP %d", res.StatusCode)
+	}
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("microsoft oauth token exchange returned no access token")
+	}
+	return &tokenResp, nil
+}
+
+// FetchUserWithToken fetches the current user from Microsoft Graph.
+func FetchUserWithToken(accessToken string) (*MicrosoftUser, error) {
+	req, err := http.NewRequest(http.MethodGet, graphAPIBase+"/me?$select=id,displayName,mail,userPrincipalName", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "gantry-azure-auth/1.0")
+
+	res, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("microsoft graph request: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read graph response: %w", err)
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("microsoft graph /me: HTTP %d: %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var user MicrosoftUser
+	if err := json.Unmarshal(body, &user); err != nil {
+		return nil, fmt.Errorf("decode graph response: %w", err)
+	}
+	return &user, nil
+}
+
+// ParseIdentityClaims extracts useful claims from the returned ID token without re-validating it.
+// The token comes directly from the Microsoft token endpoint over TLS after a successful code exchange.
+func ParseIdentityClaims(idToken string) (*IdentityClaims, error) {
+	if strings.TrimSpace(idToken) == "" {
+		return &IdentityClaims{}, nil
+	}
+
+	var claims IdentityClaims
+	if _, _, err := new(jwt.Parser).ParseUnverified(idToken, &claims); err != nil {
+		return nil, fmt.Errorf("parse id token claims: %w", err)
+	}
+	return &claims, nil
+}

--- a/internal/plugins/azure/client.go
+++ b/internal/plugins/azure/client.go
@@ -276,11 +276,12 @@ func audienceContains(audience jwt.ClaimStrings, clientID string) bool {
 
 func fetchJWKSKeys(tenantID string) (map[string]*rsa.PublicKey, error) {
 	tenant := normalizeTenantID(tenantID)
+	now := time.Now()
 
 	jwksCache.RLock()
 	entry, ok := jwksCache.entries[tenant]
 	jwksCache.RUnlock()
-	if ok && time.Now().Before(entry.expiresAt) {
+	if ok && now.Before(entry.expiresAt) {
 		return entry.keys, nil
 	}
 
@@ -290,8 +291,11 @@ func fetchJWKSKeys(tenantID string) (map[string]*rsa.PublicKey, error) {
 	}
 
 	jwksCache.Lock()
+	defer jwksCache.Unlock()
+	if entry, ok := jwksCache.entries[tenant]; ok && time.Now().Before(entry.expiresAt) {
+		return entry.keys, nil
+	}
 	jwksCache.entries[tenant] = jwksCacheEntry{keys: keys, expiresAt: time.Now().Add(jwksCacheTTL)}
-	jwksCache.Unlock()
 	return keys, nil
 }
 

--- a/internal/plugins/azure/client_test.go
+++ b/internal/plugins/azure/client_test.go
@@ -162,6 +162,63 @@ func TestParseIdentityClaimsRejectsInvalidAudience(t *testing.T) {
 	assertNoJWKSHandlerError(t, handlerErrCh)
 }
 
+func TestParseIdentityClaimsAcceptsDomainConfiguredTenant(t *testing.T) {
+	const (
+		configuredTenant = "contoso.onmicrosoft.com"
+		tokenTenant      = "11111111-2222-3333-4444-555555555555"
+		clientID         = "client-123"
+		keyID            = "test-key"
+	)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	handlerErrCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/contoso.onmicrosoft.com/discovery/v2.0/keys"; got != want {
+			recordJWKSHandlerError(w, handlerErrCh, "JWKS path = %q, want %q", got, want)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{jwkFromPublicKey(keyID, &privateKey.PublicKey)},
+		}); err != nil {
+			recordJWKSHandlerError(w, handlerErrCh, "Encode JWKS: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	oldLoginBaseURL := loginBaseURL
+	loginBaseURL = server.URL
+	defer func() { loginBaseURL = oldLoginBaseURL }()
+	clearJWKSCache()
+	defer clearJWKSCache()
+
+	tokenString, err := newSignedToken(privateKey, keyID, jwt.MapClaims{
+		"oid":                "user-oid",
+		"tid":                tokenTenant,
+		"preferred_username": "person@example.com",
+		"iss":                fmt.Sprintf("%s/%s/v2.0", server.URL, tokenTenant),
+		"aud":                clientID,
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"nbf":                time.Now().Add(-time.Minute).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+
+	claims, err := ParseIdentityClaims(tokenString, configuredTenant, clientID)
+	assertNoJWKSHandlerError(t, handlerErrCh)
+	if err != nil {
+		t.Fatalf("ParseIdentityClaims: %v", err)
+	}
+	if got, want := claims.TID, tokenTenant; got != want {
+		t.Fatalf("TID = %q, want %q", got, want)
+	}
+}
+
 func TestParseIdentityClaimsRefreshesJWKSOnUnknownKeyID(t *testing.T) {
 	const (
 		configuredTenant = "common"

--- a/internal/plugins/azure/client_test.go
+++ b/internal/plugins/azure/client_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -59,16 +60,18 @@ func TestParseIdentityClaimsValidatesSignatureAndClaims(t *testing.T) {
 		t.Fatalf("GenerateKey: %v", err)
 	}
 
+	handlerErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got, want := r.URL.Path, "/common/discovery/v2.0/keys"; got != want {
-			t.Fatalf("JWKS path = %q, want %q", got, want)
+			recordJWKSHandlerError(w, handlerErrCh, "JWKS path = %q, want %q", got, want)
+			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"keys": []map[string]any{jwkFromPublicKey(keyID, &privateKey.PublicKey)},
 		}); err != nil {
-			t.Fatalf("Encode JWKS: %v", err)
+			recordJWKSHandlerError(w, handlerErrCh, "Encode JWKS: %v", err)
 		}
 	}))
 	defer server.Close()
@@ -96,6 +99,7 @@ func TestParseIdentityClaimsValidatesSignatureAndClaims(t *testing.T) {
 	}
 
 	claims, err := ParseIdentityClaims(tokenString, configuredTenant, clientID)
+	assertNoJWKSHandlerError(t, handlerErrCh)
 	if err != nil {
 		t.Fatalf("ParseIdentityClaims: %v", err)
 	}
@@ -122,12 +126,13 @@ func TestParseIdentityClaimsRejectsInvalidAudience(t *testing.T) {
 		t.Fatalf("GenerateKey: %v", err)
 	}
 
+	handlerErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"keys": []map[string]any{jwkFromPublicKey("test-key", &privateKey.PublicKey)},
 		}); err != nil {
-			t.Fatalf("Encode JWKS: %v", err)
+			recordJWKSHandlerError(w, handlerErrCh, "Encode JWKS: %v", err)
 		}
 	}))
 	defer server.Close()
@@ -151,8 +156,10 @@ func TestParseIdentityClaimsRejectsInvalidAudience(t *testing.T) {
 	}
 
 	if _, err := ParseIdentityClaims(tokenString, "common", "client-123"); err == nil || !strings.Contains(err.Error(), "audience") {
+		assertNoJWKSHandlerError(t, handlerErrCh)
 		t.Fatalf("ParseIdentityClaims error = %v, want audience validation error", err)
 	}
+	assertNoJWKSHandlerError(t, handlerErrCh)
 }
 
 func TestParseIdentityClaimsRefreshesJWKSOnUnknownKeyID(t *testing.T) {
@@ -172,18 +179,19 @@ func TestParseIdentityClaimsRefreshesJWKSOnUnknownKeyID(t *testing.T) {
 		t.Fatalf("Generate fresh key: %v", err)
 	}
 
-	requestCount := 0
+	var requestCount atomic.Int32
+	handlerErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		current := requestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 
 		keys := []map[string]any{jwkFromPublicKey("stale-key", &stalePrivateKey.PublicKey)}
-		if requestCount > 1 {
+		if current > 1 {
 			keys = append(keys, jwkFromPublicKey(freshKeyID, &freshPrivateKey.PublicKey))
 		}
 
 		if err := json.NewEncoder(w).Encode(map[string]any{"keys": keys}); err != nil {
-			t.Fatalf("Encode JWKS: %v", err)
+			recordJWKSHandlerError(w, handlerErrCh, "Encode JWKS: %v", err)
 		}
 	}))
 	defer server.Close()
@@ -195,6 +203,7 @@ func TestParseIdentityClaimsRefreshesJWKSOnUnknownKeyID(t *testing.T) {
 	defer clearJWKSCache()
 
 	cachedKeys, err := requestJWKSKeys(configuredTenant)
+	assertNoJWKSHandlerError(t, handlerErrCh)
 	if err != nil {
 		t.Fatalf("requestJWKSKeys: %v", err)
 	}
@@ -218,10 +227,12 @@ func TestParseIdentityClaimsRefreshesJWKSOnUnknownKeyID(t *testing.T) {
 	}
 
 	if _, err := ParseIdentityClaims(tokenString, configuredTenant, clientID); err != nil {
+		assertNoJWKSHandlerError(t, handlerErrCh)
 		t.Fatalf("ParseIdentityClaims: %v", err)
 	}
-	if requestCount != 2 {
-		t.Fatalf("JWKS request count = %d, want 2", requestCount)
+	assertNoJWKSHandlerError(t, handlerErrCh)
+	if got := requestCount.Load(); got != 2 {
+		t.Fatalf("JWKS request count = %d, want 2", got)
 	}
 }
 
@@ -255,5 +266,22 @@ func jwkFromPublicKey(keyID string, publicKey *rsa.PublicKey) map[string]any {
 		"use": "sig",
 		"n":   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
 		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+	}
+}
+
+func recordJWKSHandlerError(w http.ResponseWriter, handlerErrCh chan<- error, format string, args ...any) {
+	select {
+	case handlerErrCh <- fmt.Errorf(format, args...):
+	default:
+	}
+	http.Error(w, "test handler error", http.StatusInternalServerError)
+}
+
+func assertNoJWKSHandlerError(t *testing.T, handlerErrCh <-chan error) {
+	t.Helper()
+	select {
+	case err := <-handlerErrCh:
+		t.Fatalf("jwks test server handler error: %v", err)
+	default:
 	}
 }

--- a/internal/plugins/azure/client_test.go
+++ b/internal/plugins/azure/client_test.go
@@ -155,6 +155,76 @@ func TestParseIdentityClaimsRejectsInvalidAudience(t *testing.T) {
 	}
 }
 
+func TestParseIdentityClaimsRefreshesJWKSOnUnknownKeyID(t *testing.T) {
+	const (
+		configuredTenant = "common"
+		tokenTenant      = "tenant-id"
+		clientID         = "client-123"
+		freshKeyID       = "fresh-key"
+	)
+
+	stalePrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Generate stale key: %v", err)
+	}
+	freshPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Generate fresh key: %v", err)
+	}
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		keys := []map[string]any{jwkFromPublicKey("stale-key", &stalePrivateKey.PublicKey)}
+		if requestCount > 1 {
+			keys = append(keys, jwkFromPublicKey(freshKeyID, &freshPrivateKey.PublicKey))
+		}
+
+		if err := json.NewEncoder(w).Encode(map[string]any{"keys": keys}); err != nil {
+			t.Fatalf("Encode JWKS: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	oldLoginBaseURL := loginBaseURL
+	loginBaseURL = server.URL
+	defer func() { loginBaseURL = oldLoginBaseURL }()
+	clearJWKSCache()
+	defer clearJWKSCache()
+
+	cachedKeys, err := requestJWKSKeys(configuredTenant)
+	if err != nil {
+		t.Fatalf("requestJWKSKeys: %v", err)
+	}
+	jwksCache.Lock()
+	jwksCache.entries[configuredTenant] = jwksCacheEntry{
+		keys:      cachedKeys,
+		expiresAt: time.Now().Add(time.Hour),
+	}
+	jwksCache.Unlock()
+
+	tokenString, err := newSignedToken(freshPrivateKey, freshKeyID, jwt.MapClaims{
+		"oid":                "user-oid",
+		"tid":                tokenTenant,
+		"preferred_username": "person@example.com",
+		"iss":                fmt.Sprintf("%s/%s/v2.0", server.URL, tokenTenant),
+		"aud":                clientID,
+		"exp":                time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+
+	if _, err := ParseIdentityClaims(tokenString, configuredTenant, clientID); err != nil {
+		t.Fatalf("ParseIdentityClaims: %v", err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("JWKS request count = %d, want 2", requestCount)
+	}
+}
+
 func TestNormalizeScopesPreservesExplicitValue(t *testing.T) {
 	const scopes = "openid profile email User.Read GroupMember.Read.All"
 	authURL := AuthorizationURL("contoso.onmicrosoft.com", "client-123", "http://localhost/callback", "state-abc", scopes)

--- a/internal/plugins/azure/client_test.go
+++ b/internal/plugins/azure/client_test.go
@@ -1,9 +1,18 @@
 package azure
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
@@ -37,31 +46,106 @@ func TestAuthorizationURLUsesDefaults(t *testing.T) {
 	}
 }
 
-func TestParseIdentityClaims(t *testing.T) {
-	token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+func TestParseIdentityClaimsValidatesSignatureAndClaims(t *testing.T) {
+	const (
+		configuredTenant = "common"
+		tokenTenant      = "tenant-id"
+		clientID         = "client-123"
+		keyID            = "test-key"
+	)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/common/discovery/v2.0/keys"; got != want {
+			t.Fatalf("JWKS path = %q, want %q", got, want)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{jwkFromPublicKey(keyID, &privateKey.PublicKey)},
+		}); err != nil {
+			t.Fatalf("Encode JWKS: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	oldLoginBaseURL := loginBaseURL
+	loginBaseURL = server.URL
+	defer func() { loginBaseURL = oldLoginBaseURL }()
+	clearJWKSCache()
+	defer clearJWKSCache()
+
+	tokenString, err := newSignedToken(privateKey, keyID, jwt.MapClaims{
 		"oid":                "user-oid",
-		"tid":                "tenant-id",
+		"tid":                tokenTenant,
 		"email":              "person@example.com",
 		"name":               "Azure Person",
 		"preferred_username": "person@example.com",
+		"iss":                fmt.Sprintf("%s/%s/v2.0", server.URL, tokenTenant),
+		"aud":                clientID,
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"nbf":                time.Now().Add(-time.Minute).Unix(),
+		"iat":                time.Now().Add(-time.Minute).Unix(),
 	})
-	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
 	if err != nil {
 		t.Fatalf("SignedString: %v", err)
 	}
 
-	claims, err := ParseIdentityClaims(tokenString)
+	claims, err := ParseIdentityClaims(tokenString, configuredTenant, clientID)
 	if err != nil {
 		t.Fatalf("ParseIdentityClaims: %v", err)
 	}
 	if got, want := claims.OID, "user-oid"; got != want {
 		t.Fatalf("OID = %q, want %q", got, want)
 	}
-	if got, want := claims.TID, "tenant-id"; got != want {
+	if got, want := claims.TID, tokenTenant; got != want {
 		t.Fatalf("TID = %q, want %q", got, want)
 	}
 	if got, want := claims.Email, "person@example.com"; got != want {
 		t.Fatalf("Email = %q, want %q", got, want)
+	}
+}
+
+func TestParseIdentityClaimsRejectsInvalidAudience(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{jwkFromPublicKey("test-key", &privateKey.PublicKey)},
+		}); err != nil {
+			t.Fatalf("Encode JWKS: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	oldLoginBaseURL := loginBaseURL
+	loginBaseURL = server.URL
+	defer func() { loginBaseURL = oldLoginBaseURL }()
+	clearJWKSCache()
+	defer clearJWKSCache()
+
+	tokenString, err := newSignedToken(privateKey, "test-key", jwt.MapClaims{
+		"oid":                "user-oid",
+		"tid":                "tenant-id",
+		"preferred_username": "person@example.com",
+		"iss":                fmt.Sprintf("%s/%s/v2.0", server.URL, "tenant-id"),
+		"aud":                "different-client",
+		"exp":                time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+
+	if _, err := ParseIdentityClaims(tokenString, "common", "client-123"); err == nil || !strings.Contains(err.Error(), "audience") {
+		t.Fatalf("ParseIdentityClaims error = %v, want audience validation error", err)
 	}
 }
 
@@ -70,5 +154,22 @@ func TestNormalizeScopesPreservesExplicitValue(t *testing.T) {
 	authURL := AuthorizationURL("contoso.onmicrosoft.com", "client-123", "http://localhost/callback", "state-abc", scopes)
 	if !strings.Contains(authURL, url.QueryEscape(scopes)) {
 		t.Fatalf("auth URL %q does not contain encoded scopes %q", authURL, scopes)
+	}
+}
+
+func newSignedToken(privateKey *rsa.PrivateKey, keyID string, claims jwt.Claims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = keyID
+	return token.SignedString(privateKey)
+}
+
+func jwkFromPublicKey(keyID string, publicKey *rsa.PublicKey) map[string]any {
+	return map[string]any{
+		"kid": keyID,
+		"kty": "RSA",
+		"alg": "RS256",
+		"use": "sig",
+		"n":   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
 	}
 }

--- a/internal/plugins/azure/client_test.go
+++ b/internal/plugins/azure/client_test.go
@@ -1,0 +1,74 @@
+package azure
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestAuthorizationURLUsesDefaults(t *testing.T) {
+	authURL := AuthorizationURL("", "client-123", "http://localhost:3000/api/v1/auth/azure/callback", "state-abc", "")
+
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got, want := parsed.Scheme, "https"; got != want {
+		t.Fatalf("scheme = %q, want %q", got, want)
+	}
+	if got, want := parsed.Host, "login.microsoftonline.com"; got != want {
+		t.Fatalf("host = %q, want %q", got, want)
+	}
+	if got, want := parsed.Path, "/common/oauth2/v2.0/authorize"; got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+
+	query := parsed.Query()
+	if got, want := query.Get("client_id"), "client-123"; got != want {
+		t.Fatalf("client_id = %q, want %q", got, want)
+	}
+	if got, want := query.Get("state"), "state-abc"; got != want {
+		t.Fatalf("state = %q, want %q", got, want)
+	}
+	if got, want := query.Get("scope"), "openid profile email User.Read"; got != want {
+		t.Fatalf("scope = %q, want %q", got, want)
+	}
+}
+
+func TestParseIdentityClaims(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+		"oid":                "user-oid",
+		"tid":                "tenant-id",
+		"email":              "person@example.com",
+		"name":               "Azure Person",
+		"preferred_username": "person@example.com",
+	})
+	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+
+	claims, err := ParseIdentityClaims(tokenString)
+	if err != nil {
+		t.Fatalf("ParseIdentityClaims: %v", err)
+	}
+	if got, want := claims.OID, "user-oid"; got != want {
+		t.Fatalf("OID = %q, want %q", got, want)
+	}
+	if got, want := claims.TID, "tenant-id"; got != want {
+		t.Fatalf("TID = %q, want %q", got, want)
+	}
+	if got, want := claims.Email, "person@example.com"; got != want {
+		t.Fatalf("Email = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeScopesPreservesExplicitValue(t *testing.T) {
+	const scopes = "openid profile email User.Read GroupMember.Read.All"
+	authURL := AuthorizationURL("contoso.onmicrosoft.com", "client-123", "http://localhost/callback", "state-abc", scopes)
+	if !strings.Contains(authURL, url.QueryEscape(scopes)) {
+		t.Fatalf("auth URL %q does not contain encoded scopes %q", authURL, scopes)
+	}
+}

--- a/internal/plugins/azure/client_test.go
+++ b/internal/plugins/azure/client_test.go
@@ -110,6 +110,12 @@ func TestParseIdentityClaimsValidatesSignatureAndClaims(t *testing.T) {
 	}
 }
 
+func TestParseIdentityClaimsRejectsEmptyToken(t *testing.T) {
+	if _, err := ParseIdentityClaims("   ", "tenant-id", "client-123"); err == nil || !strings.Contains(err.Error(), "id token is empty") {
+		t.Fatalf("ParseIdentityClaims error = %v, want empty token error", err)
+	}
+}
+
 func TestParseIdentityClaimsRejectsInvalidAudience(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -154,6 +160,14 @@ func TestNormalizeScopesPreservesExplicitValue(t *testing.T) {
 	authURL := AuthorizationURL("contoso.onmicrosoft.com", "client-123", "http://localhost/callback", "state-abc", scopes)
 	if !strings.Contains(authURL, url.QueryEscape(scopes)) {
 		t.Fatalf("auth URL %q does not contain encoded scopes %q", authURL, scopes)
+	}
+}
+
+func TestNormalizeScopesAddsOpenIDWhenMissing(t *testing.T) {
+	const scopes = "profile email User.Read"
+	authURL := AuthorizationURL("contoso.onmicrosoft.com", "client-123", "http://localhost/callback", "state-abc", scopes)
+	if !strings.Contains(authURL, url.QueryEscape("openid "+scopes)) {
+		t.Fatalf("auth URL %q does not contain encoded scopes %q", authURL, "openid "+scopes)
 	}
 }
 

--- a/internal/plugins/bundled/registry.json
+++ b/internal/plugins/bundled/registry.json
@@ -113,12 +113,12 @@
     "name": "microsoft-azure",
     "title": "Microsoft Azure",
     "description": "Microsoft Entra ID / Azure AD authentication for Gantry login.",
-    "longDescription": "The Microsoft Azure plugin adds single sign-on to Gantry using Microsoft Entra ID (formerly Azure Active Directory). Configure an app registration, enable the plugin, and your team can sign in with their Microsoft work accounts instead of local passwords.\n\nThe plugin supports single-tenant or multi-tenant sign-in, optional auto-provisioning for first-time users, and role assignment for new SSO accounts.",
+    "longDescription": "The Microsoft Azure plugin adds single sign-on to Gantry using Microsoft Entra ID (formerly Azure Active Directory). Configure an app registration, enable the plugin, and your team can sign in with their Microsoft work accounts instead of local passwords.\n\nThe plugin supports single-tenant or multi-tenant sign-in, optional auto-provisioning for first-time users, and default access assignment for new SSO accounts using Gantry's built-in RBAC groups.",
     "features": [
       "Microsoft Entra ID / Azure AD OAuth 2.0 login",
       "Single-tenant or multi-tenant sign-in via configurable tenant ID",
       "Optional auto-provisioning for first-time SSO users",
-      "Default role assignment for auto-provisioned users",
+      "Default access assignment for auto-provisioned users",
       "Login page button and guided plugin configuration"
     ],
     "version": "1.0.0",
@@ -165,7 +165,7 @@
         "defaultRole": {
           "type": "string",
           "title": "Default SSO User Role",
-          "description": "Role assigned to auto-provisioned users who sign in via Microsoft Azure.",
+          "description": "Default access for auto-provisioned users who sign in via Microsoft Azure. Gantry maps built-in roles to the matching built-in RBAC groups when possible.",
           "enum": ["viewer", "developer", "admin"],
           "default": "viewer"
         }

--- a/internal/plugins/bundled/registry.json
+++ b/internal/plugins/bundled/registry.json
@@ -110,6 +110,71 @@
     "actionTypes": ["github-workflow-dispatch"]
   },
   {
+    "name": "microsoft-azure",
+    "title": "Microsoft Azure",
+    "description": "Microsoft Entra ID / Azure AD authentication for Gantry login.",
+    "longDescription": "The Microsoft Azure plugin adds single sign-on to Gantry using Microsoft Entra ID (formerly Azure Active Directory). Configure an app registration, enable the plugin, and your team can sign in with their Microsoft work accounts instead of local passwords.\n\nThe plugin supports single-tenant or multi-tenant sign-in, optional auto-provisioning for first-time users, and role assignment for new SSO accounts.",
+    "features": [
+      "Microsoft Entra ID / Azure AD OAuth 2.0 login",
+      "Single-tenant or multi-tenant sign-in via configurable tenant ID",
+      "Optional auto-provisioning for first-time SSO users",
+      "Default role assignment for auto-provisioned users",
+      "Login page button and guided plugin configuration"
+    ],
+    "version": "1.0.0",
+    "author": "Gantry",
+    "category": "auth-provider",
+    "homepage": "https://github.com/go2engle/gantry",
+    "configSchema": {
+      "type": "object",
+      "properties": {
+        "ssoEnabled": {
+          "type": "boolean",
+          "title": "Enable Microsoft Azure SSO",
+          "description": "Allow users to sign in to Gantry with Microsoft Entra ID / Azure AD."
+        },
+        "tenantId": {
+          "type": "string",
+          "title": "Tenant ID or Domain",
+          "description": "Use a specific tenant ID or verified domain to restrict sign-in, or `common` for multi-tenant login.",
+          "default": "common"
+        },
+        "clientId": {
+          "type": "string",
+          "title": "Application (client) ID",
+          "description": "Client ID from your Azure app registration. Required when SSO is enabled."
+        },
+        "clientSecret": {
+          "type": "string",
+          "title": "Client Secret",
+          "description": "Client secret from your Azure app registration. Required when SSO is enabled.",
+          "secret": true
+        },
+        "scopes": {
+          "type": "string",
+          "title": "OAuth Scopes",
+          "description": "Space-delimited scopes to request. Defaults to `openid profile email User.Read`.",
+          "default": "openid profile email User.Read"
+        },
+        "autoProvision": {
+          "type": "boolean",
+          "title": "Auto-Provision Users",
+          "description": "Automatically create Gantry accounts for first-time Azure SSO users.",
+          "default": false
+        },
+        "defaultRole": {
+          "type": "string",
+          "title": "Default SSO User Role",
+          "description": "Role assigned to auto-provisioned users who sign in via Microsoft Azure.",
+          "enum": ["viewer", "developer", "admin"],
+          "default": "viewer"
+        }
+      }
+    },
+    "entityPanels": [],
+    "actionTypes": []
+  },
+  {
     "name": "pagerduty",
     "title": "PagerDuty",
     "description": "On-call schedule panels for Services and Teams, plus incident management widgets.",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -145,6 +145,9 @@ export const api = {
   getGitHubSSOConfig: () =>
     request<{ ssoEnabled: boolean }>('GET', '/auth/github/config'),
 
+  getAzureSSOConfig: () =>
+    request<{ ssoEnabled: boolean }>('GET', '/auth/azure/config'),
+
   getGitHubRepo: (url: string) =>
     request<GitHubRepoInfo>('GET', `/plugins/github/repo?url=${encodeURIComponent(url)}`),
 

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -12,12 +12,17 @@ export default function Login() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const [ssoEnabled, setSsoEnabled] = useState(false);
+  const [gitHubSSOEnabled, setGitHubSSOEnabled] = useState(false);
+  const [azureSSOEnabled, setAzureSSOEnabled] = useState(false);
   const [appVersion, setAppVersion] = useState('');
 
   useEffect(() => {
     api.getGitHubSSOConfig()
-      .then((cfg) => setSsoEnabled(cfg.ssoEnabled))
+      .then((cfg) => setGitHubSSOEnabled(cfg.ssoEnabled))
+      .catch(() => {}); // SSO check is non-critical
+
+    api.getAzureSSOConfig()
+      .then((cfg) => setAzureSSOEnabled(cfg.ssoEnabled))
       .catch(() => {}); // SSO check is non-critical
 
     api.getVersion().then((v) => setAppVersion(v.version)).catch(() => {});
@@ -26,7 +31,7 @@ export default function Login() {
     const params = new URLSearchParams(window.location.search);
     const ssoError = params.get('error');
     if (ssoError === 'sso_not_authorized') {
-      setError('Your GitHub account is not authorized for Gantry. Ask an administrator to create your account first.');
+      setError('Your single sign-on account is not authorized for Gantry. Ask an administrator to create your account first.');
       window.history.replaceState({}, '', window.location.pathname);
     }
   }, []);
@@ -66,16 +71,28 @@ export default function Login() {
 
         {/* Login Card */}
         <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-6 shadow-sm">
-          {/* GitHub SSO button */}
-          {ssoEnabled && (
+          {(gitHubSSOEnabled || azureSSOEnabled) && (
             <>
-              <a
-                href={`/api/v1/auth/github?return_to=${encodeURIComponent(window.location.origin)}`}
-                className="flex w-full items-center justify-center gap-2 rounded-lg border border-[var(--gantry-border)] px-4 py-2.5 text-sm font-medium text-[var(--gantry-text-primary)] transition-colors hover:bg-[var(--gantry-bg-secondary)]"
-              >
-                <Github className="h-4 w-4" />
-                Sign in with GitHub
-              </a>
+              <div className="space-y-3">
+                {gitHubSSOEnabled && (
+                  <a
+                    href={`/api/v1/auth/github?return_to=${encodeURIComponent(window.location.origin)}`}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-[var(--gantry-border)] px-4 py-2.5 text-sm font-medium text-[var(--gantry-text-primary)] transition-colors hover:bg-[var(--gantry-bg-secondary)]"
+                  >
+                    <Github className="h-4 w-4" />
+                    Sign in with GitHub
+                  </a>
+                )}
+                {azureSSOEnabled && (
+                  <a
+                    href={`/api/v1/auth/azure?return_to=${encodeURIComponent(window.location.origin)}`}
+                    className="flex w-full items-center justify-center gap-2 rounded-lg border border-[var(--gantry-border)] px-4 py-2.5 text-sm font-medium text-[var(--gantry-text-primary)] transition-colors hover:bg-[var(--gantry-bg-secondary)]"
+                  >
+                    <span className="flex h-4 w-4 items-center justify-center rounded-sm border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] text-[10px] font-semibold text-[var(--gantry-text-primary)]">M</span>
+                    Sign in with Microsoft Azure
+                  </a>
+                )}
+              </div>
               <div className="my-4 flex items-center gap-3">
                 <div className="h-px flex-1 bg-[var(--gantry-border)]" />
                 <span className="text-xs text-[var(--gantry-text-secondary)]">or</span>

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -5,6 +5,17 @@ import { useTheme } from '../hooks/useTheme';
 import { api } from '../lib/api';
 import ThemeToggle from '../components/ThemeToggle';
 
+function MicrosoftLogo() {
+  return (
+    <span className="grid h-4 w-4 grid-cols-2 gap-[2px]" aria-hidden="true">
+      <span className="rounded-[1px] bg-[#f25022]" />
+      <span className="rounded-[1px] bg-[#7fba00]" />
+      <span className="rounded-[1px] bg-[#00a4ef]" />
+      <span className="rounded-[1px] bg-[#ffb900]" />
+    </span>
+  );
+}
+
 export default function Login() {
   const { login } = useAuth();
   const { theme } = useTheme();
@@ -88,7 +99,7 @@ export default function Login() {
                     href={`/api/v1/auth/azure?return_to=${encodeURIComponent(window.location.origin)}`}
                     className="flex w-full items-center justify-center gap-2 rounded-lg border border-[var(--gantry-border)] px-4 py-2.5 text-sm font-medium text-[var(--gantry-text-primary)] transition-colors hover:bg-[var(--gantry-bg-secondary)]"
                   >
-                    <span className="flex h-4 w-4 items-center justify-center rounded-sm border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] text-[10px] font-semibold text-[var(--gantry-text-primary)]">M</span>
+                    <MicrosoftLogo />
                     Sign in with Microsoft Azure
                   </a>
                 )}

--- a/web/src/pages/Plugins.tsx
+++ b/web/src/pages/Plugins.tsx
@@ -12,7 +12,7 @@ const SYNCABLE_PLUGINS = new Set(['kubernetes', 'github', 'argocd']);
 
 // Plugins with full backend + frontend implementations.
 // Anything not in this set is shown as "Coming Soon" and cannot be enabled.
-const IMPLEMENTED_PLUGINS = new Set(['github', 'kubernetes', 'argocd', 'status-monitor', 'gitops', 'teams', 'harbor', 'nexus-repository-manager', 'topology-explorer']);
+const IMPLEMENTED_PLUGINS = new Set(['github', 'microsoft-azure', 'kubernetes', 'argocd', 'status-monitor', 'gitops', 'teams', 'harbor', 'nexus-repository-manager', 'topology-explorer']);
 
 const CATEGORIES = [
   { id: 'all', label: 'All' },
@@ -122,6 +122,40 @@ const PLUGIN_SECTIONS: Record<string, Array<{
       },
     },
   ],
+  'microsoft-azure': [
+    {
+      title: 'Microsoft Azure SSO',
+      description: 'Let users sign in to Gantry with Microsoft Entra ID / Azure AD via OAuth 2.0 and Microsoft Graph.',
+      fields: ['ssoEnabled', 'tenantId', 'clientId', 'clientSecret', 'scopes', 'autoProvision', 'defaultRole'],
+      renderBanner: () => {
+        const origin = window.location.origin;
+        return (
+          <div className="rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-900/20 px-4 py-3 space-y-3">
+            <div className="flex items-start gap-2">
+              <span className="text-blue-500 text-base leading-none mt-0.5">ℹ</span>
+              <div>
+                <p className="text-sm font-medium text-blue-800 dark:text-blue-300">Azure app registration required</p>
+                <p className="text-xs text-blue-700 dark:text-blue-400 mt-0.5">
+                  Create an app registration in the Azure portal, add the Microsoft Graph <code>User.Read</code> delegated permission, and configure this redirect URI:
+                </p>
+              </div>
+            </div>
+            <div className="space-y-2 pl-6">
+              <div>
+                <p className="text-xs font-semibold text-blue-700 dark:text-blue-400 mb-0.5">Redirect URI</p>
+                <code className="block text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-900 dark:text-blue-200 font-mono px-2.5 py-1.5 rounded">
+                  {origin}/api/v1/auth/azure/callback
+                </code>
+              </div>
+              <p className="text-xs text-blue-700 dark:text-blue-400">
+                Use <code>common</code> as the tenant ID for multi-tenant sign-in, or set a specific tenant ID / domain to restrict access.
+              </p>
+            </div>
+          </div>
+        );
+      },
+    },
+  ],
   teams: [
     {
       title: 'Delivery',
@@ -154,6 +188,14 @@ const FIELD_VISIBILITY: Record<string, Record<string, VisibilityFn>> = {
     installationId:     (v) => v.authMode === 'app',
     oauthClientId:      (v) => !!v.ssoEnabled,
     oauthClientSecret:  (v) => !!v.ssoEnabled,
+    defaultRole:        (v) => !!v.ssoEnabled,
+  },
+  'microsoft-azure': {
+    tenantId:           (v) => !!v.ssoEnabled,
+    clientId:           (v) => !!v.ssoEnabled,
+    clientSecret:       (v) => !!v.ssoEnabled,
+    scopes:             (v) => !!v.ssoEnabled,
+    autoProvision:      (v) => !!v.ssoEnabled,
     defaultRole:        (v) => !!v.ssoEnabled,
   },
 };

--- a/web/src/pages/Plugins.tsx
+++ b/web/src/pages/Plugins.tsx
@@ -130,24 +130,24 @@ const PLUGIN_SECTIONS: Record<string, Array<{
       renderBanner: () => {
         const origin = window.location.origin;
         return (
-          <div className="rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-900/20 px-4 py-3 space-y-3">
+          <div className="rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-tertiary)] px-4 py-3 space-y-3">
             <div className="flex items-start gap-2">
-              <span className="text-blue-500 text-base leading-none mt-0.5">ℹ</span>
+              <span className="text-[var(--gantry-accent)] text-base leading-none mt-0.5">ℹ</span>
               <div>
-                <p className="text-sm font-medium text-blue-800 dark:text-blue-300">Azure app registration required</p>
-                <p className="text-xs text-blue-700 dark:text-blue-400 mt-0.5">
+                <p className="text-sm font-medium text-[var(--gantry-text-primary)]">Azure app registration required</p>
+                <p className="text-xs text-[var(--gantry-text-secondary)] mt-0.5">
                   Create an app registration in the Azure portal, add the Microsoft Graph <code>User.Read</code> delegated permission, and configure this redirect URI:
                 </p>
               </div>
             </div>
             <div className="space-y-2 pl-6">
               <div>
-                <p className="text-xs font-semibold text-blue-700 dark:text-blue-400 mb-0.5">Redirect URI</p>
-                <code className="block text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-900 dark:text-blue-200 font-mono px-2.5 py-1.5 rounded">
+                <p className="text-xs font-semibold text-[var(--gantry-text-primary)] mb-0.5">Redirect URI</p>
+                <code className="block text-xs bg-[var(--gantry-bg-secondary)] text-[var(--gantry-text-primary)] font-mono px-2.5 py-1.5 rounded border border-[var(--gantry-border)]">
                   {origin}/api/v1/auth/azure/callback
                 </code>
               </div>
-              <p className="text-xs text-blue-700 dark:text-blue-400">
+              <p className="text-xs text-[var(--gantry-text-secondary)]">
                 Use <code>common</code> as the tenant ID for multi-tenant sign-in, or set a specific tenant ID / domain to restrict access.
               </p>
             </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import type { APIKey } from '../lib/types';
 export default function Settings() {
   const { user, logout } = useAuth();
   const { theme, toggle } = useTheme();
+  const effectiveRole = user?.effectiveRole || user?.role || '';
 
   // API Keys
   const [apiKeys, setAPIKeys] = useState<APIKey[]>([]);
@@ -111,7 +112,7 @@ export default function Settings() {
               <dt className="text-sm text-[var(--gantry-text-secondary)]">Role</dt>
               <dd className="flex items-center gap-1.5 text-sm font-medium text-[var(--gantry-text-primary)]">
                 <Shield className="h-3.5 w-3.5 text-[var(--gantry-accent)]" />
-                {user?.role || '-'}
+                {effectiveRole || '-'}
               </dd>
             </div>
           </dl>


### PR DESCRIPTION
## Summary
- add a new `microsoft-azure` auth-provider plugin with Microsoft Entra ID / Azure AD OAuth support
- expose public Azure SSO auth endpoints and auto-provision/login handling on the backend
- add Azure SSO configuration guidance in the plugins UI and a Microsoft Azure login button

## Validation
- `npm run build` (from `web/`)
- `python3 -m json.tool internal/plugins/bundled/registry.json`
- `git diff --check`

Closes #69

@Go2Engle please review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft Azure SSO: new auth endpoints, full OAuth flow, public SSO config endpoint, and frontend “Sign in with Microsoft Azure” button
  * Admin UI: enable/configure Azure SSO (tenant, client ID/secret, scopes, auto-provision, default role) with validation and redirect URI guidance

* **Bug Fixes**
  * Improved email-based user lookup to detect/handle ambiguous matches and clearer SSO provider error reporting

* **Tests**
  * Added unit tests for Azure OAuth flow, ID token parsing, JWKS handling, and handler validation

* **Plugins**
  * Bundled Microsoft Azure auth plugin registry entry added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->