### PR TITLE
Fix: mcp bug

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go2engle/gantry/internal/api/handlers"
 	"github.com/go2engle/gantry/internal/entity"
+	"github.com/go2engle/gantry/internal/search"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -43,7 +44,11 @@ func registerTools(srv *mcpsdk.Server, h *handlers.Handlers) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("search failed: %w", err)
 		}
-		return jsonResult(results)
+		if results == nil {
+			results = []*search.Result{}
+		}
+		// MCP structuredContent must be an object, not an array — wrap the slice.
+		return jsonResult(map[string]any{"results": results, "count": len(results)})
 	})
 
 	mcpsdk.AddTool(srv, &mcpsdk.Tool{
@@ -73,7 +78,8 @@ func registerTools(srv *mcpsdk.Server, h *handlers.Handlers) {
 			return nil, nil, fmt.Errorf("list entities failed: %w", err)
 		}
 		filtered := filterEntities(entities, in.Owner, in.Tag)
-		return jsonResult(filtered)
+		// MCP structuredContent must be an object, not an array — wrap the slice.
+		return jsonResult(map[string]any{"entities": filtered, "count": len(filtered)})
 	})
 
 	mcpsdk.AddTool(srv, &mcpsdk.Tool{


### PR DESCRIPTION
This pull request introduces support for the Model Context Protocol (MCP) in Gantry, allowing local AI agents (such as Claude Code and Cursor) to query the Gantry catalog directly via a new HTTP endpoint. The implementation includes server-side support, tool registration, documentation, and necessary dependency and configuration updates.

**Key changes:**

### MCP Protocol Support

* Added a new MCP server under `/api/v1/mcp` that exposes Gantry's catalog via Streamable HTTP, enabling AI agents to perform full-text search, retrieve entity details, list entities with filters, and fetch relationship graphs. The server is authenticated and uses the same API keys as other Gantry endpoints. (`internal/mcp/server.go` [[1]](diffhunk://#diff-bd1206cc7c35c535055e67843535907d782276f8de2fc949a9357b85f53ab466R1-R29) `internal/api/server.go` [[2]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R170-R176)
* Registered MCP tools: `search`, `get_entity`, `list_entities`, and `get_graph`, each mapped to existing Gantry services for catalog access. (`internal/mcp/tools.go` [internal/mcp/tools.goR1-R126](diffhunk://#diff-7c0d527ba4a221ad07c68fbba6d86758d527c2332590fa5758195e17ba3075a0R1-R126))

### API and CORS Adjustments

* Updated CORS settings to allow MCP-specific headers (`Mcp-Session-Id`, `MCP-Protocol-Version`) for cross-origin agent connections. (`internal/api/server.go` [internal/api/server.goL52-R63](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093L52-R63))

### Documentation

* Added comprehensive documentation for the new MCP endpoint, including usage, configuration guides for Claude Code and other clients, tool descriptions, and troubleshooting tips. (`website/docs/docs/api/mcp.md` [website/docs/docs/api/mcp.mdR1-R154](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3R1-R154))
* Updated the docs sidebar to include the new MCP documentation page. (`website/docs/sidebars.js` [website/docs/sidebars.jsR41](diffhunk://#diff-ea240d693ec49f75399dbbda35504d95150ebd65ebbae17f1c5e29ec87b11d51R41))

### Dependency and Build Updates

* Upgraded Go version to 1.25 across the build pipeline, Dockerfile, and `go.mod`. (`.github/workflows/ci.yml` [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL21-R21) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL39-R39) `.github/workflows/release.yml` [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35-R35) `Dockerfile` [[4]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10-R10) `go.mod` [[5]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R16)
* Updated and added dependencies to support MCP, including `github.com/modelcontextprotocol/go-sdk`, and bumped several other libraries to latest versions. (`go.mod` [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R16) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R32) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R42-R53)

---

**References:**  
[[1]](diffhunk://#diff-bd1206cc7c35c535055e67843535907d782276f8de2fc949a9357b85f53ab466R1-R29) [[2]](diffhunk://#diff-7c0d527ba4a221ad07c68fbba6d86758d527c2332590fa5758195e17ba3075a0R1-R126) [[3]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R170-R176) [[4]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093L52-R63) [[5]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3R1-R154) [[6]](diffhunk://#diff-ea240d693ec49f75399dbbda35504d95150ebd65ebbae17f1c5e29ec87b11d51R41) [[7]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL21-R21) [[8]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL39-R39) [[9]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35-R35) [[10]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10-R10) [[11]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R16) [[12]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R32) [[13]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R42-R53)