### PR TITLE
fix(admin): align plugin settings actions

### DIFF
--- a/web/src/components/AdminPluginSettings.tsx
+++ b/web/src/components/AdminPluginSettings.tsx
@@ -71,12 +71,12 @@ function PluginSettingsCard({
             </div>
             <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">{plugin.description}</p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex w-full flex-wrap items-stretch justify-start gap-2 sm:w-auto sm:justify-end">
             {canSync && (
               <button
                 onClick={onSync}
                 disabled={syncing}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--gantry-border)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] hover:bg-[var(--gantry-bg-tertiary)] disabled:opacity-50"
+                className="inline-flex min-h-[2.5rem] items-center justify-center gap-1.5 rounded-lg border border-[var(--gantry-border)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] hover:bg-[var(--gantry-bg-tertiary)] disabled:opacity-50 sm:min-w-[7.5rem]"
               >
                 <RefreshCw className={`h-4 w-4 ${syncing ? 'animate-spin' : ''}`} />
                 Sync
@@ -84,14 +84,14 @@ function PluginSettingsCard({
             )}
             <button
               onClick={onDisable}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--gantry-border)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] hover:bg-[var(--gantry-bg-tertiary)]"
+              className="inline-flex min-h-[2.5rem] items-center justify-center gap-1.5 rounded-lg border border-[var(--gantry-border)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] hover:bg-[var(--gantry-bg-tertiary)] sm:min-w-[7.5rem]"
             >
               <Slash className="h-4 w-4" />
               Disable
             </button>
             <button
               onClick={onToggleExpanded}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--gantry-accent)] px-3 py-2 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)]"
+              className="inline-flex min-h-[2.5rem] items-center justify-center gap-1.5 rounded-lg bg-[var(--gantry-accent)] px-3 py-2 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)] sm:min-w-[8.5rem]"
             >
               <Settings className="h-4 w-4" />
               {expanded ? 'Hide settings' : 'Configure'}


### PR DESCRIPTION
## Summary
- align the enabled plugin action buttons on the admin settings page so Sync, Disable, and Configure share a consistent height and width
- let the action group stretch cleanly on small screens while keeping the controls aligned on larger layouts
- keep the existing admin plugin settings workflow unchanged while fixing the visual mismatch reported in the dashboard screenshot

## Validation
- `npm run build` (from `web/`)

Closes #90

@go2engle please review.
