### PR TITLE
Update plugin config defaults and catalog visibility

### DIFF
--- a/web/src/components/AdminPluginSettings.tsx
+++ b/web/src/components/AdminPluginSettings.tsx
@@ -11,6 +11,7 @@ import {
   Slash,
 } from 'lucide-react';
 import { api, PLUGINS_UPDATED_EVENT } from '../lib/api';
+import { applySchemaDefaults } from '../lib/utils';
 import type { PluginConfig, PluginRegistryEntry, PluginSyncResult } from '../lib/types';
 import { PluginConfigForm, SYNCABLE_PLUGINS } from './PluginConfigForm';
 
@@ -216,7 +217,7 @@ export default function AdminPluginSettings() {
     try {
       const config = await api.getPluginConfig(name);
       setConfigs((prev) => ({ ...prev, [name]: config }));
-      setValues((prev) => ({ ...prev, [name]: config.values ?? {} }));
+      setValues((prev) => ({ ...prev, [name]: applySchemaDefaults(config.schema, config.values) }));
     } catch (e: any) {
       setLoadErrors((prev) => ({ ...prev, [name]: e.message }));
     } finally {

--- a/web/src/components/PluginConfigForm.tsx
+++ b/web/src/components/PluginConfigForm.tsx
@@ -361,6 +361,7 @@ function ConfigField({
   }
 
   if (isBool) {
+    const effectiveValue = value ?? fieldSchema.default ?? false;
     return (
       <div className="flex items-start justify-between gap-6 py-1">
         <div className="min-w-0 flex-1">
@@ -374,15 +375,15 @@ function ConfigField({
         <button
           type="button"
           role="switch"
-          aria-checked={!!value}
-          onClick={() => onChange(!value)}
+          aria-checked={!!effectiveValue}
+          onClick={() => onChange(!effectiveValue)}
           className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--gantry-accent)] focus:ring-offset-2 ${
-            value ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-border)]'
+            effectiveValue ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-border)]'
           }`}
         >
           <span
             className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform ${
-              value ? 'translate-x-[19px]' : 'translate-x-[3px]'
+              effectiveValue ? 'translate-x-[19px]' : 'translate-x-[3px]'
             }`}
           />
         </button>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
   LayoutDashboard,
@@ -30,7 +30,8 @@ import { useAuth } from '../hooks/useAuth';
 import { useTheme } from '../hooks/useTheme';
 import { api, PLUGINS_UPDATED_EVENT } from '../lib/api';
 import ThemeToggle from './ThemeToggle';
-import { ENTITY_KINDS } from '../lib/types';
+import { ENTITY_KINDS, filterEntityKindsByPlugins } from '../lib/types';
+import type { PluginRegistryEntry } from '../lib/types';
 
 const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   Server,
@@ -54,21 +55,6 @@ interface SidebarProps {
   onCloseMobile?: () => void;
 }
 
-const navItems: NavItem[] = [
-  { label: 'Dashboard', path: '/', icon: LayoutDashboard },
-  {
-    label: 'Catalog',
-    path: '/catalog',
-    icon: Box,
-    children: ENTITY_KINDS.map((k) => ({
-      label: k.name,
-      path: `/catalog/${k.name}`,
-      icon: iconMap[k.icon] || Box,
-    })),
-  },
-  { label: 'Actions', path: '/actions', icon: Zap },
-];
-
 export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [catalogOpen, setCatalogOpen] = useState(false);
@@ -78,6 +64,7 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
   const [topologyEnabled, setTopologyEnabled] = useState(false);
   const [flowEnabled, setFlowEnabled] = useState(false);
   const [nexusEnabled, setNexusEnabled] = useState(false);
+  const [plugins, setPlugins] = useState<PluginRegistryEntry[] | null>(null);
   const location = useLocation();
   const { user, logout } = useAuth();
   const { theme } = useTheme();
