### PR TITLE
Feautre: Export Flows in various formats

### DIFF
--- a/web/src/lib/flow-export.ts
+++ b/web/src/lib/flow-export.ts
@@ -1,0 +1,817 @@
+import type { Entity, FlowEntityNode, FlowMockNode, FlowSpec } from './types';
+import {
+  connectedEdgeHealth,
+  edgeLabelPosition,
+  edgeOffsetTransform,
+  edgePath,
+  edgeStrokeForHealth,
+  FLOW_EDGE_HEALTHY_STROKE,
+  FLOW_EDGE_STROKE,
+  FLOW_EDGE_UNHEALTHY_STROKE,
+  getAbsolutePosition,
+  getNodeDimensions,
+  isMockNode,
+  mockFoldFill,
+  nodeBadge,
+  nodeColor,
+  nodeEntityKey,
+  nodeSubtitle,
+  withAlpha,
+} from './flow';
+
+export type FlowExportFormat = 'svg' | 'png' | 'pdf';
+export type FlowExportStyle = 'presentation' | 'clean';
+export type FlowExportBackground = 'theme' | 'light' | 'transparent';
+export type FlowExportTheme = 'app' | 'light' | 'dark';
+
+interface FlowExportOptions {
+  name?: string;
+  title?: string;
+  description?: string;
+  owner?: string;
+  namespace?: string;
+  spec: FlowSpec;
+  entitiesByKey: Map<string, Entity>;
+  healthStatuses: Map<string, boolean | null>;
+  style?: FlowExportStyle;
+  background?: FlowExportBackground;
+  theme?: FlowExportTheme;
+}
+
+interface FlowExportPalette {
+  bgPrimary: string;
+  bgSecondary: string;
+  bgTertiary: string;
+  textPrimary: string;
+  textSecondary: string;
+  border: string;
+  accent: string;
+  accentHover: string;
+  danger: string;
+  grid: string;
+}
+
+interface NormalizedFlowExportOptions extends FlowExportOptions {
+  style: FlowExportStyle;
+  background: FlowExportBackground;
+  theme: FlowExportTheme;
+  showHeader: boolean;
+  showFrame: boolean;
+  showGrid: boolean;
+  showEdgeLabels: boolean;
+  palette: FlowExportPalette;
+}
+
+interface FlowSvgDocument {
+  baseName: string;
+  svg: string;
+  width: number;
+  height: number;
+}
+
+export interface FlowExportPreview {
+  svg: string;
+  width: number;
+  height: number;
+}
+
+const PAGE_PADDING = 28;
+const CARD_PADDING = 48;
+const HEADER_HEIGHT = 120;
+const MIN_CONTENT_WIDTH = 760;
+const MIN_CONTENT_HEIGHT = 420;
+const EMPTY_CONTENT_WIDTH = 960;
+const EMPTY_CONTENT_HEIGHT = 560;
+const GRID_SIZE = 32;
+const CLEAN_PADDING = 28;
+const PDF_PORTRAIT = { width: 612, height: 792 };
+const PDF_LANDSCAPE = { width: 792, height: 612 };
+
+const LIGHT_EXPORT_PALETTE: FlowExportPalette = {
+  bgPrimary: '#FFFFFF',
+  bgSecondary: '#F8FAFC',
+  bgTertiary: '#EEF2F7',
+  textPrimary: '#111827',
+  textSecondary: '#6B7280',
+  border: '#D1D5DB',
+  accent: '#111827',
+  accentHover: '#374151',
+  danger: '#DC2626',
+  grid: 'rgba(107, 114, 128, 0.10)',
+};
+
+const DARK_EXPORT_PALETTE: FlowExportPalette = {
+  bgPrimary: '#1C1C1E',
+  bgSecondary: '#111113',
+  bgTertiary: '#2C2C2E',
+  textPrimary: '#F5F5F7',
+  textSecondary: '#8E8E93',
+  border: '#38383A',
+  accent: '#F5F5F7',
+  accentHover: '#D1D1D6',
+  danger: '#FF453A',
+  grid: 'rgba(142, 142, 147, 0.18)',
+};
+
+export async function exportFlowDiagram(options: FlowExportOptions, format: FlowExportFormat): Promise<void> {
+  const doc = buildFlowSvgDocument(normalizeExportOptions(options, format));
+
+  if (format === 'svg') {
+    downloadBlob(`${doc.baseName}.svg`, new Blob([doc.svg], { type: 'image/svg+xml;charset=utf-8' }));
+    return;
+  }
+
+  const canvas = await renderSvgToCanvas(doc.svg, doc.width, doc.height, 2);
+  if (format === 'png') {
+    const blob = await canvasToBlob(canvas, 'image/png');
+    downloadBlob(`${doc.baseName}.png`, blob);
+    return;
+  }
+
+  const jpegDataURL = canvas.toDataURL('image/jpeg', 0.94);
+  const jpegBytes = decodeBase64DataUrl(jpegDataURL);
+  const pdfBytes = buildPdfFromJpeg(jpegBytes, canvas.width, canvas.height);
+  downloadBlob(`${doc.baseName}.pdf`, new Blob([toArrayBuffer(pdfBytes)], { type: 'application/pdf' }));
+}
+
+export function getFlowExportPreview(options: FlowExportOptions, format: FlowExportFormat): FlowExportPreview {
+  const doc = buildFlowSvgDocument(normalizeExportOptions(options, format));
+  return {
+    svg: doc.svg,
+    width: doc.width,
+    height: doc.height,
+  };
+}
+
+function normalizeExportOptions(options: FlowExportOptions, format: FlowExportFormat): NormalizedFlowExportOptions {
+  const theme = options.theme || 'app';
+  const style = options.style || 'presentation';
+  const palette = resolveThemePalette(theme);
+  let background = options.background;
+  if (!background) {
+    background = style === 'clean'
+      ? (format === 'pdf' ? 'light' : 'transparent')
+      : 'theme';
+  }
+  if (format === 'pdf' && background === 'transparent') {
+    background = 'light';
+  }
+
+  return {
+    ...options,
+    style,
+    background,
+    theme,
+    showHeader: style === 'presentation',
+    showFrame: style === 'presentation',
+    showGrid: style === 'presentation',
+    showEdgeLabels: style === 'presentation',
+    palette,
+  };
+}
+
+function buildFlowSvgDocument(options: NormalizedFlowExportOptions): FlowSvgDocument {
+  const baseName = sanitizeFileName(options.title || options.name || 'flow');
+  const displayTitle = (options.title || options.name || 'Untitled Flow').trim() || 'Untitled Flow';
+  const description = (options.description || '').trim();
+  const owner = (options.owner || '').trim();
+  const namespace = (options.namespace || 'default').trim() || 'default';
+  const nodeMap = new Map(options.spec.nodes.map((node) => [node.id, node]));
+  const childIds = new Set(options.spec.nodes.filter((node) => node.parentId).map((node) => node.parentId!));
+  const bounds = getDiagramBounds(options.spec, nodeMap, options.showFrame ? CARD_PADDING : 0);
+  const backgroundFill = getDocumentBackground(options);
+  const nodeCount = options.spec.nodes.length;
+  const edgeCount = options.spec.edges.length;
+  const metaParts = [
+    namespace !== 'default' ? `Namespace: ${namespace}` : '',
+    owner ? `Owner: ${owner}` : '',
+    `${nodeCount} node${nodeCount === 1 ? '' : 's'}`,
+    `${edgeCount} edge${edgeCount === 1 ? '' : 's'}`,
+  ].filter(Boolean);
+
+  const sortedNodes = [...options.spec.nodes].sort((a, b) => {
+    const aIsContainer = childIds.has(a.id);
+    const bIsContainer = childIds.has(b.id);
+    if (aIsContainer && !bIsContainer) return -1;
+    if (!aIsContainer && bIsContainer) return 1;
+    return (a.zIndex ?? 0) - (b.zIndex ?? 0);
+  });
+
+  const contentWidth = options.spec.nodes.length > 0
+    ? Math.max(bounds.width, options.style === 'presentation' ? MIN_CONTENT_WIDTH : 0)
+    : EMPTY_CONTENT_WIDTH;
+  const contentHeight = options.spec.nodes.length > 0
+    ? Math.max(bounds.height, options.style === 'presentation' ? MIN_CONTENT_HEIGHT : 0)
+    : EMPTY_CONTENT_HEIGHT;
+
+  let width: number;
+  let height: number;
+  let offsetX: number;
+  let offsetY: number;
+  let headerSvg = '';
+  let frameSvg = '';
+  let gridSvg = '';
+
+  if (options.showFrame) {
+    const cardX = PAGE_PADDING;
+    const cardY = HEADER_HEIGHT;
+    const cardWidth = contentWidth + CARD_PADDING * 2;
+    const cardHeight = contentHeight + CARD_PADDING * 2;
+    width = cardX * 2 + cardWidth;
+    height = cardY + cardHeight + PAGE_PADDING;
+    offsetX = cardX + CARD_PADDING + (contentWidth - bounds.width) / 2 - bounds.minX;
+    offsetY = cardY + CARD_PADDING + (contentHeight - bounds.height) / 2 - bounds.minY;
+
+    headerSvg = options.showHeader ? `
+  <text class="flow-title" x="${PAGE_PADDING}" y="48">${escapeXml(displayTitle)}</text>
+  <text class="flow-meta" x="${PAGE_PADDING}" y="72">${escapeXml(metaParts.join(' · '))}</text>
+  ${description ? `<text class="flow-description" x="${PAGE_PADDING}" y="98">${escapeXml(description)}</text>` : ''}
+` : '';
+    frameSvg = `
+  <rect x="${cardX}" y="${cardY}" width="${cardWidth}" height="${cardHeight}" rx="28" fill="${options.palette.bgPrimary}" stroke="${options.palette.border}" />
+`;
+    gridSvg = options.showGrid ? `
+  <rect x="${cardX + 1}" y="${cardY + 1}" width="${cardWidth - 2}" height="${cardHeight - 2}" rx="27" fill="url(#flow-grid)" />
+` : '';
+  } else {
+    width = contentWidth + CLEAN_PADDING * 2;
+    height = contentHeight + CLEAN_PADDING * 2;
+    offsetX = CLEAN_PADDING - bounds.minX + (contentWidth - bounds.width) / 2;
+    offsetY = CLEAN_PADDING - bounds.minY + (contentHeight - bounds.height) / 2;
+  }
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="flow-export-title flow-export-meta">
+  <title id="flow-export-title">${escapeXml(displayTitle)}</title>
+  <desc id="flow-export-meta">${escapeXml(metaParts.join(' · '))}</desc>
+  <defs>
+    <pattern id="flow-grid" width="${GRID_SIZE}" height="${GRID_SIZE}" patternUnits="userSpaceOnUse">
+      <path d="M ${GRID_SIZE} 0 L 0 0 0 ${GRID_SIZE}" fill="none" stroke="${options.palette.grid}" stroke-width="1" />
+    </pattern>
+    <marker id="flow-arrow-end-default" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${resolveEdgeColor(FLOW_EDGE_STROKE, options.palette)}" />
+    </marker>
+    <marker id="flow-arrow-end-healthy" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${resolveEdgeColor(FLOW_EDGE_HEALTHY_STROKE, options.palette)}" />
+    </marker>
+    <marker id="flow-arrow-end-unhealthy" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${resolveEdgeColor(FLOW_EDGE_UNHEALTHY_STROKE, options.palette)}" />
+    </marker>
+    <marker id="flow-arrow-start-default" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${resolveEdgeColor(FLOW_EDGE_STROKE, options.palette)}" />
+    </marker>
+    <marker id="flow-arrow-start-healthy" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${resolveEdgeColor(FLOW_EDGE_HEALTHY_STROKE, options.palette)}" />
+    </marker>
+    <marker id="flow-arrow-start-unhealthy" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${resolveEdgeColor(FLOW_EDGE_UNHEALTHY_STROKE, options.palette)}" />
+    </marker>
+    <style>
+      text { font-family: Inter, "Segoe UI", Helvetica, Arial, sans-serif; }
+      .flow-title { fill: ${options.palette.textPrimary}; font-size: 28px; font-weight: 700; }
+      .flow-meta { fill: ${options.palette.textSecondary}; font-size: 13px; font-weight: 500; }
+      .flow-description { fill: ${options.palette.textSecondary}; font-size: 14px; }
+      .edge-label { fill: ${options.palette.textSecondary}; font-size: 11px; font-weight: 600; }
+      .node-title { fill: ${options.palette.textPrimary}; font-size: 14px; font-weight: 700; }
+      .node-subtitle { fill: ${options.palette.textSecondary}; font-size: 11px; font-weight: 500; }
+      .node-badge { font-size: 10px; font-weight: 700; }
+      .empty-title { fill: ${options.palette.textPrimary}; font-size: 22px; font-weight: 700; }
+      .empty-body { fill: ${options.palette.textSecondary}; font-size: 14px; }
+    </style>
+  </defs>
+  ${backgroundFill ? `<rect x="0" y="0" width="${width}" height="${height}" fill="${backgroundFill}" />` : ''}
+  ${headerSvg}
+  ${frameSvg}
+  ${gridSvg}
+  <g transform="translate(${offsetX}, ${offsetY})">
+    ${options.spec.edges.map((edge) => renderEdge(edge, options, nodeMap)).join('\n')}
+    ${sortedNodes.map((node) => renderNode(node, options, nodeMap, childIds)).join('\n')}
+    ${options.spec.nodes.length === 0 ? renderEmptyState(contentWidth, contentHeight, options.palette) : ''}
+  </g>
+</svg>`;
+
+  return { baseName, svg, width, height };
+}
+
+function renderEdge(
+  edge: FlowSpec['edges'][number],
+  options: NormalizedFlowExportOptions,
+  nodeMap: Map<string, FlowSpec['nodes'][number]>
+): string {
+  const source = nodeMap.get(edge.source);
+  const target = nodeMap.get(edge.target);
+  if (!source || !target) return '';
+
+  const sourceAbs = getAbsolutePosition(source, nodeMap);
+  const targetAbs = getAbsolutePosition(target, nodeMap);
+  const sourceSize = getNodeDimensions(source);
+  const targetSize = getNodeDimensions(target);
+  const path = edgePath(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
+  const labelPos = edgeLabelPosition(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
+  const health = connectedEdgeHealth(edge, nodeMap, options.healthStatuses);
+  const edgeColor = resolveEdgeColor(edgeStrokeForHealth(health), options.palette);
+  const markerVariant = health === true ? 'healthy' : health === false ? 'unhealthy' : 'default';
+  const label = edge.label || edge.relation;
+  const labelWidth = Math.max(60, Math.min(160, 22 + label.length * 6.5));
+  const twoWay = edge.direction === 'two-way';
+  const forwardTransform = twoWay ? edgeOffsetTransform(sourceAbs, sourceSize, targetAbs, targetSize, 3, edge.sourceHandle, edge.targetHandle) : '';
+  const reverseTransform = twoWay ? edgeOffsetTransform(sourceAbs, sourceSize, targetAbs, targetSize, -3, edge.sourceHandle, edge.targetHandle) : '';
+
+  return `<g>
+    ${!twoWay ? `<path d="${path}" fill="none" stroke="${edgeColor}" stroke-width="${options.style === 'clean' ? 2.4 : 2}" marker-end="url(#flow-arrow-end-${markerVariant})" />` : ''}
+    ${twoWay ? `<path d="${path}" fill="none" transform="${forwardTransform}" stroke="${edgeColor}" stroke-width="${options.style === 'clean' ? 2.5 : 2.1}" marker-end="url(#flow-arrow-end-${markerVariant})" />` : ''}
+    ${twoWay ? `<path d="${path}" fill="none" transform="${reverseTransform}" stroke="${edgeColor}" stroke-width="${options.style === 'clean' ? 2.2 : 1.9}" marker-start="url(#flow-arrow-start-${markerVariant})" />` : ''}
+    ${options.showEdgeLabels ? `<rect x="${labelPos.x - labelWidth / 2}" y="${labelPos.y - 17}" width="${labelWidth}" height="22" rx="11" fill="${options.palette.bgPrimary}" stroke="${health === undefined ? options.palette.border : edgeColor}" />
+    <text class="edge-label" x="${labelPos.x}" y="${labelPos.y - 2}" text-anchor="middle">${escapeXml(label)}</text>` : ''}
+  </g>`;
+}
+
+function renderNode(
+  node: FlowSpec['nodes'][number],
+  options: NormalizedFlowExportOptions,
+  nodeMap: Map<string, FlowSpec['nodes'][number]>,
+  childIds: Set<string>
+): string {
+  const size = getNodeDimensions(node);
+  const absPos = getAbsolutePosition(node, nodeMap);
+  const color = nodeColor(node);
+  const badge = nodeBadge(node);
+  const subtitle = nodeSubtitle(node);
+  const title = nodeTitle(node, options.entitiesByKey);
+  const hasChildren = childIds.has(node.id);
+  const baseBorderColor = options.style === 'clean' ? withAlpha(color, '66') : options.palette.border;
+
+  if (isMockNode(node)) {
+    return renderMockNode(node, title, subtitle, badge, absPos.x, absPos.y, size.width, size.height, hasChildren, baseBorderColor, color, options);
+  }
+
+  return renderEntityNode(node, title, subtitle, badge, absPos.x, absPos.y, size.width, size.height, hasChildren, color, options);
+}
+
+function renderMockNode(
+  node: FlowMockNode,
+  title: string,
+  subtitle: string,
+  badge: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  hasChildren: boolean,
+  borderColor: string,
+  color: string,
+  options: NormalizedFlowExportOptions
+): string {
+  const titleLines = wrapText(title, mockTitleChars(node.shape, width), 4);
+  const subtitleLines = wrapText(subtitle, mockSubtitleChars(node.shape, width), 4);
+  const badgeColor = withAlpha(color, '1A');
+  const shell = renderMockShell(node.shape, x, y, width, height, borderColor, color, options.palette.bgPrimary);
+  const overlay = hasChildren
+    ? `<rect x="${x + 6}" y="${y + 6}" width="${Math.max(1, width - 12)}" height="${Math.max(1, height - 12)}" rx="${node.shape === 'pill' ? (height - 12) / 2 : 18}" fill="none" stroke="${withAlpha(color, options.style === 'clean' ? '40' : '55')}" stroke-width="1.5" stroke-dasharray="6 5" />`
+    : '';
+
+  if (node.shape === 'diamond') {
+    let currentY = y + (badge ? 28 : 22);
+    const badgeSvg = badge
+      ? `<rect x="${x + width / 2 - Math.min(72, badge.length * 4.3 + 16)}" y="${y + 18}" width="${Math.min(144, badge.length * 8.6 + 32)}" height="18" rx="9" fill="${badgeColor}" />
+         <text class="node-badge" x="${x + width / 2}" y="${y + 31}" text-anchor="middle" fill="${color}">${escapeXml(badge)}</text>`
+      : '';
+    const titleSvg = titleLines.map((line) => {
+      const next = `<text class="node-title" x="${x + width / 2}" y="${currentY + 16}" text-anchor="middle">${escapeXml(line)}</text>`;
+      currentY += 18;
+      return next;
+    }).join('');
+    currentY += subtitleLines.length > 0 ? 8 : 0;
+    const subtitleSvg = subtitleLines.map((line) => {
+      const next = `<text class="node-subtitle" x="${x + width / 2}" y="${currentY + 14}" text-anchor="middle">${escapeXml(line)}</text>`;
+      currentY += 16;
+      return next;
+    }).join('');
+    return `<g>${shell}${overlay}${badgeSvg}${titleSvg}${subtitleSvg}</g>`;
+  }
+
+  const horizontalInset = node.shape === 'pill' ? 28 : node.shape === 'note' ? 24 : 18;
+  let currentY = y + 22;
+  const badgeSvg = badge
+    ? `<rect x="${x + horizontalInset}" y="${currentY - 2}" width="${Math.min(150, badge.length * 8.5 + 22)}" height="18" rx="9" fill="${badgeColor}" />
+       <text class="node-badge" x="${x + horizontalInset + 11}" y="${currentY + 11}" fill="${color}">${escapeXml(badge)}</text>`
+    : '';
+  currentY += badge ? 24 : 4;
+  const titleSvg = titleLines.map((line) => {
+    const next = `<text class="node-title" x="${x + horizontalInset}" y="${currentY + 14}">${escapeXml(line)}</text>`;
+    currentY += 18;
+    return next;
+  }).join('');
+  currentY += subtitleLines.length > 0 ? 8 : 0;
+  const subtitleSvg = subtitleLines.map((line) => {
+    const next = `<text class="node-subtitle" x="${x + horizontalInset}" y="${currentY + 12}">${escapeXml(line)}</text>`;
+    currentY += 16;
+    return next;
+  }).join('');
+
+  return `<g>${shell}${overlay}${badgeSvg}${titleSvg}${subtitleSvg}</g>`;
+}
+
+function renderEntityNode(
+  node: FlowEntityNode,
+  title: string,
+  subtitle: string,
+  badge: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  hasChildren: boolean,
+  color: string,
+  options: NormalizedFlowExportOptions
+): string {
+  const badgeColor = withAlpha(color, '1A');
+  const titleLines = wrapText(title, 22, 3);
+  const subtitleLines = wrapText(subtitle, 24, 2);
+  const health = options.healthStatuses.get(nodeEntityKey(node));
+  const healthColor = health === true ? '#10B981' : health === false ? options.palette.danger : '';
+  const borderColor = options.style === 'clean' ? withAlpha(color, '66') : options.palette.border;
+
+  let currentY = y + 18;
+  const badgeSvg = badge
+    ? `<rect x="${x + 14}" y="${currentY}" width="${Math.min(150, badge.length * 8.5 + 22)}" height="18" rx="9" fill="${badgeColor}" />
+       <text class="node-badge" x="${x + 25}" y="${currentY + 13}" fill="${color}">${escapeXml(badge)}</text>`
+    : '';
+  currentY += badge ? 26 : 8;
+  const titleSvg = titleLines.map((line) => {
+    const next = `<text class="node-title" x="${x + 14}" y="${currentY + 14}">${escapeXml(line)}</text>`;
+    currentY += 18;
+    return next;
+  }).join('');
+  const subtitleY = Math.min(y + height - 14, currentY + 18);
+  const subtitleX = x + 14 + (healthColor ? 12 : 0);
+  const subtitleSvg = subtitleLines.map((line, index) => `<text class="node-subtitle" x="${subtitleX}" y="${subtitleY + index * 14}">${escapeXml(line)}</text>`).join('');
+  const healthSvg = healthColor
+    ? `<circle cx="${x + 18}" cy="${subtitleY - 4}" r="4" fill="${healthColor}" />`
+    : '';
+  const containerSvg = hasChildren
+    ? `<rect x="${x + 4}" y="${y + 4}" width="${width - 8}" height="${height - 8}" rx="20" fill="none" stroke="${options.style === 'clean' ? withAlpha(color, '35') : options.palette.border}" stroke-width="1.2" stroke-dasharray="6 5" />`
+    : '';
+
+  return `<g>
+    <rect x="${x}" y="${y}" width="${width}" height="${height}" rx="24" fill="${options.palette.bgPrimary}" stroke="${borderColor}" stroke-width="${options.style === 'clean' ? 1.8 : 1.2}" />
+    ${containerSvg}
+    ${badgeSvg}
+    ${titleSvg}
+    ${healthSvg}
+    ${subtitleSvg}
+  </g>`;
+}
+
+function renderMockShell(
+  shape: 'box' | 'pill' | 'diamond' | 'note',
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  borderColor: string,
+  color: string,
+  fill: string
+): string {
+  switch (shape) {
+    case 'pill':
+      return `<rect x="${x}" y="${y + 4}" width="${width}" height="${Math.max(1, height - 8)}" rx="${Math.max(18, (height - 8) / 2)}" fill="${fill}" stroke="${borderColor}" stroke-width="1.5" />`;
+    case 'diamond':
+      return `<polygon points="${x + width / 2},${y + 6} ${x + width - 14},${y + height / 2} ${x + width / 2},${y + height - 6} ${x + 14},${y + height / 2}" fill="${fill}" stroke="${borderColor}" stroke-width="1.5" />`;
+    case 'note':
+      return `<g>
+        <path d="M ${x + 14} ${y + 8} H ${x + width - 34} L ${x + width - 14} ${y + 28} V ${y + height - 14} Q ${x + width - 14} ${y + height - 8} ${x + width - 22} ${y + height - 8} H ${x + 22} Q ${x + 14} ${y + height - 8} ${x + 14} ${y + height - 16} Z" fill="${fill}" stroke="${borderColor}" stroke-width="1.5" />
+        <path d="M ${x + width - 34} ${y + 8} V ${y + 22} Q ${x + width - 34} ${y + 28} ${x + width - 28} ${y + 28} H ${x + width - 14} L ${x + width - 34} ${y + 8} Z" fill="${mockFoldFill(color)}" stroke="${borderColor}" stroke-width="1.5" stroke-linejoin="round" />
+      </g>`;
+    case 'box':
+    default:
+      return `<rect x="${x}" y="${y}" width="${width}" height="${height}" rx="20" fill="${fill}" stroke="${borderColor}" stroke-width="1.5" />`;
+  }
+}
+
+function renderEmptyState(contentWidth: number, contentHeight: number, palette: FlowExportPalette): string {
+  const centerX = contentWidth / 2;
+  const centerY = contentHeight / 2;
+  return `<g>
+    <circle cx="${centerX}" cy="${centerY - 36}" r="34" fill="${withAlpha(palette.accent, '12')}" />
+    <path d="M ${centerX - 16} ${centerY - 36} h 32 M ${centerX} ${centerY - 52} v 32" stroke="${palette.accent}" stroke-width="2.5" stroke-linecap="round" />
+    <text class="empty-title" x="${centerX}" y="${centerY + 26}" text-anchor="middle">Start building this flow</text>
+    <text class="empty-body" x="${centerX}" y="${centerY + 52}" text-anchor="middle">Add entities or mock nodes in Gantry, then export the finished diagram to share it.</text>
+  </g>`;
+}
+
+function getDiagramBounds(spec: FlowSpec, nodeMap: Map<string, FlowSpec['nodes'][number]>, padding: number) {
+  if (spec.nodes.length === 0) {
+    return {
+      minX: 0,
+      minY: 0,
+      maxX: EMPTY_CONTENT_WIDTH,
+      maxY: EMPTY_CONTENT_HEIGHT,
+      width: EMPTY_CONTENT_WIDTH,
+      height: EMPTY_CONTENT_HEIGHT,
+    };
+  }
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const node of spec.nodes) {
+    const absPos = getAbsolutePosition(node, nodeMap);
+    const size = getNodeDimensions(node);
+    minX = Math.min(minX, absPos.x);
+    minY = Math.min(minY, absPos.y);
+    maxX = Math.max(maxX, absPos.x + size.width);
+    maxY = Math.max(maxY, absPos.y + size.height);
+  }
+
+  minX -= padding;
+  minY -= padding;
+  maxX += padding;
+  maxY += padding;
+
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+  };
+}
+
+function resolveThemePalette(theme: FlowExportTheme): FlowExportPalette {
+  if (theme === 'light') return LIGHT_EXPORT_PALETTE;
+  if (theme === 'dark') return DARK_EXPORT_PALETTE;
+
+  const styles = getComputedStyle(document.documentElement);
+  const read = (name: string, fallback: string) => styles.getPropertyValue(name).trim() || fallback;
+
+  return {
+    bgPrimary: read('--gantry-bg-primary', LIGHT_EXPORT_PALETTE.bgPrimary),
+    bgSecondary: read('--gantry-bg-secondary', LIGHT_EXPORT_PALETTE.bgSecondary),
+    bgTertiary: read('--gantry-bg-tertiary', LIGHT_EXPORT_PALETTE.bgTertiary),
+    textPrimary: read('--gantry-text-primary', LIGHT_EXPORT_PALETTE.textPrimary),
+    textSecondary: read('--gantry-text-secondary', LIGHT_EXPORT_PALETTE.textSecondary),
+    border: read('--gantry-border', LIGHT_EXPORT_PALETTE.border),
+    accent: read('--gantry-accent', LIGHT_EXPORT_PALETTE.accent),
+    accentHover: read('--gantry-accent-hover', LIGHT_EXPORT_PALETTE.accentHover),
+    danger: read('--gantry-danger', LIGHT_EXPORT_PALETTE.danger),
+    grid: withAlpha(read('--gantry-text-secondary', LIGHT_EXPORT_PALETTE.textSecondary), '16'),
+  };
+}
+
+function getDocumentBackground(options: NormalizedFlowExportOptions): string {
+  switch (options.background) {
+    case 'light':
+      return '#FFFFFF';
+    case 'transparent':
+      return '';
+    case 'theme':
+    default:
+      return options.palette.bgSecondary;
+  }
+}
+
+function resolveEdgeColor(color: string, palette: FlowExportPalette): string {
+  if (color === FLOW_EDGE_UNHEALTHY_STROKE || color === 'var(--gantry-danger)') return palette.danger;
+  return color;
+}
+
+function nodeTitle(node: FlowSpec['nodes'][number], entitiesByKey: Map<string, Entity>): string {
+  if (isMockNode(node)) return node.label;
+  return entitiesByKey.get(nodeEntityKey(node))?.metadata.title || node.entityRef.name;
+}
+
+function mockTitleChars(shape: 'box' | 'pill' | 'diamond' | 'note', width: number): number {
+  switch (shape) {
+    case 'diamond':
+      return Math.max(8, Math.floor((width * 0.42) / 8));
+    case 'pill':
+      return Math.max(12, Math.floor((width - 44) / 8));
+    case 'note':
+      return Math.max(12, Math.floor((width - 52) / 8));
+    case 'box':
+    default:
+      return Math.max(12, Math.floor((width - 36) / 8));
+  }
+}
+
+function mockSubtitleChars(shape: 'box' | 'pill' | 'diamond' | 'note', width: number): number {
+  switch (shape) {
+    case 'diamond':
+      return Math.max(8, Math.floor((width * 0.42) / 9));
+    case 'pill':
+      return Math.max(12, Math.floor((width - 44) / 9));
+    case 'note':
+      return Math.max(12, Math.floor((width - 52) / 9));
+    case 'box':
+    default:
+      return Math.max(12, Math.floor((width - 36) / 9));
+  }
+}
+
+function wrapText(text: string, maxChars: number, maxLines: number): string[] {
+  const normalized = text.trim();
+  if (!normalized) return [];
+
+  const lines: string[] = [];
+  for (const segment of normalized.split(/\r?\n/)) {
+    const words = segment.split(/\s+/).filter(Boolean);
+    if (words.length === 0) {
+      lines.push('');
+      continue;
+    }
+
+    let current = '';
+    for (const word of words) {
+      if (word.length > maxChars) {
+        if (current) {
+          lines.push(current);
+          current = '';
+        }
+        for (let index = 0; index < word.length; index += maxChars) {
+          lines.push(word.slice(index, index + maxChars));
+        }
+        continue;
+      }
+
+      const candidate = current ? `${current} ${word}` : word;
+      if (candidate.length <= maxChars) {
+        current = candidate;
+      } else {
+        lines.push(current);
+        current = word;
+      }
+    }
+    if (current) lines.push(current);
+  }
+
+  if (lines.length <= maxLines) return lines;
+  const clamped = lines.slice(0, maxLines);
+  const last = clamped[maxLines - 1];
+  clamped[maxLines - 1] = last.length >= maxChars ? `${last.slice(0, Math.max(1, maxChars - 1))}…` : `${last}…`;
+  return clamped;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function sanitizeFileName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-_]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'flow';
+}
+
+async function renderSvgToCanvas(svg: string, width: number, height: number, scale: number): Promise<HTMLCanvasElement> {
+  const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const image = await loadImage(url);
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(width * scale));
+    canvas.height = Math.max(1, Math.round(height * scale));
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Canvas export is not supported in this browser');
+    context.setTransform(scale, 0, 0, scale, 0, 0);
+    context.drawImage(image, 0, 0, width, height);
+    return canvas;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Failed to render exported flow'));
+    image.src = url;
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('Failed to encode exported flow'));
+        return;
+      }
+      resolve(blob);
+    }, type);
+  });
+}
+
+function decodeBase64DataUrl(dataUrl: string): Uint8Array {
+  const [, payload = ''] = dataUrl.split(',', 2);
+  const binary = atob(payload);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function buildPdfFromJpeg(jpegBytes: Uint8Array, imageWidth: number, imageHeight: number): Uint8Array {
+  const pageSize = imageWidth >= imageHeight ? PDF_LANDSCAPE : PDF_PORTRAIT;
+  const margin = 24;
+  const scale = Math.min(
+    (pageSize.width - margin * 2) / imageWidth,
+    (pageSize.height - margin * 2) / imageHeight
+  );
+  const drawWidth = imageWidth * scale;
+  const drawHeight = imageHeight * scale;
+  const x = (pageSize.width - drawWidth) / 2;
+  const y = (pageSize.height - drawHeight) / 2;
+
+  const contentStream = `q
+${formatPdfNumber(drawWidth)} 0 0 ${formatPdfNumber(drawHeight)} ${formatPdfNumber(x)} ${formatPdfNumber(y)} cm
+/Im0 Do
+Q
+`;
+
+  const objects: Uint8Array[] = [
+    encodeAscii('<< /Type /Catalog /Pages 2 0 R >>'),
+    encodeAscii('<< /Type /Pages /Kids [3 0 R] /Count 1 >>'),
+    encodeAscii(`<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${formatPdfNumber(pageSize.width)} ${formatPdfNumber(pageSize.height)}] /Resources << /XObject << /Im0 4 0 R >> /ProcSet [/PDF /ImageC] >> /Contents 5 0 R >>`),
+    concatBytes([
+      encodeAscii(`<< /Type /XObject /Subtype /Image /Width ${Math.max(1, imageWidth)} /Height ${Math.max(1, imageHeight)} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${jpegBytes.length} >>\nstream\n`),
+      jpegBytes,
+      encodeAscii('\nendstream'),
+    ]),
+    concatBytes([
+      encodeAscii(`<< /Length ${contentStream.length} >>\nstream\n${contentStream}endstream`),
+    ]),
+  ];
+
+  const header = encodeAscii('%PDF-1.4\n');
+  const bodyChunks: Uint8Array[] = [header];
+  const offsets: number[] = [0];
+  let offset = header.length;
+
+  objects.forEach((objectBytes, index) => {
+    offsets.push(offset);
+    const prefix = encodeAscii(`${index + 1} 0 obj\n`);
+    const suffix = encodeAscii('\nendobj\n');
+    bodyChunks.push(prefix, objectBytes, suffix);
+    offset += prefix.length + objectBytes.length + suffix.length;
+  });
+
+  const xrefOffset = offset;
+  const xrefLines = ['xref', `0 ${objects.length + 1}`, '0000000000 65535 f '];
+  for (let index = 1; index < offsets.length; index++) {
+    xrefLines.push(`${String(offsets[index]).padStart(10, '0')} 00000 n `);
+  }
+  const trailer = `trailer
+<< /Size ${objects.length + 1} /Root 1 0 R >>
+startxref
+${xrefOffset}
+%%EOF`;
+  bodyChunks.push(encodeAscii(`${xrefLines.join('\n')}\n${trailer}`));
+  return concatBytes(bodyChunks);
+}
+
+function formatPdfNumber(value: number): string {
+  return Number(value.toFixed(2)).toString();
+}
+
+function encodeAscii(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function downloadBlob(fileName: string, blob: Blob) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/web/src/pages/Flow.tsx
+++ b/web/src/pages/Flow.tsx
@@ -8,6 +8,7 @@ import {
   ChevronsDown,
   ChevronsUp,
   Copy,
+  Download,
   ExternalLink,
   GitBranch,
   Grid3X3,
@@ -24,8 +25,18 @@ import {
   Unplug,
   Wand2,
   Workflow,
+  X,
 } from 'lucide-react';
 import { api } from '../lib/api';
+import {
+  exportFlowDiagram,
+  getFlowExportPreview,
+  type FlowExportBackground,
+  type FlowExportFormat,
+  type FlowExportPreview,
+  type FlowExportStyle,
+  type FlowExportTheme,
+} from '../lib/flow-export';
 import type { Entity, FlowEdge, FlowMockNode, FlowMockShape, FlowNode, FlowPluginSettings, FlowSpec } from '../lib/types';
 import {
   autoArrangeNodes,
@@ -56,6 +67,7 @@ import {
   renderMockNodeShell,
 } from '../lib/flow';
 import { useFlowHealth } from '../hooks/useFlowHealth';
+import { useTheme } from '../hooks/useTheme';
 
 const CANVAS_WIDTH = 1600;
 const CANVAS_HEIGHT = 900;
@@ -66,12 +78,86 @@ const FIT_PADDING = 48;
 const CONTENT_PADDING = 64;
 const DUPLICATE_OFFSET = 32;
 const RELATION_OPTIONS = ['calls', 'dependsOn', 'readsFrom', 'writesTo', 'publishesTo', 'subscribesTo', 'consumes', 'provides'];
+const EXPORT_STYLE_OPTIONS: Array<{ value: FlowExportStyle; label: string; description: string }> = [
+  {
+    value: 'clean',
+    label: 'Clean Diagram',
+    description: 'Diagram-first export with no canvas chrome. Great for sharing with people outside Gantry.',
+  },
+  {
+    value: 'presentation',
+    label: 'Presentation',
+    description: 'Keeps the title block, framed canvas, and Gantry-style visual treatment.',
+  },
+];
+const EXPORT_FORMAT_OPTIONS: Array<{ value: FlowExportFormat; label: string; description: string }> = [
+  {
+    value: 'pdf',
+    label: 'PDF',
+    description: 'Best for documents, reviews, and people who expect a print-friendly file.',
+  },
+  {
+    value: 'png',
+    label: 'PNG',
+    description: 'A bitmap image that drops well into slides, docs, and chat.',
+  },
+  {
+    value: 'svg',
+    label: 'SVG',
+    description: 'A scalable vector export that stays sharp when resized.',
+  },
+];
+const EXPORT_BACKGROUND_OPTIONS: Array<{ value: FlowExportBackground; label: string; description: string }> = [
+  {
+    value: 'transparent',
+    label: 'Transparent',
+    description: 'Exports only the diagram itself for slides and docs.',
+  },
+  {
+    value: 'light',
+    label: 'White',
+    description: 'Adds a neutral white page behind the diagram.',
+  },
+  {
+    value: 'theme',
+    label: 'Match Theme',
+    description: 'Uses the selected export theme around the diagram.',
+  },
+];
+const EXPORT_THEME_OPTIONS: Array<{ value: FlowExportTheme; label: string; description: string }> = [
+  {
+    value: 'app',
+    label: 'App Theme',
+    description: 'Matches the current Gantry theme.',
+  },
+  {
+    value: 'light',
+    label: 'Light',
+    description: 'Light node surfaces, icons, and chrome.',
+  },
+  {
+    value: 'dark',
+    label: 'Dark',
+    description: 'Dark node surfaces, icons, and chrome.',
+  },
+];
 const MOCK_NODE_LIBRARY: Array<{ label: string; subtitle: string; shape: FlowMockShape; color: string }> = [
   { label: 'Box', subtitle: 'Generic process step', shape: 'box', color: '#64748B' },
   { label: 'Diamond', subtitle: 'Decision or branch point', shape: 'diamond', color: '#F59E0B' },
   { label: 'Pill', subtitle: 'External actor or entry point', shape: 'pill', color: '#8B5CF6' },
   { label: 'Note', subtitle: 'Idea, future state, or comment', shape: 'note', color: '#0EA5E9' },
 ];
+
+function defaultExportStyleForFormat(format: FlowExportFormat): FlowExportStyle {
+  return format === 'svg' ? 'presentation' : 'clean';
+}
+
+function defaultExportBackgroundFor(format: FlowExportFormat, style: FlowExportStyle): FlowExportBackground {
+  if (format === 'pdf') {
+    return style === 'clean' ? 'light' : 'theme';
+  }
+  return style === 'clean' ? 'transparent' : 'theme';
+}
 
 function defaultFlowSpec(): FlowSpec {
   return {
@@ -236,12 +322,19 @@ function getFitViewState(width: number, height: number, spec: FlowSpec) {
 export default function Flow() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { theme: appTheme } = useTheme();
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const suppressNodeClickRef = useRef(false);
   const suppressCanvasClickRef = useRef(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [exportingFormat, setExportingFormat] = useState<FlowExportFormat | null>(null);
+  const [showExportDialog, setShowExportDialog] = useState(false);
+  const [exportFormat, setExportFormat] = useState<FlowExportFormat>('pdf');
+  const [exportStyle, setExportStyle] = useState<FlowExportStyle>('clean');
+  const [exportBackground, setExportBackground] = useState<FlowExportBackground>('light');
+  const [exportTheme, setExportTheme] = useState<FlowExportTheme>('app');
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const [pluginEnabled, setPluginEnabled] = useState(false);
   const [flowSettings, setFlowSettings] = useState<FlowPluginSettings>({
@@ -1185,6 +1278,96 @@ export default function Flow() {
   const selectedNode = flowSpec.nodes.find((node) => node.id === selectedNodeId) || null;
   const selectedEdge = flowSpec.edges.find((edge) => edge.id === selectedEdgeId) || null;
   const entityMap = new Map(availableEntities.map((entity) => [entityKey(entity), entity]));
+  const exportDisabled = flowSpec.nodes.length === 0 && flowSpec.edges.length === 0;
+
+  const exportPreview = useMemo<FlowExportPreview | null>(() => {
+    if (!showExportDialog || exportDisabled) return null;
+    return getFlowExportPreview({
+      name: flowName.trim() || currentFlowName || 'flow',
+      title: flowTitleValue.trim() || undefined,
+      description: flowDescription.trim() || undefined,
+      owner: flowOwner.trim() || undefined,
+      namespace: currentNamespace,
+      spec: flowSpec,
+      entitiesByKey: entityMap,
+      healthStatuses,
+      style: exportStyle,
+      background: exportBackground,
+      theme: exportTheme,
+    }, exportFormat);
+  }, [
+    showExportDialog,
+    exportDisabled,
+    flowName,
+    currentFlowName,
+    flowTitleValue,
+    flowDescription,
+    flowOwner,
+    currentNamespace,
+    flowSpec,
+    entityMap,
+    healthStatuses,
+    exportStyle,
+    exportBackground,
+    exportTheme,
+    exportFormat,
+  ]);
+
+  function openExportDialog() {
+    if (exportDisabled || exportingFormat) return;
+    const nextFormat = exportFormat;
+    const nextStyle = defaultExportStyleForFormat(nextFormat);
+    setExportFormat(nextFormat);
+    setExportStyle(nextStyle);
+    setExportBackground(defaultExportBackgroundFor(nextFormat, nextStyle));
+    setExportTheme('app');
+    setShowExportDialog(true);
+    setError('');
+  }
+
+  function closeExportDialog() {
+    if (exportingFormat) return;
+    setShowExportDialog(false);
+  }
+
+  function updateExportFormat(nextFormat: FlowExportFormat) {
+    setExportFormat(nextFormat);
+    setExportBackground(defaultExportBackgroundFor(nextFormat, exportStyle));
+  }
+
+  function updateExportStyle(nextStyle: FlowExportStyle) {
+    setExportStyle(nextStyle);
+    setExportBackground(defaultExportBackgroundFor(exportFormat, nextStyle));
+  }
+
+  async function confirmExport() {
+    if (!showExportDialog || exportDisabled || exportingFormat) return;
+
+    setExportingFormat(exportFormat);
+    setError('');
+
+    try {
+      await exportFlowDiagram({
+        name: flowName.trim() || currentFlowName || 'flow',
+        title: flowTitleValue.trim() || undefined,
+        description: flowDescription.trim() || undefined,
+        owner: flowOwner.trim() || undefined,
+        namespace: currentNamespace,
+        spec: flowSpec,
+        entitiesByKey: entityMap,
+        healthStatuses,
+        style: exportStyle,
+        background: exportBackground,
+        theme: exportTheme,
+      }, exportFormat);
+      setNotice(`Exported ${flowTitleValue.trim() || flowName.trim() || currentFlowName || 'flow'} as ${exportFormat.toUpperCase()} (${exportStyle === 'clean' ? 'clean diagram' : 'presentation'}).`);
+      setShowExportDialog(false);
+    } catch (err: any) {
+      setError(err.message || `Failed to export Flow as ${exportFormat.toUpperCase()}`);
+    } finally {
+      setExportingFormat(null);
+    }
+  }
 
   const nodeMap = useMemo(
     () => new Map(flowSpec.nodes.map((n) => [n.id, n])),
@@ -1220,7 +1403,7 @@ export default function Flow() {
       <div className="rounded-2xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-4">
         <h2 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Saved Flows</h2>
         <p className="mt-1 text-xs text-[var(--gantry-text-secondary)]">
-          Diagrams persist as `Flow` entities and can be exported by GitOps like the rest of your catalog.
+          Diagrams persist as `Flow` entities, so you can share them as SVG, PNG, PDF, or GitOps-backed YAML.
         </p>
         <div className="mt-4 space-y-2">
           {flows.length === 0 ? (
@@ -1249,6 +1432,231 @@ export default function Flow() {
               );
             })
           )}
+        </div>
+      </div>
+    );
+  }
+
+  function renderExportDialog() {
+    if (!showExportDialog) return null;
+
+    const previewUrl = exportPreview
+      ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(exportPreview.svg)}`
+      : '';
+    const selectedThemeLabel = exportTheme === 'app'
+      ? `App ${appTheme === 'dark' ? 'Dark' : 'Light'}`
+      : exportTheme === 'dark'
+      ? 'Dark'
+      : 'Light';
+    const previewBackgroundClass = exportBackground === 'transparent'
+      ? 'bg-[linear-gradient(45deg,rgba(148,163,184,0.18)_25%,transparent_25%,transparent_75%,rgba(148,163,184,0.18)_75%,rgba(148,163,184,0.18)),linear-gradient(45deg,rgba(148,163,184,0.18)_25%,transparent_25%,transparent_75%,rgba(148,163,184,0.18)_75%,rgba(148,163,184,0.18))] bg-[length:24px_24px] bg-[position:0_0,12px_12px]'
+      : '';
+    const previewBackgroundStyle: CSSProperties | undefined = exportBackground === 'transparent'
+      ? undefined
+      : exportBackground === 'light'
+      ? { backgroundColor: '#FFFFFF' }
+      : {
+          backgroundColor: exportTheme === 'dark'
+            ? '#111113'
+            : exportTheme === 'light'
+            ? '#F8FAFC'
+            : 'var(--gantry-bg-secondary)',
+        };
+    const optionButtonClass = (selected: boolean) => `flex h-full min-h-[9.5rem] w-full flex-col items-start justify-start rounded-lg border px-3 py-2.5 text-left transition-colors ${
+      selected
+        ? 'border-[var(--gantry-accent)] bg-[var(--gantry-accent)]/10'
+        : 'border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-bg-tertiary)]'
+    }`;
+
+    return (
+      <div className="fixed inset-0 z-50 overflow-y-auto bg-black/55 p-3 sm:p-6" onClick={closeExportDialog}>
+        <div className="flex min-h-full items-center justify-center">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="flow-export-dialog-title"
+            className="flex max-h-[calc(100vh-1.5rem)] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] shadow-2xl sm:max-h-[calc(100vh-3rem)]"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-4 border-b border-[var(--gantry-border)] px-4 py-4 sm:px-6 sm:py-5">
+              <div>
+                <h2 id="flow-export-dialog-title" className="text-lg font-semibold text-[var(--gantry-text-primary)]">
+                  Export Flow
+                </h2>
+                <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
+                  Pick the format, look, and theme, then preview before downloading.
+                </p>
+              </div>
+              <button
+                onClick={closeExportDialog}
+                disabled={Boolean(exportingFormat)}
+                className="rounded-lg p-2 text-[var(--gantry-text-secondary)] hover:bg-[var(--gantry-bg-secondary)] hover:text-[var(--gantry-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5">
+              <div className="space-y-5">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] p-3">
+                    <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Format</h3>
+                    <p className="mt-1 text-xs text-[var(--gantry-text-secondary)]">
+                      Choose the file type first.
+                    </p>
+                    <div className="mt-3 grid gap-2 sm:grid-cols-3">
+                      {EXPORT_FORMAT_OPTIONS.map((option) => {
+                        const selected = exportFormat === option.value;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => updateExportFormat(option.value)}
+                            className={optionButtonClass(selected)}
+                          >
+                            <div className="text-sm font-semibold text-[var(--gantry-text-primary)]">{option.label}</div>
+                            <p className="mt-1 text-[11px] leading-4 text-[var(--gantry-text-secondary)]">{option.description}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] p-3">
+                    <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Style</h3>
+                    <p className="mt-1 text-xs text-[var(--gantry-text-secondary)]">
+                      Clean is diagram-first. Presentation keeps the framed Gantry look.
+                    </p>
+                    <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                      {EXPORT_STYLE_OPTIONS.map((option) => {
+                        const selected = exportStyle === option.value;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => updateExportStyle(option.value)}
+                            className={optionButtonClass(selected)}
+                          >
+                            <div className="text-sm font-semibold text-[var(--gantry-text-primary)]">{option.label}</div>
+                            <p className="mt-1 text-[11px] leading-4 text-[var(--gantry-text-secondary)]">{option.description}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] p-3">
+                    <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Theme</h3>
+                    <p className="mt-1 text-xs text-[var(--gantry-text-secondary)]">
+                      Controls node surfaces, icon chips, and export chrome. Current app theme: {appTheme}.
+                    </p>
+                    <div className="mt-3 grid gap-2 sm:grid-cols-3">
+                      {EXPORT_THEME_OPTIONS.map((option) => {
+                        const selected = exportTheme === option.value;
+                        const description = option.value === 'app'
+                          ? `Matches Gantry’s current ${appTheme} theme.`
+                          : option.description;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => setExportTheme(option.value)}
+                            className={optionButtonClass(selected)}
+                          >
+                            <div className="text-sm font-semibold text-[var(--gantry-text-primary)]">{option.label}</div>
+                            <p className="mt-1 text-[11px] leading-4 text-[var(--gantry-text-secondary)]">{description}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] p-3">
+                    <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Background</h3>
+                    <p className="mt-1 text-xs text-[var(--gantry-text-secondary)]">
+                      Choose what sits behind the diagram in the final file.
+                    </p>
+                    {exportFormat !== 'pdf' ? (
+                      <div className="mt-3 grid gap-2 sm:grid-cols-3">
+                        {EXPORT_BACKGROUND_OPTIONS.map((option) => {
+                          const selected = exportBackground === option.value;
+                          return (
+                            <button
+                              key={option.value}
+                              type="button"
+                              onClick={() => setExportBackground(option.value)}
+                              className={optionButtonClass(selected)}
+                            >
+                              <div className="text-sm font-semibold text-[var(--gantry-text-primary)]">{option.label}</div>
+                              <p className="mt-1 text-[11px] leading-4 text-[var(--gantry-text-secondary)]">{option.description}</p>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <div className="mt-3 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-xs leading-5 text-[var(--gantry-text-secondary)]">
+                        PDF always uses an opaque page. Clean defaults to white, while Match Theme uses the selected export theme.
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Preview</h3>
+                      <p className="mt-1 text-xs text-[var(--gantry-text-secondary)]">
+                        This uses the same SVG source as the final export.
+                      </p>
+                    </div>
+                    <div className="rounded-full border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-1 text-xs font-medium text-[var(--gantry-text-secondary)]">
+                      {exportFormat.toUpperCase()} · {exportStyle === 'clean' ? 'Clean' : 'Presentation'} · {selectedThemeLabel}
+                    </div>
+                  </div>
+
+                  <div
+                    className={`max-h-[50vh] overflow-auto rounded-2xl border border-[var(--gantry-border)] p-3 sm:p-4 ${previewBackgroundClass}`}
+                    style={previewBackgroundStyle}
+                  >
+                    {exportPreview ? (
+                      <div className="flex min-h-[14rem] min-w-full items-center justify-center sm:min-h-[18rem]">
+                        <img
+                          src={previewUrl}
+                          alt="Export preview"
+                          className="h-auto max-w-none rounded-lg shadow-sm"
+                          style={{
+                            width: Math.min(exportPreview.width, 960),
+                            minWidth: Math.min(exportPreview.width, 260),
+                            aspectRatio: `${exportPreview.width} / ${exportPreview.height}`,
+                          }}
+                        />
+                      </div>
+                    ) : (
+                      <div className="text-sm text-[var(--gantry-text-secondary)]">Preparing preview…</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-end gap-3 border-t border-[var(--gantry-border)] px-4 py-4 sm:px-6">
+              <button
+                onClick={closeExportDialog}
+                disabled={Boolean(exportingFormat)}
+                className="rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-4 py-2 text-sm font-medium text-[var(--gantry-text-primary)] hover:bg-[var(--gantry-bg-tertiary)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => void confirmExport()}
+                disabled={Boolean(exportingFormat)}
+                className="inline-flex items-center gap-2 rounded-lg bg-[var(--gantry-accent)] px-4 py-2 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {exportingFormat ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                Export {exportFormat.toUpperCase()}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -1863,6 +2271,7 @@ export default function Flow() {
 
   return (
     <div className="space-y-6">
+      {renderExportDialog()}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <div className="flex items-center gap-3">
@@ -1872,7 +2281,7 @@ export default function Flow() {
             <div>
               <h1 className="text-2xl font-bold text-[var(--gantry-text-primary)]">Flow</h1>
               <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">
-                Build shared system diagrams from existing catalog entities and keep them GitOps-friendly as `Flow` YAML.
+                Build shared system diagrams from existing catalog entities and export them in common formats when you need to share outside Gantry.
               </p>
             </div>
           </div>
@@ -1896,6 +2305,14 @@ export default function Flow() {
               View only
             </span>
           )}
+          <button
+            onClick={openExportDialog}
+            disabled={exportDisabled || Boolean(exportingFormat)}
+            className="inline-flex items-center gap-2 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-4 py-2 text-sm font-medium text-[var(--gantry-text-primary)] hover:bg-[var(--gantry-bg-tertiary)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {exportingFormat ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+            Export
+          </button>
           {mode === 'view' ? (
             <>
               {flowSettings.canEdit && (


### PR DESCRIPTION
## Summary
- Consolidate flow exporting into a single dialog with shared format, style, background, and theme controls
- Add live preview generation so the dialog matches the final SVG/PNG/PDF output
- Tighten the modal layout for consistency, scrollability, and smaller option cards
- Add export theme selection for app, light, and dark node/background styling

## Testing
- Local UI validation in the flow export dialog
- Frontend build verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export flow diagrams in multiple formats (SVG, PNG, and PDF) for sharing and documentation
  * Customize exported diagrams with adjustable style (clean or presentation mode), theme (app, light, or dark), and background options
  * Preview diagrams before downloading to verify export appearance and settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->