### PR TITLE
Feature: Add health-based edge coloring to Flow

### DIFF
--- a/web/src/components/FlowTab.tsx
+++ b/web/src/components/FlowTab.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ExternalLink, Workflow } from 'lucide-react';
 import { api } from '../lib/api';
+import { useFlowHealth } from '../hooks/useFlowHealth';
 import type { Entity } from '../lib/types';
 import {
   connectedEdgeHealth,
@@ -9,7 +10,6 @@ import {
   edgeLabelPosition,
   edgeOffsetTransform,
   edgePath,
-  entityKey,
   ensureFlowSpec,
   FLOW_EDGE_HEALTHY_STROKE,
   FLOW_EDGE_STROKE,
@@ -21,7 +21,6 @@ import {
   mockContentStyle,
   nodeBadge,
   nodeColor,
-  nodeEntityKey,
   nodeSubtitle,
   renderMockNodeShell,
 } from '../lib/flow';
@@ -46,7 +45,7 @@ function nodeTitle(node: Parameters<typeof nodeColor>[0]): string {
 export default function FlowTab({ entity }: { entity: Entity }) {
   const flowSpec = ensureFlowSpec(entity.spec);
   const [availableEntities, setAvailableEntities] = useState<Entity[]>([]);
-  const [healthStatuses, setHealthStatuses] = useState<Map<string, boolean | null>>(new Map());
+  const healthStatuses = useFlowHealth(flowSpec.nodes, availableEntities);
 
   useEffect(() => {
     let active = true;
@@ -66,54 +65,6 @@ export default function FlowTab({ entity }: { entity: Entity }) {
       active = false;
     };
   }, []);
-
-  const healthUrlKey = useMemo(() => {
-    const entityMap = new Map(availableEntities.map((candidate) => [entityKey(candidate), candidate]));
-    const pairs: string[] = [];
-    for (const node of flowSpec.nodes) {
-      if (isMockNode(node)) continue;
-      const candidate = entityMap.get(nodeEntityKey(node));
-      const url = candidate?.spec?.healthCheckUrl;
-      if (typeof url === 'string' && url.trim()) pairs.push(`${nodeEntityKey(node)}|${url.trim()}`);
-    }
-    return pairs.sort().join('\n');
-  }, [availableEntities, flowSpec.nodes]);
-
-  useEffect(() => {
-    let active = true;
-    const urls = new Map<string, string>();
-    for (const pair of healthUrlKey.split('\n').filter(Boolean)) {
-      const sep = pair.indexOf('|');
-      urls.set(pair.slice(0, sep), pair.slice(sep + 1));
-    }
-
-    if (urls.size === 0) {
-      setHealthStatuses(new Map());
-      return;
-    }
-
-    const check = async () => {
-      const next = new Map<string, boolean | null>();
-      await Promise.all(
-        [...urls.entries()].map(async ([key, url]) => {
-          try {
-            const res = await api.checkHealth(url);
-            if (active) next.set(key, res.reachable);
-          } catch {
-            if (active) next.set(key, null);
-          }
-        })
-      );
-      if (active) setHealthStatuses(next);
-    };
-
-    void check();
-    const interval = setInterval(check, 30_000);
-    return () => {
-      active = false;
-      clearInterval(interval);
-    };
-  }, [healthUrlKey]);
 
   // Compute fit-view transform so all nodes are visible within the fixed canvas.
   const nodeMap = new Map(flowSpec.nodes.map((n) => [n.id, n]));

--- a/web/src/components/FlowTab.tsx
+++ b/web/src/components/FlowTab.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ExternalLink, Workflow } from 'lucide-react';
+import { api } from '../lib/api';
 import type { Entity } from '../lib/types';
 import {
+  connectedEdgeHealth,
+  edgeStrokeForHealth,
   edgeLabelPosition,
   edgeOffsetTransform,
   edgePath,
+  entityKey,
   ensureFlowSpec,
+  FLOW_EDGE_HEALTHY_STROKE,
+  FLOW_EDGE_STROKE,
+  FLOW_EDGE_UNHEALTHY_STROKE,
   getAbsolutePosition,
   getNodeDimensions,
   isMockNode,
@@ -14,6 +21,7 @@ import {
   mockContentStyle,
   nodeBadge,
   nodeColor,
+  nodeEntityKey,
   nodeSubtitle,
   renderMockNodeShell,
 } from '../lib/flow';
@@ -37,6 +45,75 @@ function nodeTitle(node: Parameters<typeof nodeColor>[0]): string {
 
 export default function FlowTab({ entity }: { entity: Entity }) {
   const flowSpec = ensureFlowSpec(entity.spec);
+  const [availableEntities, setAvailableEntities] = useState<Entity[]>([]);
+  const [healthStatuses, setHealthStatuses] = useState<Map<string, boolean | null>>(new Map());
+
+  useEffect(() => {
+    let active = true;
+
+    const loadEntities = async () => {
+      try {
+        const entities = await api.listEntities();
+        if (!active) return;
+        setAvailableEntities((entities || []).filter((candidate) => candidate.kind !== 'Flow'));
+      } catch {
+        if (active) setAvailableEntities([]);
+      }
+    };
+
+    void loadEntities();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const healthUrlKey = useMemo(() => {
+    const entityMap = new Map(availableEntities.map((candidate) => [entityKey(candidate), candidate]));
+    const pairs: string[] = [];
+    for (const node of flowSpec.nodes) {
+      if (isMockNode(node)) continue;
+      const candidate = entityMap.get(nodeEntityKey(node));
+      const url = candidate?.spec?.healthCheckUrl;
+      if (typeof url === 'string' && url.trim()) pairs.push(`${nodeEntityKey(node)}|${url.trim()}`);
+    }
+    return pairs.sort().join('\n');
+  }, [availableEntities, flowSpec.nodes]);
+
+  useEffect(() => {
+    let active = true;
+    const urls = new Map<string, string>();
+    for (const pair of healthUrlKey.split('\n').filter(Boolean)) {
+      const sep = pair.indexOf('|');
+      urls.set(pair.slice(0, sep), pair.slice(sep + 1));
+    }
+
+    if (urls.size === 0) {
+      setHealthStatuses(new Map());
+      return;
+    }
+
+    const check = async () => {
+      const next = new Map<string, boolean | null>();
+      await Promise.all(
+        [...urls.entries()].map(async ([key, url]) => {
+          try {
+            const res = await api.checkHealth(url);
+            if (active) next.set(key, res.reachable);
+          } catch {
+            if (active) next.set(key, null);
+          }
+        })
+      );
+      if (active) setHealthStatuses(next);
+    };
+
+    void check();
+    const interval = setInterval(check, 30_000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [healthUrlKey]);
 
   // Compute fit-view transform so all nodes are visible within the fixed canvas.
   const nodeMap = new Map(flowSpec.nodes.map((n) => [n.id, n]));
@@ -142,12 +219,20 @@ export default function FlowTab({ entity }: { entity: Entity }) {
             <div style={{ transform: `translate(${fitTx}px, ${fitTy}px) scale(${fitScale})`, transformOrigin: '0 0', width: CANVAS_WIDTH / fitScale, height: CANVAS_HEIGHT / fitScale }}>
             <svg className="pointer-events-none absolute inset-0 overflow-visible" style={{ width: CANVAS_WIDTH / fitScale, height: CANVAS_HEIGHT / fitScale }}>
               <defs>
-                <marker id="catalog-flow-arrow-end" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
-                  <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748B" />
-                </marker>
-                <marker id="catalog-flow-arrow-start" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
-                  <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748B" />
-                </marker>
+                {[
+                  ['default', FLOW_EDGE_STROKE],
+                  ['healthy', FLOW_EDGE_HEALTHY_STROKE],
+                  ['unhealthy', FLOW_EDGE_UNHEALTHY_STROKE],
+                ].map(([suffix, fill]) => (
+                  <g key={suffix}>
+                    <marker id={`catalog-flow-arrow-end-${suffix}`} markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+                      <path d="M 0 0 L 10 5 L 0 10 z" fill={fill} />
+                    </marker>
+                    <marker id={`catalog-flow-arrow-start-${suffix}`} markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
+                      <path d="M 0 0 L 10 5 L 0 10 z" fill={fill} />
+                    </marker>
+                  </g>
+                ))}
               </defs>
               {(() => {
                 return flowSpec.edges.map((edge) => {
@@ -161,6 +246,9 @@ export default function FlowTab({ entity }: { entity: Entity }) {
                 const path = edgePath(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
                 const labelPos = edgeLabelPosition(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
                 const twoWay = edge.direction === 'two-way';
+                const health = connectedEdgeHealth(edge, nodeMap, healthStatuses);
+                const edgeColor = edgeStrokeForHealth(health);
+                const markerVariant = health === true ? 'healthy' : health === false ? 'unhealthy' : 'default';
                 const forwardTransform = twoWay ? edgeOffsetTransform(sourceAbs, sourceSize, targetAbs, targetSize, 3, edge.sourceHandle, edge.targetHandle) : undefined;
                 const reverseTransform = twoWay ? edgeOffsetTransform(sourceAbs, sourceSize, targetAbs, targetSize, -3, edge.sourceHandle, edge.targetHandle) : undefined;
 
@@ -170,10 +258,10 @@ export default function FlowTab({ entity }: { entity: Entity }) {
                       <path
                         d={path}
                         fill="none"
-                        stroke="#64748B"
+                        stroke={edgeColor}
                         strokeWidth={2}
                         strokeDasharray={edge.animated ? '8 8' : undefined}
-                        markerEnd="url(#catalog-flow-arrow-end)"
+                        markerEnd={`url(#catalog-flow-arrow-end-${markerVariant})`}
                       >
                         {edge.animated && <animate attributeName="stroke-dashoffset" from="16" to="0" dur="1s" repeatCount="indefinite" />}
                       </path>
@@ -184,10 +272,10 @@ export default function FlowTab({ entity }: { entity: Entity }) {
                           d={path}
                           fill="none"
                           transform={forwardTransform}
-                          stroke="#64748B"
+                          stroke={edgeColor}
                           strokeWidth={2.1}
                           strokeDasharray={edge.animated ? '8 8' : undefined}
-                          markerEnd="url(#catalog-flow-arrow-end)"
+                          markerEnd={`url(#catalog-flow-arrow-end-${markerVariant})`}
                         >
                           {edge.animated && <animate attributeName="stroke-dashoffset" from="16" to="0" dur="1s" repeatCount="indefinite" />}
                         </path>
@@ -195,10 +283,10 @@ export default function FlowTab({ entity }: { entity: Entity }) {
                           d={path}
                           fill="none"
                           transform={reverseTransform}
-                          stroke="#94A3B8"
+                          stroke={edgeColor}
                           strokeWidth={1.9}
                           strokeDasharray={edge.animated ? '8 8' : undefined}
-                          markerStart="url(#catalog-flow-arrow-start)"
+                          markerStart={`url(#catalog-flow-arrow-start-${markerVariant})`}
                         >
                           {edge.animated && <animate attributeName="stroke-dashoffset" from="0" to="16" dur="1s" repeatCount="indefinite" />}
                         </path>
@@ -211,7 +299,7 @@ export default function FlowTab({ entity }: { entity: Entity }) {
                       height={22}
                       rx={11}
                       fill="var(--gantry-bg-primary)"
-                      stroke={twoWay ? '#64748B' : 'var(--gantry-border)'}
+                      stroke={health === undefined ? (twoWay ? FLOW_EDGE_STROKE : 'var(--gantry-border)') : edgeColor}
                     />
                     <text x={labelPos.x} y={labelPos.y - 2} textAnchor="middle" className="fill-[var(--gantry-text-secondary)] text-[11px] font-medium">
                       {edge.label || edge.relation}

--- a/web/src/hooks/useFlowHealth.ts
+++ b/web/src/hooks/useFlowHealth.ts
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '../lib/api';
+import type { Entity, FlowNode } from '../lib/types';
+import { entityKey, isMockNode, nodeEntityKey } from '../lib/flow';
+
+const FLOW_HEALTH_POLL_INTERVAL_MS = 30_000;
+const FLOW_HEALTH_REQUEST_TIMEOUT_MS = 12_000;
+
+export function useFlowHealth(nodes: FlowNode[], entities: Entity[]) {
+  const [healthStatuses, setHealthStatuses] = useState<Map<string, boolean | null>>(new Map());
+
+  const healthUrlKey = useMemo(() => {
+    const entityMap = new Map(entities.map((entity) => [entityKey(entity), entity]));
+    const pairs: string[] = [];
+    for (const node of nodes) {
+      if (isMockNode(node)) continue;
+      const entity = entityMap.get(nodeEntityKey(node));
+      const url = entity?.spec?.healthCheckUrl;
+      if (typeof url === 'string' && url.trim()) {
+        pairs.push(`${nodeEntityKey(node)}|${url.trim()}`);
+      }
+    }
+    return pairs.sort().join('\n');
+  }, [entities, nodes]);
+
+  useEffect(() => {
+    let active = true;
+    let runVersion = 0;
+    const inFlight = new Map<string, AbortController>();
+    const urls = new Map<string, string>();
+
+    for (const pair of healthUrlKey.split('\n').filter(Boolean)) {
+      const sep = pair.indexOf('|');
+      urls.set(pair.slice(0, sep), pair.slice(sep + 1));
+    }
+
+    if (urls.size === 0) {
+      setHealthStatuses(new Map());
+      return () => {
+        active = false;
+      };
+    }
+
+    const check = async () => {
+      const currentRun = ++runVersion;
+      const next = new Map<string, boolean | null>();
+
+      await Promise.all(
+        [...urls.entries()].map(async ([key, url]) => {
+          inFlight.get(key)?.abort();
+
+          const controller = new AbortController();
+          const timeoutId = window.setTimeout(() => controller.abort(), FLOW_HEALTH_REQUEST_TIMEOUT_MS);
+          inFlight.set(key, controller);
+
+          try {
+            const res = await api.checkHealth(url, controller.signal);
+            if (!active || runVersion !== currentRun || controller.signal.aborted) return;
+            next.set(key, res.reachable);
+          } catch {
+            if (!active || runVersion !== currentRun || controller.signal.aborted) return;
+            next.set(key, null);
+          } finally {
+            window.clearTimeout(timeoutId);
+            if (inFlight.get(key) === controller) {
+              inFlight.delete(key);
+            }
+          }
+        })
+      );
+
+      if (active && runVersion === currentRun) {
+        setHealthStatuses(next);
+      }
+    };
+
+    void check();
+    const interval = window.setInterval(() => {
+      void check();
+    }, FLOW_HEALTH_POLL_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+      for (const controller of inFlight.values()) {
+        controller.abort();
+      }
+      inFlight.clear();
+    };
+  }, [healthUrlKey]);
+
+  return healthStatuses;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -11,11 +11,12 @@ function headers(): Record<string, string> {
   return h;
 }
 
-async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+async function request<T>(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
   const res = await fetch(`/api/v1${path}`, {
     method,
     headers: headers(),
     body: body ? JSON.stringify(body) : undefined,
+    signal,
   });
   if (!res.ok) {
     if (res.status === 401 && authToken) {
@@ -234,8 +235,8 @@ export const api = {
     request<void>('DELETE', `/plugins/flow/entities/${name}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
 
   // Health check proxy
-  checkHealth: (url: string) =>
-    request<{ reachable: boolean; statusCode?: number; latencyMs: number; body?: string; error?: string }>('GET', `/health-check?url=${encodeURIComponent(url)}`),
+  checkHealth: (url: string, signal?: AbortSignal) =>
+    request<{ reachable: boolean; statusCode?: number; latencyMs: number; body?: string; error?: string }>('GET', `/health-check?url=${encodeURIComponent(url)}`, undefined, signal),
 
   // Dashboard config
   getDashboardConfig: () => request<DashboardConfig>('GET', '/dashboard/config'),

--- a/web/src/lib/flow.tsx
+++ b/web/src/lib/flow.tsx
@@ -1,11 +1,14 @@
 import type { CSSProperties } from 'react';
-import type { FlowEdge, FlowEntityNode, FlowHandleSide, FlowMockNode, FlowMockShape, FlowNode, FlowSpec } from './types';
+import type { Entity, FlowEdge, FlowEntityNode, FlowEntityRef, FlowHandleSide, FlowMockNode, FlowMockShape, FlowNode, FlowSpec } from './types';
 
 export const ENTITY_NODE_WIDTH = 208;
 export const ENTITY_NODE_HEIGHT = 92;
 export const MAX_NODE_WIDTH = 440;
 export const MIN_NODE_HEIGHT = 92;
 export const MOCK_SHAPE_OPTIONS: FlowMockShape[] = ['box', 'pill', 'diamond', 'note'];
+export const FLOW_EDGE_STROKE = '#64748B';
+export const FLOW_EDGE_HEALTHY_STROKE = '#10B981';
+export const FLOW_EDGE_UNHEALTHY_STROKE = '#EF4444';
 
 export const FLOW_KIND_COLORS: Record<string, string> = {
   Service: '#3B82F6',
@@ -100,6 +103,42 @@ export function isMockNode(node: FlowNode): node is FlowMockNode {
 
 export function isEntityNode(node: FlowNode): node is FlowEntityNode {
   return !isMockNode(node);
+}
+
+export function entityKey(entity: Pick<Entity, 'kind' | 'metadata'>): string {
+  return `${entity.kind}:${entity.metadata.namespace || 'default'}:${entity.metadata.name}`;
+}
+
+export function flowEntityRefKey(entityRef: FlowEntityRef): string {
+  return `${entityRef.kind}:${entityRef.namespace || 'default'}:${entityRef.name}`;
+}
+
+export function nodeEntityKey(node: FlowNode): string {
+  if (!isEntityNode(node)) return '';
+  return flowEntityRefKey(node.entityRef);
+}
+
+export function connectedEdgeHealth(
+  edge: FlowEdge,
+  nodeMap: Map<string, FlowNode>,
+  healthStatuses: Map<string, boolean | null>
+): boolean | null | undefined {
+  const connectedStatuses = [edge.source, edge.target]
+    .map((nodeId) => nodeMap.get(nodeId))
+    .filter((node): node is FlowNode => Boolean(node))
+    .filter(isEntityNode)
+    .map((node) => healthStatuses.get(nodeEntityKey(node)));
+
+  if (connectedStatuses.some((status) => status === false)) return false;
+  if (connectedStatuses.some((status) => status === true)) return true;
+  if (connectedStatuses.some((status) => status === null)) return null;
+  return undefined;
+}
+
+export function edgeStrokeForHealth(status: boolean | null | undefined): string {
+  if (status === true) return FLOW_EDGE_HEALTHY_STROKE;
+  if (status === false) return FLOW_EDGE_UNHEALTHY_STROKE;
+  return FLOW_EDGE_STROKE;
 }
 
 export function nodeColor(node: FlowNode): string {

--- a/web/src/lib/flow.tsx
+++ b/web/src/lib/flow.tsx
@@ -8,7 +8,7 @@ export const MIN_NODE_HEIGHT = 92;
 export const MOCK_SHAPE_OPTIONS: FlowMockShape[] = ['box', 'pill', 'diamond', 'note'];
 export const FLOW_EDGE_STROKE = '#64748B';
 export const FLOW_EDGE_HEALTHY_STROKE = '#10B981';
-export const FLOW_EDGE_UNHEALTHY_STROKE = '#EF4444';
+export const FLOW_EDGE_UNHEALTHY_STROKE = 'var(--gantry-danger)';
 
 export const FLOW_KIND_COLORS: Record<string, string> = {
   Service: '#3B82F6',

--- a/web/src/pages/Flow.tsx
+++ b/web/src/pages/Flow.tsx
@@ -55,6 +55,7 @@ import {
   nodeSubtitle,
   renderMockNodeShell,
 } from '../lib/flow';
+import { useFlowHealth } from '../hooks/useFlowHealth';
 
 const CANVAS_WIDTH = 1600;
 const CANVAS_HEIGHT = 900;
@@ -249,7 +250,6 @@ export default function Flow() {
     canEdit: true,
   });
   const [availableEntities, setAvailableEntities] = useState<Entity[]>([]);
-  const [healthStatuses, setHealthStatuses] = useState<Map<string, boolean | null>>(new Map());
   const [flows, setFlows] = useState<Entity[]>([]);
   const [currentFlowName, setCurrentFlowName] = useState<string | null>(null);
   const [currentNamespace, setCurrentNamespace] = useState('default');
@@ -282,6 +282,7 @@ export default function Flow() {
   const flowBounds = useMemo(() => getFlowBounds(flowSpec), [flowSpec]);
   const [renderBounds, setRenderBounds] = useState(flowBounds);
   const activeBounds = dragging || resizing ? renderBounds : flowBounds;
+  const healthStatuses = useFlowHealth(flowSpec.nodes, availableEntities);
   const stageMinX = Math.min(0, activeBounds.minX);
   const stageMinY = Math.min(0, activeBounds.minY);
   const stageMaxX = Math.max(CANVAS_WIDTH, activeBounds.maxX);
@@ -397,54 +398,6 @@ export default function Flow() {
       active = false;
     };
   }, [requestedFlow, requestedNamespace, requestedMode]);
-
-  // Periodically check health for entities on the canvas that have healthCheckUrl.
-  // Build a stable key from the sorted set of (entityKey|url) pairs so the effect
-  // only re-subscribes when the monitored URLs actually change, not on every drag.
-  const healthUrlKey = useMemo(() => {
-    const entityMapLocal = new Map(availableEntities.map((e) => [entityKey(e), e]));
-    const pairs: string[] = [];
-    for (const node of flowSpec.nodes) {
-      if (isMockNode(node)) continue;
-      const key = nodeEntityKey(node);
-      const ent = entityMapLocal.get(key);
-      const url = ent?.spec?.healthCheckUrl;
-      if (typeof url === 'string' && url.trim()) pairs.push(`${key}|${url.trim()}`);
-    }
-    return pairs.sort().join('\n');
-  }, [availableEntities, flowSpec.nodes]);
-
-  useEffect(() => {
-    let active = true;
-    const urls = new Map<string, string>();
-    for (const pair of healthUrlKey.split('\n').filter(Boolean)) {
-      const sep = pair.indexOf('|');
-      urls.set(pair.slice(0, sep), pair.slice(sep + 1));
-    }
-
-    if (urls.size === 0) {
-      setHealthStatuses(new Map());
-      return;
-    }
-
-    const check = async () => {
-      const next = new Map<string, boolean | null>();
-      await Promise.all(
-        [...urls.entries()].map(async ([key, url]) => {
-          try {
-            const res = await api.checkHealth(url);
-            if (active) next.set(key, res.reachable);
-          } catch {
-            if (active) next.set(key, null);
-          }
-        })
-      );
-      if (active) setHealthStatuses(next);
-    };
-    void check();
-    const interval = setInterval(check, 30_000);
-    return () => { active = false; clearInterval(interval); };
-  }, [healthUrlKey]);
 
   useEffect(() => {
     if (!dragging) return;

--- a/web/src/pages/Flow.tsx
+++ b/web/src/pages/Flow.tsx
@@ -30,10 +30,16 @@ import type { Entity, FlowEdge, FlowMockNode, FlowMockShape, FlowNode, FlowPlugi
 import {
   autoArrangeNodes,
   collectDescendants,
+  connectedEdgeHealth,
+  edgeStrokeForHealth,
   edgeLabelPosition,
   edgeOffsetTransform,
   edgePath,
+  entityKey,
   ensureFlowSpec,
+  FLOW_EDGE_HEALTHY_STROKE,
+  FLOW_EDGE_STROKE,
+  FLOW_EDGE_UNHEALTHY_STROKE,
   getAbsolutePosition,
   getNodeDimensions,
   isEntityNode,
@@ -45,6 +51,7 @@ import {
   MOCK_SHAPE_OPTIONS,
   nodeBadge,
   nodeColor,
+  nodeEntityKey,
   nodeSubtitle,
   renderMockNodeShell,
 } from '../lib/flow';
@@ -80,15 +87,6 @@ function flowTitle(flow: Entity): string {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
-}
-
-function entityKey(entity: Pick<Entity, 'kind' | 'metadata'>): string {
-  return `${entity.kind}:${entity.metadata.namespace || 'default'}:${entity.metadata.name}`;
-}
-
-function nodeEntityKey(node: FlowNode): string {
-  if (!isEntityNode(node)) return '';
-  return `${node.entityRef.kind}:${node.entityRef.namespace || 'default'}:${node.entityRef.name}`;
 }
 
 function nodeTitle(node: FlowNode, entityMap: Map<string, Entity>): string {
@@ -1535,12 +1533,20 @@ export default function Flow() {
                 >
                   <svg className="pointer-events-none absolute inset-0 h-full w-full overflow-visible">
                     <defs>
-                      <marker id="flow-arrow-end" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
-                        <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748B" />
-                      </marker>
-                      <marker id="flow-arrow-start" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
-                        <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748B" />
-                      </marker>
+                      {[
+                        ['default', FLOW_EDGE_STROKE],
+                        ['healthy', FLOW_EDGE_HEALTHY_STROKE],
+                        ['unhealthy', FLOW_EDGE_UNHEALTHY_STROKE],
+                      ].map(([suffix, fill]) => (
+                        <g key={suffix}>
+                          <marker id={`flow-arrow-end-${suffix}`} markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+                            <path d="M 0 0 L 10 5 L 0 10 z" fill={fill} />
+                          </marker>
+                          <marker id={`flow-arrow-start-${suffix}`} markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
+                            <path d="M 0 0 L 10 5 L 0 10 z" fill={fill} />
+                          </marker>
+                        </g>
+                      ))}
                     </defs>
                     {flowSpec.edges.map((edge) => {
                       const source = flowSpec.nodes.find((node) => node.id === edge.source);
@@ -1554,6 +1560,9 @@ export default function Flow() {
                       const labelPos = edgeLabelPosition(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
                       const active = edge.id === selectedEdgeId;
                       const twoWay = edge.direction === 'two-way';
+                      const health = connectedEdgeHealth(edge, nodeMap, healthStatuses);
+                      const edgeColor = edgeStrokeForHealth(health);
+                      const markerVariant = health === true ? 'healthy' : health === false ? 'unhealthy' : 'default';
                       const forwardTransform = twoWay ? edgeOffsetTransform(sourceAbs, sourceSize, targetAbs, targetSize, 3, edge.sourceHandle, edge.targetHandle) : undefined;
                       const reverseTransform = twoWay ? edgeOffsetTransform(sourceAbs, sourceSize, targetAbs, targetSize, -3, edge.sourceHandle, edge.targetHandle) : undefined;
 
@@ -1563,10 +1572,10 @@ export default function Flow() {
                             <path
                               d={path}
                               fill="none"
-                              stroke={active ? 'var(--gantry-text-primary)' : 'var(--gantry-text-secondary)'}
+                              stroke={edgeColor}
                               strokeWidth={active ? 3 : 2}
                               strokeDasharray={edge.animated ? '8 8' : undefined}
-                              markerEnd="url(#flow-arrow-end)"
+                              markerEnd={`url(#flow-arrow-end-${markerVariant})`}
                             >
                               {edge.animated && <animate attributeName="stroke-dashoffset" from="16" to="0" dur="1s" repeatCount="indefinite" />}
                             </path>
@@ -1577,10 +1586,10 @@ export default function Flow() {
                                 d={path}
                                 fill="none"
                                 transform={forwardTransform}
-                                stroke={active ? 'var(--gantry-text-primary)' : 'var(--gantry-text-secondary)'}
+                                stroke={edgeColor}
                                 strokeWidth={active ? 2.8 : 2.1}
                                 strokeDasharray={edge.animated ? '8 8' : undefined}
-                                markerEnd="url(#flow-arrow-end)"
+                                markerEnd={`url(#flow-arrow-end-${markerVariant})`}
                               >
                                 {edge.animated && <animate attributeName="stroke-dashoffset" from="16" to="0" dur="1s" repeatCount="indefinite" />}
                               </path>
@@ -1588,10 +1597,10 @@ export default function Flow() {
                                 d={path}
                                 fill="none"
                                 transform={reverseTransform}
-                                stroke={active ? 'var(--gantry-text-primary)' : 'var(--gantry-text-secondary)'}
+                                stroke={edgeColor}
                                 strokeWidth={active ? 2.6 : 1.9}
                                 strokeDasharray={edge.animated ? '8 8' : undefined}
-                                markerStart="url(#flow-arrow-start)"
+                                markerStart={`url(#flow-arrow-start-${markerVariant})`}
                               >
                                 {edge.animated && <animate attributeName="stroke-dashoffset" from="0" to="16" dur="1s" repeatCount="indefinite" />}
                               </path>
@@ -1618,7 +1627,7 @@ export default function Flow() {
                             height={22}
                             rx={11}
                             fill="var(--gantry-bg-primary)"
-                            stroke={twoWay ? '#64748B' : 'var(--gantry-border)'}
+                            stroke={health === undefined ? (twoWay ? FLOW_EDGE_STROKE : 'var(--gantry-border)') : edgeColor}
                           />
                           <text x={labelPos.x} y={labelPos.y - 2} textAnchor="middle" className="fill-[var(--gantry-text-secondary)] text-[11px] font-medium">
                             {edge.label || edge.relation}


### PR DESCRIPTION
## Summary
- Color Flow edges green when connected entities report healthy health checks and red when either end is unhealthy
- Apply the same health-aware styling to both the main Flow editor and the read-only Flow tab preview
- Keep neutral styling for entities without a health check URL

## Testing
- TypeScript check passed with `npx tsc --noEmit` in `web/`
- Verified the new edge-health helpers and renderer updates in the Flow UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime health monitoring for nodes with periodic status checks
  * Edges now display color-coded indicators based on connection health status (healthy/unhealthy/unknown)
  * Improved arrow styling with health-aware visual indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->