@@ -94,6 +81,7 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
       try {
         const plugins = await api.listPlugins();
         if (!active) return;
+        setPlugins(plugins);
 
         const statusMonitorPlugin = plugins.find((p) => p.name === 'status-monitor');
         setStatusMonitorEnabled(Boolean(statusMonitorPlugin?.enabled));
@@ -147,6 +135,7 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
         }
       } catch {
         if (!active) return;
+        setPlugins([]);
         setStatusMonitorEnabled(false);
         setGitopsEnabled(false);
         setHarborEnabled(false);
@@ -168,6 +157,26 @@ export default function Sidebar({ mobileOpen = false, onCloseMobile }: SidebarPr
       window.removeEventListener(PLUGINS_UPDATED_EVENT, handlePluginsUpdated);
     };
   }, []);
+
+  const catalogKinds = useMemo(
+    () => filterEntityKindsByPlugins(ENTITY_KINDS, plugins),
+    [plugins],
+  );
+
+  const navItems: NavItem[] = useMemo(() => ([
+    { label: 'Dashboard', path: '/', icon: LayoutDashboard },
+    {
+      label: 'Catalog',
+      path: '/catalog',
+      icon: Box,
+      children: catalogKinds.map((kind) => ({
+        label: kind.name,
+        path: `/catalog/${kind.name}`,
+        icon: iconMap[kind.icon] || Box,
+      })),
+    },
+    { label: 'Actions', path: '/actions', icon: Zap },
+  ]), [catalogKinds]);
 
   const isActive = (path: string) => {
     if (path === '/') return location.pathname === '/';

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -419,6 +419,21 @@ export const ENTITY_KINDS = [
 
 export type EntityKindName = (typeof ENTITY_KINDS)[number]['name'];
 
+export function filterEntityKindsByPlugins<T extends { name: string }>(
+  kinds: readonly T[],
+  plugins?: PluginRegistryEntry[] | null,
+): T[] {
+  if (!plugins) return [...kinds];
+
+  const hiddenKinds = new Set(
+    plugins
+      .filter((plugin) => plugin.category === 'entity-kind' && !plugin.enabled)
+      .flatMap((plugin) => plugin.entityPanels ?? []),
+  );
+
+  return kinds.filter((kind) => !hiddenKinds.has(kind.name));
+}
+
 // ─── Dashboard Config ──────────────────────────────────────────────────────
 
 export type DashboardSeverity = 'info' | 'warning' | 'danger';

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -208,6 +208,13 @@ export interface PluginRegistryEntry {
   category: 'integration' | 'widget' | 'entity-kind' | 'action-type' | 'auth-provider';
   iconUrl?: string;
   homepage?: string;
+  /**
+   * Entity kinds this plugin contributes panels for.
+   *
+   * For plugins where `category === 'entity-kind'`, `filterEntityKindsByPlugins`
+   * also treats `entityPanels` as the exact `ENTITY_KINDS` names provided by the
+   * plugin so disabled kinds can be hidden from catalog navigation.
+   */
   entityPanels?: string[];
   actionTypes?: string[];
   enabled: boolean;
@@ -419,6 +426,12 @@ export const ENTITY_KINDS = [
 
 export type EntityKindName = (typeof ENTITY_KINDS)[number]['name'];
 
+/**
+ * Filters `ENTITY_KINDS`-style lists based on disabled `PluginRegistryEntry`
+ * records. For `category === 'entity-kind'`, the plugin registry must list the
+ * exact kind names in `entityPanels` so hiding remains aligned with the kinds
+ * shown elsewhere in the catalog.
+ */
 export function filterEntityKindsByPlugins<T extends { name: string }>(
   kinds: readonly T[],
   plugins?: PluginRegistryEntry[] | null,

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -33,3 +33,20 @@ function pruneValue(value: any): any {
 
   return value;
 }
+
+export function applySchemaDefaults(
+  schema: Record<string, any> | undefined,
+  values?: Record<string, any> | null,
+): Record<string, any> {
+  const next = { ...(values ?? {}) };
+  const properties = schema?.properties ?? {};
+
+  for (const [key, fieldSchema] of Object.entries(properties)) {
+    if (next[key] !== undefined) continue;
+    if (fieldSchema && typeof fieldSchema === 'object' && 'default' in fieldSchema) {
+      next[key] = (fieldSchema as { default: any }).default;
+    }
+  }
+
+  return next;
+}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -38,15 +38,75 @@ export function applySchemaDefaults(
   schema: Record<string, any> | undefined,
   values?: Record<string, any> | null,
 ): Record<string, any> {
-  const next = { ...(values ?? {}) };
-  const properties = schema?.properties ?? {};
+  const applied = applyFieldSchemaDefaults(
+    { type: 'object', properties: schema?.properties ?? {} },
+    values ?? {},
+  );
 
-  for (const [key, fieldSchema] of Object.entries(properties)) {
-    if (next[key] !== undefined) continue;
-    if (fieldSchema && typeof fieldSchema === 'object' && 'default' in fieldSchema) {
-      next[key] = (fieldSchema as { default: any }).default;
-    }
+  if (!applied || typeof applied !== 'object' || Array.isArray(applied)) {
+    return {};
   }
 
-  return next;
+  return applied;
+}
+
+function applyFieldSchemaDefaults(fieldSchema: Record<string, any> | undefined, value: any): any {
+  if (!fieldSchema || typeof fieldSchema !== 'object') return value;
+
+  let nextValue = value;
+  if (nextValue === undefined && 'default' in fieldSchema) {
+    nextValue = cloneSchemaDefault(fieldSchema.default);
+  }
+
+  const hasProperties = !!fieldSchema.properties && typeof fieldSchema.properties === 'object';
+  if (hasProperties || fieldSchema.type === 'object') {
+    const properties = fieldSchema.properties ?? {};
+    const hasExplicitObjectValue = nextValue !== undefined;
+    const nextObject = nextValue && typeof nextValue === 'object' && !Array.isArray(nextValue)
+      ? { ...nextValue }
+      : {};
+    let shouldReturnObject = hasExplicitObjectValue;
+    for (const [key, childSchema] of Object.entries(properties)) {
+      const currentChild = nextObject[key];
+      const nextChild = applyFieldSchemaDefaults(childSchema as Record<string, any>, currentChild);
+      if (nextChild !== undefined) {
+        nextObject[key] = nextChild;
+        shouldReturnObject = true;
+      }
+    }
+
+    if (shouldReturnObject || Object.keys(nextObject).length > 0) {
+      return nextObject;
+    }
+    return nextValue;
+  }
+
+  if (Array.isArray(nextValue)) {
+    const itemSchema = fieldSchema.items && typeof fieldSchema.items === 'object'
+      ? fieldSchema.items as Record<string, any>
+      : undefined;
+    if (!itemSchema) return nextValue;
+    return nextValue.map((item) => applyFieldSchemaDefaults(itemSchema, item));
+  }
+
+  return nextValue;
+}
+
+function cloneSchemaDefault<T>(value: T): T {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(value);
+  }
+  return cloneSchemaDefaultFallback(value);
+}
+
+function cloneSchemaDefaultFallback<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => cloneSchemaDefaultFallback(entry)) as T;
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, cloneSchemaDefaultFallback(entry)]),
+    ) as T;
+  }
+  return value;
 }

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -125,7 +125,6 @@ export default function Catalog() {
 
     setCreateKind(fallbackCreateKind);
     if (showCreate) {
-      setShowCreate(false);
       setCreateStep('kind');
     }
   }, [plugins, visibleKinds, createKind, fallbackCreateKind, showCreate]);

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -98,6 +98,7 @@ export default function Catalog() {
     () => filterEntityKindsByPlugins(ENTITY_KINDS, plugins),
     [plugins],
   );
