### PR TITLE
feat: add write tools for entity management in MCP

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -96,6 +96,8 @@ func registerTools(srv *mcpsdk.Server, h *handlers.Handlers) {
 		}
 		return jsonResult(graph)
 	})
+
+	registerWriteTools(srv, h)
 }
 
 func filterEntities(entities []*entity.Entity, owner, tag string) []*entity.Entity {

--- a/internal/mcp/write_tools.go
+++ b/internal/mcp/write_tools.go
@@ -1,0 +1,180 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go2engle/gantry/internal/api/handlers"
+	"github.com/go2engle/gantry/internal/api/middleware"
+	"github.com/go2engle/gantry/internal/auth"
+	"github.com/go2engle/gantry/internal/db"
+	"github.com/go2engle/gantry/internal/entity"
+	"github.com/go2engle/gantry/internal/events"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type listSchemasInput struct{}
+
+type getSchemaInput struct {
+	Kind string `json:"kind" jsonschema:"entity kind, e.g. Service, API, Team, Infrastructure"`
+}
+
+type createEntityInput struct {
+	Entity entity.Entity `json:"entity" jsonschema:"the entity to create; must have kind, metadata.name, and valid spec per the kind's schema (call get_schema first to learn the allowed fields)"`
+}
+
+type updateEntityInput struct {
+	Entity entity.Entity `json:"entity" jsonschema:"the updated entity; must have kind, metadata.name matching an existing entity, and valid spec per the kind's schema"`
+}
+
+func registerWriteTools(srv *mcpsdk.Server, h *handlers.Handlers) {
+	mcpsdk.AddTool(srv, &mcpsdk.Tool{
+		Name:        "list_schemas",
+		Description: "List all entity kinds with their JSON Schemas. Use this to discover what kinds of entities exist in this Gantry instance and what fields each accepts. Call this before `create_entity` or `update_entity` if you need to know the spec fields for a specific kind.",
+	}, func(_ context.Context, _ *mcpsdk.CallToolRequest, _ listSchemasInput) (*mcpsdk.CallToolResult, any, error) {
+		schemas := h.Validator.ListSchemas()
+		return jsonResult(map[string]any{"schemas": schemas, "count": len(schemas)})
+	})
+
+	mcpsdk.AddTool(srv, &mcpsdk.Tool{
+		Name:        "get_schema",
+		Description: "Return the JSON Schema for a specific entity kind. Call this before `create_entity` or `update_entity` to learn which `metadata` and `spec` fields that kind accepts and what values are valid. All built-in schemas set additionalProperties:false, so unknown fields will be rejected at write time.",
+	}, func(_ context.Context, _ *mcpsdk.CallToolRequest, in getSchemaInput) (*mcpsdk.CallToolResult, any, error) {
+		raw, err := h.Validator.GetSchema(in.Kind)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get schema: %w", err)
+		}
+		return jsonResult(map[string]any{"kind": in.Kind, "schema": raw})
+	})
+
+	mcpsdk.AddTool(srv, &mcpsdk.Tool{
+		Name:        "create_entity",
+		Description: "Create a new entity in the Gantry catalog. Before calling this, call `get_schema` (or `list_schemas`) to learn which `metadata` and `spec` fields the kind accepts — spec is free-form JSON and the validator rejects unknown fields. Requires developer role or higher. On success, GitOps sync is triggered automatically (if enabled) and an audit entry is written. Returns the created entity with server-set defaults (timestamps, createdBy).",
+	}, func(ctx context.Context, _ *mcpsdk.CallToolRequest, in createEntityInput) (*mcpsdk.CallToolResult, any, error) {
+		if err := requireDeveloperRole(ctx); err != nil {
+			return nil, nil, err
+		}
+		if strings.EqualFold(in.Entity.Kind, "Flow") {
+			return nil, nil, errors.New("Flow entities must be created via the REST API due to plugin-specific access rules")
+		}
+
+		e := in.Entity
+		e.SetDefaults()
+
+		claims := middleware.GetClaims(ctx)
+		if claims != nil {
+			e.Metadata.CreatedBy = claims.Username
+		}
+
+		if err := h.Validator.Validate(&e); err != nil {
+			return nil, nil, fmt.Errorf("validation failed: %w", err)
+		}
+
+		if err := h.DB.CreateEntity(ctx, &e); err != nil {
+			if errors.Is(err, entity.ErrEntityAlreadyExists) {
+				return nil, nil, fmt.Errorf("entity %s/%s already exists in namespace %q", e.Kind, e.Metadata.Name, e.Metadata.Namespace)
+			}
+			return nil, nil, fmt.Errorf("create entity: %w", err)
+		}
+
+		h.Events.Publish(events.Event{
+			Type: events.EntityCreated,
+			Data: map[string]any{
+				"kind":      e.Kind,
+				"name":      e.Metadata.Name,
+				"namespace": e.Metadata.Namespace,
+			},
+		})
+
+		writeMCPAuditEntry(ctx, h, claims, "entity.created", &e, "", marshalEntityStateJSON(&e))
+
+		return jsonResult(map[string]any{"entity": e, "created": true})
+	})
+
+	mcpsdk.AddTool(srv, &mcpsdk.Tool{
+		Name:        "update_entity",
+		Description: "Update an existing entity. Before calling this, call `get_entity` to see the current state and `get_schema` to confirm which fields are valid for the kind. Requires developer role or higher. The entity is validated before the DB write. On success, GitOps sync is triggered automatically (if enabled). Returns the updated entity.",
+	}, func(ctx context.Context, _ *mcpsdk.CallToolRequest, in updateEntityInput) (*mcpsdk.CallToolResult, any, error) {
+		if err := requireDeveloperRole(ctx); err != nil {
+			return nil, nil, err
+		}
+		if strings.EqualFold(in.Entity.Kind, "Flow") {
+			return nil, nil, errors.New("Flow entities must be updated via the REST API due to plugin-specific access rules")
+		}
+
+		e := in.Entity
+		e.SetDefaults()
+
+		if err := h.Validator.Validate(&e); err != nil {
+			return nil, nil, fmt.Errorf("validation failed: %w", err)
+		}
+
+		ns := e.Metadata.Namespace
+		if ns == "" {
+			ns = entity.DefaultNamespace
+		}
+		var beforeState string
+		if prev, err := h.DB.GetEntity(ctx, e.Kind, ns, e.Metadata.Name); err == nil {
+			beforeState = marshalEntityStateJSON(prev)
+		}
+
+		if err := h.DB.UpdateEntity(ctx, &e); err != nil {
+			if errors.Is(err, entity.ErrEntityNotFound) {
+				return nil, nil, fmt.Errorf("entity %s/%s not found in namespace %q", e.Kind, e.Metadata.Name, ns)
+			}
+			return nil, nil, fmt.Errorf("update entity: %w", err)
+		}
+
+		h.Events.Publish(events.Event{
+			Type: events.EntityUpdated,
+			Data: map[string]any{
+				"kind":      e.Kind,
+				"name":      e.Metadata.Name,
+				"namespace": e.Metadata.Namespace,
+			},
+		})
+
+		claims := middleware.GetClaims(ctx)
+		writeMCPAuditEntry(ctx, h, claims, "entity.updated", &e, beforeState, marshalEntityStateJSON(&e))
+
+		return jsonResult(map[string]any{"entity": e, "updated": true})
+	})
+}
+
+func requireDeveloperRole(ctx context.Context) error {
+	role := middleware.GetEffectiveRole(ctx)
+	if auth.RoleLevel(role) < auth.RoleLevel("developer") {
+		return fmt.Errorf("this tool requires developer role or higher; current effective role: %q", role)
+	}
+	return nil
+}
+
+func writeMCPAuditEntry(ctx context.Context, h *handlers.Handlers, claims *auth.Claims, action string, e *entity.Entity, before, after string) {
+	userName := ""
+	userID := ""
+	if claims != nil {
+		userName = claims.Username
+		userID = claims.UserID
+	}
+	_ = h.DB.CreateAuditEntry(ctx, &db.AuditEntry{
+		UserID:       userID,
+		UserName:     userName,
+		Action:       action,
+		ResourceType: e.Kind,
+		ResourceName: e.Metadata.Name,
+		BeforeState:  before,
+		AfterState:   after,
+		Source:       "mcp",
+	})
+}
+
+func marshalEntityStateJSON(e *entity.Entity) string {
+	b, err := json.Marshal(e)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/website/docs/docs/api/mcp.md
+++ b/website/docs/docs/api/mcp.md
@@ -6,7 +6,7 @@ description: Query Gantry from local AI agents (Claude Code, Cursor, etc.) over 
 
 # MCP Server
 
-Gantry exposes a [Model Context Protocol](https://modelcontextprotocol.io) endpoint so local AI agents like Claude Code and Cursor can query the catalog directly — searching entities, reading service details, and inspecting relationship graphs — without a human context-switching to the UI.
+Gantry exposes a [Model Context Protocol](https://modelcontextprotocol.io) endpoint so local AI agents like Claude Code and Cursor can query the catalog directly — searching entities, reading service details, inspecting relationship graphs, and (with a `developer+` key) creating or updating entities — without a human context-switching to the UI.
 
 The endpoint is served by the Gantry binary itself over HTTP, so there is **nothing to install on developer machines**. Users add a URL and an API key to their agent's MCP config and they're done.
 
@@ -24,9 +24,11 @@ Authentication uses the same [API keys](./authentication.md#api-keys) as every o
 Authorization: Bearer gantry_<your-key>
 ```
 
-The `/api/v1/mcp` route is protected by the standard authentication middleware — any authenticated Gantry user (or API key) can connect, regardless of role. The permissions of the key's user still apply to every tool call, so the tools return only data that user is allowed to see. Because v1 exposes only read-only tools, using a `viewer`-role key is a good least-privilege default.
+The `/api/v1/mcp` route is protected by the standard authentication middleware — any authenticated Gantry user (or API key) can connect, regardless of role. The permissions of the key's user still apply to every tool call, so the tools return only data that user is allowed to see. Read and schema-discovery tools work for any authenticated key; write tools (`create_entity`, `update_entity`) require **developer role or higher**.
 
 ## Available Tools
+
+### Read & Discovery
 
 | Tool | Purpose |
 |---|---|
@@ -34,8 +36,17 @@ The `/api/v1/mcp` route is protected by the standard authentication middleware �
 | `get_entity` | Return the full record (metadata + spec) for a specific `kind`+`name`. |
 | `list_entities` | List entities, optionally filtered by `kind`, `namespace`, `owner`, or `tag`. |
 | `get_graph` | Return the relationship graph (dependencies, owners, consumed/provided APIs) centered on a given entity. |
+| `list_schemas` | Return every entity kind with its JSON Schema — discover what kinds exist and what each accepts. |
+| `get_schema` | Return the JSON Schema for a single kind — the authoritative list of valid `metadata` and `spec` fields. |
 
-Write tools (create entity, execute action) are not yet exposed over MCP.
+### Write (requires `developer+`)
+
+| Tool | Purpose |
+|---|---|
+| `create_entity` | Create a new entity. Validated against the kind's JSON Schema. Triggers GitOps sync and writes an audit entry (source `mcp`). |
+| `update_entity` | Update an existing entity. Validated against the kind's JSON Schema. Triggers GitOps sync and writes an audit entry (source `mcp`). |
+
+`delete_entity` and `Flow`-kind writes are **not currently exposed over MCP**; use the REST API or UI for those.
 
 ### Tool: `search`
 
@@ -70,6 +81,51 @@ All fields are optional — omit them to list everything.
 | `name` | string (required) | Name of the root entity |
 | `namespace` | string | Defaults to `default` when omitted |
 
+### Tool: `list_schemas`
+
+No inputs. Returns `{"schemas": {"service": {...}, "api": {...}, ...}, "count": N}` where each value is the raw JSON Schema for that kind.
+
+### Tool: `get_schema`
+
+| Input | Type | Description |
+|---|---|---|
+| `kind` | string (required) | e.g. `Service`, `API`, `Team`, `Infrastructure` |
+
+Returns `{"kind": "Service", "schema": { ... }}`. Agents should call this (or `list_schemas`) before `create_entity` / `update_entity` — spec is free-form JSON and all built-in schemas set `additionalProperties: false`, so unknown fields are rejected at write time.
+
+### Tool: `create_entity`
+
+Requires **`developer` role or higher**. The key's user's role applies.
+
+| Input | Type | Description |
+|---|---|---|
+| `entity` | object (required) | Full entity: `kind`, `apiVersion`, `metadata` (with at least `name`), and `spec`. Call `get_schema` for the kind first to know which fields to populate. |
+
+Server-side on success:
+
+- `metadata.createdBy` is set from the authenticated user (any client-supplied value is overwritten).
+- `metadata.createdAt` / `updatedAt` default to now if not provided.
+- The event bus publishes `entity.created`, which triggers a **GitOps commit** if GitOps is enabled.
+- An audit log entry is written with `source: "mcp"`.
+- Returns `{"entity": {...}, "created": true}`.
+
+Common errors the tool will surface:
+
+- `this tool requires developer role or higher` — key's user lacks permission
+- `validation failed: …` — entity doesn't match the kind's JSON Schema
+- `entity <kind>/<name> already exists in namespace "<ns>"` — duplicate
+- `Flow entities must be created via the REST API …` — deliberate v1 limitation
+
+### Tool: `update_entity`
+
+Requires **`developer` role or higher**.
+
+| Input | Type | Description |
+|---|---|---|
+| `entity` | object (required) | The updated entity. `kind` and `metadata.name` identify the target; other fields are replaced. |
+
+Server-side on success: validates against the kind's schema, writes to DB, publishes `entity.updated` (triggering GitOps), writes an audit entry with `before` and `after` states, and returns `{"entity": {...}, "updated": true}`.
+
 ## Configuring Claude Code
 
 Create an API key in **Settings → API Keys** (copy the full `gantry_...` value — it's only shown once), then:
@@ -94,6 +150,8 @@ Start a Claude Code session and ask a question — Claude will call the Gantry t
 - "Use gantry to find services tagged `payments`."
 - "What does the `checkout` service depend on, according to gantry?"
 - "List the APIs owned by the `platform` team."
+- "Create a new Service called `billing-api` owned by team `platform` with repo `github.com/example/billing`." *(requires a `developer`+ key)*
+- "Change the owner of `billing-api` to team `data`." *(requires a `developer`+ key)*
 
 ## Configuring Other MCP Clients
 
@@ -150,5 +208,5 @@ A healthy response is `200 OK` with JSON containing `"serverInfo": {"name": "gan
 
 - MCP traffic inherits Gantry's **rate limiting** (applied to all `/api/v1` routes) and **audit logging** where relevant.
 - MCP respects **RBAC**: because the route lives inside the authenticated API group, any endpoint the key can't reach via REST is also unreachable via MCP.
-- Keys you hand to an agent should be **scoped to the minimum role the agent needs** — `viewer` is enough for the current read-only toolset.
+- Keys you hand to an agent should be **scoped to the minimum role the agent needs** — `viewer` is enough for read and schema-discovery tools; use a `developer` key only if you want the agent to create or update entities.
 - Prefer **HTTPS** in production; an agent config pastes the key into `Authorization` on every request.


### PR DESCRIPTION
This pull request introduces write capabilities to the Gantry MCP (Model Context Protocol) API, allowing authorized users (developer role or higher) to create and update entities directly from local AI agents. It adds new tools for schema discovery and entity management, updates documentation to reflect these changes, and enforces role-based access for write operations.

**New Write Tools and Schema Discovery**

* Added `list_schemas` and `get_schema` tools to MCP, enabling clients to discover available entity kinds and their JSON Schemas (`internal/mcp/write_tools.go`, `website/docs/docs/api/mcp.md`). [[1]](diffhunk://#diff-30326a750df4bcb698b21a00ddb7fb66807e1261a7a76ba2baf05f7d2169e978R1-R180) [[2]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3R84-R128)
* Introduced `create_entity` and `update_entity` tools with input validation, audit logging, event publishing, and role enforcement (`internal/mcp/write_tools.go`, `internal/mcp/tools.go`, `website/docs/docs/api/mcp.md`). [[1]](diffhunk://#diff-30326a750df4bcb698b21a00ddb7fb66807e1261a7a76ba2baf05f7d2169e978R1-R180) [[2]](diffhunk://#diff-7c0d527ba4a221ad07c68fbba6d86758d527c2332590fa5758195e17ba3075a0R99-R100) [[3]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3R84-R128)

**Role-based Access Control**

* Write tools (`create_entity`, `update_entity`) require a user with developer role or higher; read and schema-discovery tools remain available to any authenticated user (`internal/mcp/write_tools.go`, `website/docs/docs/api/mcp.md`). [[1]](diffhunk://#diff-30326a750df4bcb698b21a00ddb7fb66807e1261a7a76ba2baf05f7d2169e978R1-R180) [[2]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3L27-R49) F1a8dfc2L208R208)

**Documentation Updates**

* Updated MCP API documentation to describe new tools, their inputs, outputs, permissions, and usage examples (`website/docs/docs/api/mcp.md`). [[1]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3L9-R9) [[2]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3L27-R49) [[3]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3R84-R128) [[4]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3R153-R154) [[5]](diffhunk://#diff-2d2c6a6f2ff87d4e4758950600b4a29a709dc2c99c2232cb12a74b263bd52da3L153-R211)

These changes make Gantry's MCP endpoint more powerful and flexible, supporting both read and write operations for AI agents while maintaining strong RBAC and audit trails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP API now supports entity creation and updates via new tools, requiring developer role or higher
  * Added schema discovery tools to list and retrieve entity schemas
  * Write operations include validation, server defaults, and audit trail entries

* **Documentation**
  * Updated MCP documentation with write operation examples and security requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->