### PR TITLE
feat: support health check URLs on infrastructure entities

### DIFF
--- a/internal/entity/schemas/infrastructure.json
+++ b/internal/entity/schemas/infrastructure.json
@@ -22,6 +22,11 @@
       "type": "string",
       "description": "Connection string or endpoint for the infrastructure resource"
     },
+    "healthCheckUrl": {
+      "type": "string",
+      "title": "Health Check URL",
+      "description": "URL to the infrastructure health endpoint (e.g., https://postgres.example.com/healthz)"
+    },
     "system": {
       "type": "string",
       "description": "Parent system or domain"

--- a/internal/entity/validation_test.go
+++ b/internal/entity/validation_test.go
@@ -1,0 +1,36 @@
+package entity
+
+import "testing"
+
+func TestSchemaValidatorAllowsHealthCheckURLForAPIAndInfrastructure(t *testing.T) {
+	validator, err := NewSchemaValidator("")
+	if err != nil {
+		t.Fatalf("NewSchemaValidator() error = %v", err)
+	}
+
+	tests := []struct {
+		name string
+		kind string
+	}{
+		{name: "api", kind: "API"},
+		{name: "infrastructure", kind: "Infrastructure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Entity{
+				Kind: tt.kind,
+				Metadata: EntityMetadata{
+					Name: "payments-health",
+				},
+				Spec: map[string]any{
+					"healthCheckUrl": "https://example.com/healthz",
+				},
+			}
+
+			if err := validator.Validate(e); err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `spec.healthCheckUrl` to the Infrastructure schema so infra entities can store health endpoints like Services and APIs
- add schema validation coverage for both API and Infrastructure health check URLs
- note that API entities already supported `healthCheckUrl`, so this closes the remaining gap from the issue request

## Validation
- `python3 -m json.tool internal/entity/schemas/infrastructure.json`
- `git diff --check`
- `go test ./internal/entity/...` *(blocked in this runner: `go` binary is not installed)*

Closes #81

@go2engle please review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Infrastructure and API configurations now support optional health check URL settings. Users can specify custom health check endpoints for their deployments, enabling flexible health monitoring configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->