+  const kindsResolved = plugins !== null;
 
   useEffect(() => {
     if (!kind || plugins === null) return;
@@ -305,31 +306,35 @@ export default function Catalog() {
       </div>
 
       {/* Kind tabs */}
-      <div className="mt-4 flex gap-1 overflow-x-auto border-b border-[var(--gantry-border)]">
-        <button
-          onClick={() => navigate('/catalog')}
-          className={`whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-            !kind
-              ? 'border-[var(--gantry-accent)] text-[var(--gantry-accent)]'
-              : 'border-transparent text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]'
-          }`}
-        >
-          All
-        </button>
-        {visibleKinds.map((k) => (
+      {kindsResolved ? (
+        <div className="mt-4 flex gap-1 overflow-x-auto border-b border-[var(--gantry-border)]">
           <button
-            key={k.name}
-            onClick={() => navigate(`/catalog/${k.name}`)}
+            onClick={() => navigate('/catalog')}
             className={`whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-              kind === k.name
+              !kind
                 ? 'border-[var(--gantry-accent)] text-[var(--gantry-accent)]'
                 : 'border-transparent text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]'
             }`}
           >
-            {k.name}
+            All
           </button>
-        ))}
-      </div>
+          {visibleKinds.map((k) => (
+            <button
+              key={k.name}
+              onClick={() => navigate(`/catalog/${k.name}`)}
+              className={`whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                kind === k.name
+                  ? 'border-[var(--gantry-accent)] text-[var(--gantry-accent)]'
+                  : 'border-transparent text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]'
+              }`}
+            >
+              {k.name}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-4 h-10 animate-pulse rounded-lg bg-[var(--gantry-bg-secondary)]" />
+      )}
 
       {/* Error */}
       {error && (
@@ -412,33 +417,41 @@ export default function Catalog() {
             {/* Step 1: Kind picker */}
             {createStep === 'kind' && (
               <div className="flex-1 overflow-y-auto p-6">
-                <p className="mb-6 text-sm text-[var(--gantry-text-secondary)]">
-                  Select the type of entity you want to add to the catalog.
-                </p>
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  {visibleKinds.map((k) => {
-                    const meta = KIND_META[k.name];
-                    return (
-                      <button
-                        key={k.name}
-                        onClick={() => { setCreateKind(k.name); setCreateStep('form'); }}
-                        className="group flex items-start gap-4 rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] p-4 text-left transition-all hover:border-[var(--gantry-accent)] hover:shadow-md"
-                      >
-                        <div className={`mt-0.5 shrink-0 ${meta?.color ?? 'text-[var(--gantry-accent)]'}`}>
-                          {meta?.icon}
-                        </div>
-                        <div className="min-w-0">
-                          <div className="font-semibold text-[var(--gantry-text-primary)] group-hover:text-[var(--gantry-accent)]">
-                            {k.name}
-                          </div>
-                          <div className="mt-1 text-xs leading-relaxed text-[var(--gantry-text-secondary)]">
-                            {meta?.description}
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
+                {kindsResolved ? (
+                  <>
+                    <p className="mb-6 text-sm text-[var(--gantry-text-secondary)]">
+                      Select the type of entity you want to add to the catalog.
+                    </p>
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                      {visibleKinds.map((k) => {
+                        const meta = KIND_META[k.name];
+                        return (
+                          <button
+                            key={k.name}
+                            onClick={() => { setCreateKind(k.name); setCreateStep('form'); }}
+                            className="group flex items-start gap-4 rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] p-4 text-left transition-all hover:border-[var(--gantry-accent)] hover:shadow-md"
+                          >
+                            <div className={`mt-0.5 shrink-0 ${meta?.color ?? 'text-[var(--gantry-accent)]'}`}>
+                              {meta?.icon}
+                            </div>
+                            <div className="min-w-0">
+                              <div className="font-semibold text-[var(--gantry-text-primary)] group-hover:text-[var(--gantry-accent)]">
+                                {k.name}
+                              </div>
+                              <div className="mt-1 text-xs leading-relaxed text-[var(--gantry-text-secondary)]">
+                                {meta?.description}
+                              </div>
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex h-full min-h-48 items-center justify-center">
+                    <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--gantry-accent)] border-t-transparent" />
+                  </div>
+                )}
               </div>
             )}
 

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -77,7 +77,15 @@ export default function Catalog() {
 
   useEffect(() => {
     const refreshPlugins = () => {
-      api.listPlugins().then((data) => setPlugins(data || [])).catch(() => setPlugins([]));
+      api.listPlugins()
+        .then((data) => {
+          if (data != null) {
+            setPlugins(data);
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to refresh plugin registry for catalog', err);
+        });
     };
 
     api.listSchemas().then((data) => setSchemas(data || {})).catch(() => {});
@@ -99,6 +107,7 @@ export default function Catalog() {
     [plugins],
   );
   const kindsResolved = plugins !== null;
+  const fallbackCreateKind = visibleKinds[0]?.name ?? 'Service';
 
   useEffect(() => {
     if (!kind || plugins === null) return;
@@ -108,6 +117,18 @@ export default function Catalog() {
       navigate('/catalog', { replace: true });
     }
   }, [kind, navigate, plugins, visibleKinds]);
+
+  useEffect(() => {
+    if (plugins === null) return;
+    const createKindIsVisible = visibleKinds.some((entityKind) => entityKind.name === createKind);
+    if (createKindIsVisible) return;
+
+    setCreateKind(fallbackCreateKind);
+    if (showCreate) {
+      setShowCreate(false);
+      setCreateStep('kind');
+    }
+  }, [plugins, visibleKinds, createKind, fallbackCreateKind, showCreate]);
 
   const allOwners = useMemo(() => {
     const owners = new Set(entities.map((e) => e.metadata.owner).filter(Boolean) as string[]);
@@ -139,6 +160,9 @@ export default function Catalog() {
   const hasFilters = searchQuery || ownerFilter || tagFilter;
 
   const openCreate = () => {
+    if (!visibleKinds.some((entityKind) => entityKind.name === createKind)) {
+      setCreateKind(fallbackCreateKind);
+    }
     setCreateStep('kind');
     setShowCreate(true);
   };
@@ -150,6 +174,13 @@ export default function Catalog() {
 
   const handleCreate = async (raw: Record<string, any>) => {
     try {
+      if (!visibleKinds.some((entityKind) => entityKind.name === createKind)) {
+        setError('The selected entity kind is no longer available. Please choose a kind again.');
+        setCreateKind(fallbackCreateKind);
+        closeCreate();
+        return;
+      }
+
       const name = (raw._name as string) || '';
       const title = (raw._title as string) || '';
       const owner = (raw._owner as string) || '';

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -5,10 +5,10 @@ import {
   Search, LayoutGrid, List, Plus, X, ArrowLeft,
   Server, Globe, Database, Users, Cloud, FileText, Network,
 } from 'lucide-react';
-import { api } from '../lib/api';
-import { ENTITY_KINDS } from '../lib/types';
+import { api, PLUGINS_UPDATED_EVENT } from '../lib/api';
+import { ENTITY_KINDS, filterEntityKindsByPlugins } from '../lib/types';
 import { pruneEmpty } from '../lib/utils';
-import type { Entity, JsonSchema } from '../lib/types';
+import type { Entity, JsonSchema, PluginRegistryEntry } from '../lib/types';
 import EntityCard from '../components/EntityCard';
 import EntityTable from '../components/EntityTable';
 import SchemaForm from '../components/SchemaForm';
@@ -67,7 +67,7 @@ export default function Catalog() {
   const [createKind, setCreateKind] = useState('Service');
   const [schemas, setSchemas] = useState<Record<string, JsonSchema>>({});
   const [error, setError] = useState('');
-  const [enabledPlugins, setEnabledPlugins] = useState<Set<string>>(new Set());
+  const [plugins, setPlugins] = useState<PluginRegistryEntry[] | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -76,9 +76,37 @@ export default function Catalog() {
   }, [kind]);
 
   useEffect(() => {
+    const refreshPlugins = () => {
+      api.listPlugins().then((data) => setPlugins(data || [])).catch(() => setPlugins([]));
+    };
+
     api.listSchemas().then((data) => setSchemas(data || {})).catch(() => {});
-    api.listPlugins().then((plugins) => setEnabledPlugins(new Set(plugins.filter((p) => p.enabled).map((p) => p.name)))).catch(() => {});
+    refreshPlugins();
+    window.addEventListener(PLUGINS_UPDATED_EVENT, refreshPlugins);
+
+    return () => {
+      window.removeEventListener(PLUGINS_UPDATED_EVENT, refreshPlugins);
+    };
   }, []);
+
+  const enabledPlugins = useMemo(
+    () => new Set((plugins || []).filter((plugin) => plugin.enabled).map((plugin) => plugin.name)),
+    [plugins],
+  );
+
+  const visibleKinds = useMemo(
+    () => filterEntityKindsByPlugins(ENTITY_KINDS, plugins),
+    [plugins],
+  );
+
+  useEffect(() => {
+    if (!kind || plugins === null) return;
+    const isCatalogKind = ENTITY_KINDS.some((entityKind) => entityKind.name === kind);
+    const isVisibleKind = visibleKinds.some((entityKind) => entityKind.name === kind);
+    if (isCatalogKind && !isVisibleKind) {
+      navigate('/catalog', { replace: true });
+    }
+  }, [kind, navigate, plugins, visibleKinds]);
 
   const allOwners = useMemo(() => {
     const owners = new Set(entities.map((e) => e.metadata.owner).filter(Boolean) as string[]);
@@ -288,7 +316,7 @@ export default function Catalog() {
         >
           All
         </button>
-        {ENTITY_KINDS.map((k) => (
+        {visibleKinds.map((k) => (
           <button
             key={k.name}
             onClick={() => navigate(`/catalog/${k.name}`)}
@@ -388,7 +416,7 @@ export default function Catalog() {
                   Select the type of entity you want to add to the catalog.
                 </p>
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  {ENTITY_KINDS.map((k) => {
+                  {visibleKinds.map((k) => {
                     const meta = KIND_META[k.name];
                     return (
                       <button

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -13,41 +13,49 @@ import EntityCard from '../components/EntityCard';
 import EntityTable from '../components/EntityTable';
 import SchemaForm from '../components/SchemaForm';
 
-const KIND_META: Record<string, { icon: React.ReactNode; description: string; color: string }> = {
+const KIND_COLOR_CLASSES = {
+  accent: 'text-[var(--gantry-accent)]',
+  accentHover: 'text-[var(--gantry-accent-hover)]',
+  textPrimary: 'text-[var(--gantry-text-primary)]',
+  textSecondary: 'text-[var(--gantry-text-secondary)]',
+  danger: 'text-[var(--gantry-danger)]',
+} as const;
+
+const KIND_META: Record<string, { icon: React.ReactNode; description: string; colorClass: string }> = {
   Service: {
     icon: <Server className="h-7 w-7" />,
     description: 'A deployable unit of software — microservice, monolith, or serverless function.',
-    color: 'text-blue-500',
+    colorClass: KIND_COLOR_CLASSES.accent,
   },
   API: {
     icon: <Globe className="h-7 w-7" />,
     description: 'An interface that services expose — REST, GraphQL, gRPC, or event stream.',
-    color: 'text-purple-500',
+    colorClass: KIND_COLOR_CLASSES.accentHover,
   },
   Infrastructure: {
     icon: <Database className="h-7 w-7" />,
     description: 'Cloud resources — databases, queues, storage, and other infrastructure.',
-    color: 'text-orange-500',
+    colorClass: KIND_COLOR_CLASSES.textPrimary,
   },
   Team: {
     icon: <Users className="h-7 w-7" />,
     description: 'A group of people who own and maintain services and resources.',
-    color: 'text-green-500',
+    colorClass: KIND_COLOR_CLASSES.textSecondary,
   },
   Environment: {
     icon: <Cloud className="h-7 w-7" />,
     description: 'A deployment target — production, staging, development, or preview.',
-    color: 'text-cyan-500',
+    colorClass: KIND_COLOR_CLASSES.accentHover,
   },
   Documentation: {
     icon: <FileText className="h-7 w-7" />,
     description: 'Technical docs, runbooks, ADRs, and knowledge base articles.',
-    color: 'text-yellow-500',
+    colorClass: KIND_COLOR_CLASSES.textSecondary,
   },
   Flow: {
     icon: <Network className="h-7 w-7" />,
     description: 'Editable system flow diagrams backed by real catalog entities and GitOps-friendly YAML.',
-    color: 'text-[var(--gantry-accent)]',
+    colorClass: KIND_COLOR_CLASSES.accent,
   },
 };
 
@@ -106,6 +114,10 @@ export default function Catalog() {
     () => filterEntityKindsByPlugins(ENTITY_KINDS, plugins),
     [plugins],
   );
+  const visibleKindNames = useMemo(
+    () => new Set<string>(visibleKinds.map((entityKind) => entityKind.name)),
+    [visibleKinds],
+  );
   const kindsResolved = plugins !== null;
   const fallbackCreateKind = visibleKinds[0]?.name ?? 'Service';
 
@@ -141,6 +153,7 @@ export default function Catalog() {
 
   const filtered = useMemo(() => {
     return entities.filter((e) => {
+      if (!visibleKindNames.has(e.kind)) return false;
       if (ownerFilter && e.metadata.owner !== ownerFilter) return false;
       if (tagFilter && !(e.metadata.tags || []).includes(tagFilter)) return false;
       if (searchQuery) {
@@ -154,7 +167,7 @@ export default function Catalog() {
       }
       return true;
     });
-  }, [entities, searchQuery, ownerFilter, tagFilter]);
+  }, [entities, searchQuery, ownerFilter, tagFilter, visibleKindNames]);
 
   const hasFilters = searchQuery || ownerFilter || tagFilter;
 
@@ -176,7 +189,7 @@ export default function Catalog() {
       if (!visibleKinds.some((entityKind) => entityKind.name === createKind)) {
         setError('The selected entity kind is no longer available. Please choose a kind again.');
         setCreateKind(fallbackCreateKind);
-        closeCreate();
+        setCreateStep('kind');
         return;
       }
 
@@ -461,7 +474,7 @@ export default function Catalog() {
                             onClick={() => { setCreateKind(k.name); setCreateStep('form'); }}
                             className="group flex items-start gap-4 rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] p-4 text-left transition-all hover:border-[var(--gantry-accent)] hover:shadow-md"
                           >
-                            <div className={`mt-0.5 shrink-0 ${meta?.color ?? 'text-[var(--gantry-accent)]'}`}>
+                            <div className={`mt-0.5 shrink-0 ${meta?.colorClass ?? KIND_COLOR_CLASSES.accent}`}>
                               {meta?.icon}
                             </div>
                             <div className="min-w-0">
@@ -490,7 +503,7 @@ export default function Catalog() {
               <div className="flex-1 overflow-y-auto p-6">
                 {/* Kind badge */}
                 <div className="mb-6 flex items-center gap-3 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-4 py-3">
-                  <div className={`shrink-0 ${KIND_META[createKind]?.color ?? 'text-[var(--gantry-accent)]'}`}>
+                  <div className={`shrink-0 ${KIND_META[createKind]?.colorClass ?? KIND_COLOR_CLASSES.accent}`}>
                     {KIND_META[createKind]?.icon}
                   </div>
                   <div>

--- a/web/src/pages/Plugins.tsx
+++ b/web/src/pages/Plugins.tsx
@@ -798,15 +798,27 @@ function PluginDetailModal({
   // Sync initialTab if it changes (e.g. when parent reopens with different tab)
   useEffect(() => { setTab(initialTab); }, [initialTab]);
 
+  useEffect(() => {
+    setConfig(null);
+    setValues({});
+    setSaveError(null);
+  }, [plugin.name]);
+
   // Load config whenever we switch to config tab
   useEffect(() => {
+    let isActive = true;
+    const pluginName = plugin.name;
     if (tab !== 'config') return;
     if (config) return; // already loaded
-    api.getPluginConfig(plugin.name).then((c) => {
+    api.getPluginConfig(pluginName).then((c) => {
+      if (!isActive) return;
       setConfig(c);
       setValues(applySchemaDefaults(c.schema, c.values));
     }).catch(() => {});
-  }, [tab, plugin.name]);
+    return () => {
+      isActive = false;
+    };
+  }, [tab, plugin.name, config]);
 
   async function handleSave() {
     setSaving(true);

--- a/web/src/pages/Plugins.tsx
+++ b/web/src/pages/Plugins.tsx
@@ -5,6 +5,7 @@ import {
   BookOpen, Zap, Layers, CheckSquare, GripVertical,
 } from 'lucide-react';
 import { api } from '../lib/api';
+import { applySchemaDefaults } from '../lib/utils';
 import type { PluginRegistryEntry, PluginConfig, PluginSyncResult, Role } from '../lib/types';
 
 // Plugins that expose a server-side sync operation.
@@ -411,6 +412,7 @@ function ConfigField({
   }
 
   if (isBool) {
+    const effectiveValue = value ?? fieldSchema.default ?? false;
     return (
       <div className="flex items-start justify-between gap-6 py-1">
         <div className="flex-1 min-w-0">
@@ -424,15 +426,15 @@ function ConfigField({
         <button
           type="button"
           role="switch"
-          aria-checked={!!value}
-          onClick={() => onChange(!value)}
+          aria-checked={!!effectiveValue}
+          onClick={() => onChange(!effectiveValue)}
           className={`relative flex-shrink-0 mt-0.5 inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--gantry-accent)] focus:ring-offset-2 ${
-            value ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-border)]'
+            effectiveValue ? 'bg-[var(--gantry-accent)]' : 'bg-[var(--gantry-border)]'
           }`}
         >
           <span
             className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform ${
-              value ? 'translate-x-[19px]' : 'translate-x-[3px]'
+              effectiveValue ? 'translate-x-[19px]' : 'translate-x-[3px]'
             }`}
           />
         </button>
@@ -802,7 +804,7 @@ function PluginDetailModal({
     if (config) return; // already loaded
     api.getPluginConfig(plugin.name).then((c) => {
       setConfig(c);
-      setValues(c.values ?? {});
+      setValues(applySchemaDefaults(c.schema, c.values));
     }).catch(() => {});
   }, [tab, plugin.name]);
 


### PR DESCRIPTION
## Summary
- Hide catalog kinds backed by disabled entity-kind plugins, including Flow, until the plugin is enabled.
- Hydrate plugin config forms from schema defaults so boolean toggles reflect their intended initial state.
- Keep the Flow sidebar and plugin settings UI consistent when the plugin is enabled for the first time.

## Testing
- `npx tsc --noEmit` in `web/`
- Verified the updated catalog and plugin settings flows in the UI path by inspection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin settings and boolean toggles now reflect schema-defined defaults when unset.
  * Plugin config modal resets when switching plugins and avoids applying stale load results.
  * Plugin fetch failures no longer cause incorrect catalog visibility or unexpected UI state.

* **New Features**
  * Catalog and sidebar now dynamically update visible entity types based on loaded plugins.
  * Kind tabs/picker show a loading state until plugins resolve; creation flow validates and adjusts when kinds become unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->