### PR TITLE
Fix: Flow node resizing and wrapping

### DIFF
--- a/internal/entity/schemas/flow.json
+++ b/internal/entity/schemas/flow.json
@@ -55,6 +55,18 @@
                 "required": ["kind", "name"],
                 "additionalProperties": false
               },
+              "shape": {
+                "type": "string",
+                "enum": ["box", "pill", "diamond", "note"]
+              },
+              "width": {
+                "type": "number",
+                "exclusiveMinimum": 0
+              },
+              "height": {
+                "type": "number",
+                "exclusiveMinimum": 0
+              },
               "position": {
                 "type": "object",
                 "properties": {

--- a/web/src/components/FlowTab.tsx
+++ b/web/src/components/FlowTab.tsx
@@ -10,6 +10,7 @@ import {
   edgeLabelPosition,
   edgeOffsetTransform,
   edgePath,
+  entityKey,
   ensureFlowSpec,
   FLOW_EDGE_HEALTHY_STROKE,
   FLOW_EDGE_STROKE,
@@ -21,6 +22,8 @@ import {
   mockContentStyle,
   nodeBadge,
   nodeColor,
+  nodeEntityKey,
+  nodeShape,
   nodeSubtitle,
   renderMockNodeShell,
 } from '../lib/flow';
@@ -38,14 +41,24 @@ function flowHref(entity: Entity, mode: 'view' | 'edit') {
   return `/flow?${params.toString()}`;
 }
 
-function nodeTitle(node: Parameters<typeof nodeColor>[0]): string {
-  return isMockNode(node) ? node.label : node.entityRef.name;
+function clampText(lines: number) {
+  return {
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical' as const,
+    WebkitLineClamp: lines,
+    overflow: 'hidden',
+  };
+}
+
+function nodeTitle(node: Parameters<typeof nodeColor>[0], entityMap: Map<string, Entity>): string {
+  return isMockNode(node) ? node.label : entityMap.get(nodeEntityKey(node))?.metadata.title || node.entityRef.name;
 }
 
 export default function FlowTab({ entity }: { entity: Entity }) {
   const flowSpec = ensureFlowSpec(entity.spec);
   const [availableEntities, setAvailableEntities] = useState<Entity[]>([]);
   const healthStatuses = useFlowHealth(flowSpec.nodes, availableEntities);
+  const entityMap = new Map(availableEntities.map((candidate) => [entityKey(candidate), candidate]));
 
   useEffect(() => {
     let active = true;
@@ -77,7 +90,7 @@ export default function FlowTab({ entity }: { entity: Entity }) {
     let maxX = -Infinity;
     let maxY = -Infinity;
     for (const node of flowSpec.nodes) {
-      const size = getNodeDimensions(node);
+      const size = getNodeDimensions(node, { title: nodeTitle(node, entityMap), subtitle: nodeSubtitle(node) });
       const abs = getAbsolutePosition(node, nodeMap);
       minX = Math.min(minX, abs.x);
       minY = Math.min(minY, abs.y);
@@ -192,8 +205,8 @@ export default function FlowTab({ entity }: { entity: Entity }) {
                 if (!source || !target) return null;
                 const sourceAbs = getAbsolutePosition(source, nodeMap);
                 const targetAbs = getAbsolutePosition(target, nodeMap);
-                const sourceSize = getNodeDimensions(source);
-                const targetSize = getNodeDimensions(target);
+                const sourceSize = getNodeDimensions(source, { title: nodeTitle(source, entityMap), subtitle: nodeSubtitle(source) });
+                const targetSize = getNodeDimensions(target, { title: nodeTitle(target, entityMap), subtitle: nodeSubtitle(target) });
                 const path = edgePath(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
                 const labelPos = edgeLabelPosition(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
                 const twoWay = edge.direction === 'two-way';
@@ -262,11 +275,13 @@ export default function FlowTab({ entity }: { entity: Entity }) {
             </svg>
 
             {flowSpec.nodes.map((node) => {
+              const shape = nodeShape(node);
               const color = nodeColor(node);
               const badge = nodeBadge(node);
               const subtitle = nodeSubtitle(node);
               const baseBorderColor = 'var(--gantry-border)';
-              const nodeSize = getNodeDimensions(node);
+              const title = nodeTitle(node, entityMap);
+              const nodeSize = getNodeDimensions(node, { title, subtitle });
               const absPos = getAbsolutePosition(node, nodeMap);
               return (
                 <div
@@ -280,58 +295,36 @@ export default function FlowTab({ entity }: { entity: Entity }) {
                   }}
                 >
                   <div className="relative h-full w-full">
-                    {isMockNode(node) ? (
-                      renderMockNodeShell(node.shape, baseBorderColor, color, nodeSize.width, nodeSize.height)
-                    ) : (
-                      <div className="absolute inset-0 rounded-2xl border" style={{ borderColor: baseBorderColor, background: 'var(--gantry-bg-primary)' }} />
-                    )}
-
-                    {isMockNode(node) ? (
-                      <div className={`relative flex h-full flex-col ${mockContentClasses(node.shape)}`}>
-                        <div
-                          className={`${node.shape === 'diamond' ? 'w-full space-y-2' : ''} min-w-0`}
-                          style={mockContentStyle(node.shape, nodeSize.width)}
-                        >
-                          {badge && (
-                            <div
-                              className="inline-flex rounded-full px-2 py-0.5 text-[11px] font-semibold"
-                              style={{ backgroundColor: `${color}1A`, color }}
-                            >
-                              {badge}
-                            </div>
-                          )}
-                          <div className={`${badge ? 'mt-2' : ''} break-words whitespace-pre-wrap text-sm font-semibold leading-5 text-[var(--gantry-text-primary)] ${node.shape === 'diamond' ? 'text-center' : ''}`}>
-                            {nodeTitle(node)}
-                          </div>
-                        </div>
-                        {subtitle && (
+                    {renderMockNodeShell(shape, baseBorderColor, color, nodeSize.width, nodeSize.height)}
+                    <div className={`relative flex h-full min-h-0 flex-col overflow-hidden ${mockContentClasses(shape)}`}>
+                      <div
+                        className={`${shape === 'diamond' ? 'w-full space-y-2' : ''} min-w-0`}
+                        style={mockContentStyle(shape, nodeSize.width)}
+                      >
+                        {badge && (
                           <div
-                            className={`min-w-0 break-words whitespace-pre-wrap text-xs leading-4 text-[var(--gantry-text-secondary)] ${node.shape === 'diamond' ? 'text-center' : ''}`}
-                            style={mockContentStyle(node.shape, nodeSize.width)}
+                            className="inline-flex rounded-full px-2 py-0.5 text-[11px] font-semibold"
+                            style={{ backgroundColor: `${color}1A`, color }}
                           >
-                            {subtitle}
+                            {badge}
                           </div>
                         )}
-                      </div>
-                    ) : (
-                      <div className="relative flex h-full flex-col justify-between p-3">
-                        <div>
-                          {badge && (
-                            <div className="inline-flex rounded-full px-2 py-0.5 text-[11px] font-semibold" style={{ backgroundColor: `${color}1A`, color }}>
-                              {badge}
-                            </div>
-                          )}
-                          <div className={`${badge ? 'mt-2' : ''} break-words text-sm font-semibold leading-5 text-[var(--gantry-text-primary)]`}>
-                            {nodeTitle(node)}
-                          </div>
+                        <div
+                          className={`${badge ? 'mt-2' : ''} break-words text-sm font-semibold leading-5 text-[var(--gantry-text-primary)] ${shape === 'diamond' ? 'text-center' : ''}`}
+                          style={clampText(4)}
+                        >
+                          {title}
                         </div>
-                        {subtitle && (
-                          <div className="break-words text-xs leading-4 text-[var(--gantry-text-secondary)]">
-                            {subtitle}
-                          </div>
-                        )}
                       </div>
-                    )}
+                      {subtitle && (
+                        <div
+                          className={`min-w-0 break-words text-xs leading-4 text-[var(--gantry-text-secondary)] ${shape === 'diamond' ? 'text-center' : ''}`}
+                          style={{ ...mockContentStyle(shape, nodeSize.width), ...clampText(3) }}
+                        >
+                          {subtitle}
+                        </div>
+                      )}
+                    </div>
                   </div>
                 </div>
               );

--- a/web/src/lib/flow-export.ts
+++ b/web/src/lib/flow-export.ts
@@ -15,6 +15,7 @@ import {
   nodeBadge,
   nodeColor,
   nodeEntityKey,
+  nodeShape,
   nodeSubtitle,
   withAlpha,
 } from './flow';
@@ -178,7 +179,7 @@ function buildFlowSvgDocument(options: NormalizedFlowExportOptions): FlowSvgDocu
   const namespace = (options.namespace || 'default').trim() || 'default';
   const nodeMap = new Map(options.spec.nodes.map((node) => [node.id, node]));
   const childIds = new Set(options.spec.nodes.filter((node) => node.parentId).map((node) => node.parentId!));
-  const bounds = getDiagramBounds(options.spec, nodeMap, options.showFrame ? CARD_PADDING : 0);
+  const bounds = getDiagramBounds(options.spec, nodeMap, options.entitiesByKey, options.showFrame ? CARD_PADDING : 0);
   const backgroundFill = getDocumentBackground(options);
   const nodeCount = options.spec.nodes.length;
   const edgeCount = options.spec.edges.length;
@@ -304,8 +305,8 @@ function renderEdge(
 
   const sourceAbs = getAbsolutePosition(source, nodeMap);
   const targetAbs = getAbsolutePosition(target, nodeMap);
-  const sourceSize = getNodeDimensions(source);
-  const targetSize = getNodeDimensions(target);
+  const sourceSize = getNodeDimensions(source, { title: nodeTitle(source, options.entitiesByKey), subtitle: nodeSubtitle(source) });
+  const targetSize = getNodeDimensions(target, { title: nodeTitle(target, options.entitiesByKey), subtitle: nodeSubtitle(target) });
   const path = edgePath(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
   const labelPos = edgeLabelPosition(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
   const health = connectedEdgeHealth(edge, nodeMap, options.healthStatuses);
@@ -332,12 +333,12 @@ function renderNode(
   nodeMap: Map<string, FlowSpec['nodes'][number]>,
   childIds: Set<string>
 ): string {
-  const size = getNodeDimensions(node);
+  const title = nodeTitle(node, options.entitiesByKey);
+  const subtitle = nodeSubtitle(node);
+  const size = getNodeDimensions(node, { title, subtitle });
   const absPos = getAbsolutePosition(node, nodeMap);
   const color = nodeColor(node);
   const badge = nodeBadge(node);
-  const subtitle = nodeSubtitle(node);
-  const title = nodeTitle(node, options.entitiesByKey);
   const hasChildren = childIds.has(node.id);
   const baseBorderColor = options.style === 'clean' ? withAlpha(color, '66') : options.palette.border;
 
@@ -425,42 +426,58 @@ function renderEntityNode(
   color: string,
   options: NormalizedFlowExportOptions
 ): string {
+  const shape = nodeShape(node);
   const badgeColor = withAlpha(color, '1A');
-  const titleLines = wrapText(title, 22, 3);
-  const subtitleLines = wrapText(subtitle, 24, 2);
+  const titleLines = wrapText(title, mockTitleChars(shape, width), 4);
+  const subtitleLines = wrapText(subtitle, mockSubtitleChars(shape, width), 3);
   const health = options.healthStatuses.get(nodeEntityKey(node));
   const healthColor = health === true ? '#10B981' : health === false ? options.palette.danger : '';
   const borderColor = options.style === 'clean' ? withAlpha(color, '66') : options.palette.border;
-
-  let currentY = y + 18;
-  const badgeSvg = badge
-    ? `<rect x="${x + 14}" y="${currentY}" width="${Math.min(150, badge.length * 8.5 + 22)}" height="18" rx="9" fill="${badgeColor}" />
-       <text class="node-badge" x="${x + 25}" y="${currentY + 13}" fill="${color}">${escapeXml(badge)}</text>`
+  const shell = renderMockShell(shape, x, y, width, height, borderColor, color, options.palette.bgPrimary);
+  const containerSvg = hasChildren
+    ? `<rect x="${x + 4}" y="${y + 4}" width="${width - 8}" height="${height - 8}" rx="${shape === 'pill' ? Math.max(18, (height - 8) / 2) : 20}" fill="none" stroke="${options.style === 'clean' ? withAlpha(color, '35') : options.palette.border}" stroke-width="1.2" stroke-dasharray="6 5" />`
     : '';
-  currentY += badge ? 26 : 8;
+
+  if (shape === 'diamond') {
+    let currentY = y + (badge ? 28 : 22);
+    const badgeSvg = badge
+      ? `<rect x="${x + width / 2 - Math.min(72, badge.length * 4.3 + 16)}" y="${y + 18}" width="${Math.min(144, badge.length * 8.6 + 32)}" height="18" rx="9" fill="${badgeColor}" />
+         <text class="node-badge" x="${x + width / 2}" y="${y + 31}" text-anchor="middle" fill="${color}">${escapeXml(badge)}</text>`
+      : '';
+    const titleSvg = titleLines.map((line) => {
+      const next = `<text class="node-title" x="${x + width / 2}" y="${currentY + 16}" text-anchor="middle">${escapeXml(line)}</text>`;
+      currentY += 18;
+      return next;
+    }).join('');
+    currentY += subtitleLines.length > 0 ? 10 : 0;
+    const healthSvg = healthColor
+      ? `<circle cx="${x + width / 2 - 34}" cy="${currentY + 4}" r="4" fill="${healthColor}" />`
+      : '';
+    const subtitleX = x + width / 2 + (healthColor ? 10 : 0);
+    const subtitleSvg = subtitleLines.map((line, index) => `<text class="node-subtitle" x="${subtitleX}" y="${currentY + 12 + index * 16}" text-anchor="${healthColor ? 'start' : 'middle'}">${escapeXml(line)}</text>`).join('');
+    return `<g>${shell}${containerSvg}${badgeSvg}${titleSvg}${healthSvg}${subtitleSvg}</g>`;
+  }
+
+  const horizontalInset = shape === 'pill' ? 28 : shape === 'note' ? 24 : 18;
+  let currentY = y + 22;
+  const badgeSvg = badge
+    ? `<rect x="${x + horizontalInset}" y="${currentY - 2}" width="${Math.min(150, badge.length * 8.5 + 22)}" height="18" rx="9" fill="${badgeColor}" />
+       <text class="node-badge" x="${x + horizontalInset + 11}" y="${currentY + 11}" fill="${color}">${escapeXml(badge)}</text>`
+    : '';
+  currentY += badge ? 24 : 4;
   const titleSvg = titleLines.map((line) => {
-    const next = `<text class="node-title" x="${x + 14}" y="${currentY + 14}">${escapeXml(line)}</text>`;
+    const next = `<text class="node-title" x="${x + horizontalInset}" y="${currentY + 14}">${escapeXml(line)}</text>`;
     currentY += 18;
     return next;
   }).join('');
-  const subtitleY = Math.min(y + height - 14, currentY + 18);
-  const subtitleX = x + 14 + (healthColor ? 12 : 0);
-  const subtitleSvg = subtitleLines.map((line, index) => `<text class="node-subtitle" x="${subtitleX}" y="${subtitleY + index * 14}">${escapeXml(line)}</text>`).join('');
+  currentY += subtitleLines.length > 0 ? 8 : 0;
+  const subtitleX = x + horizontalInset + (healthColor ? 12 : 0);
   const healthSvg = healthColor
-    ? `<circle cx="${x + 18}" cy="${subtitleY - 4}" r="4" fill="${healthColor}" />`
+    ? `<circle cx="${x + horizontalInset + 4}" cy="${currentY + 3}" r="4" fill="${healthColor}" />`
     : '';
-  const containerSvg = hasChildren
-    ? `<rect x="${x + 4}" y="${y + 4}" width="${width - 8}" height="${height - 8}" rx="20" fill="none" stroke="${options.style === 'clean' ? withAlpha(color, '35') : options.palette.border}" stroke-width="1.2" stroke-dasharray="6 5" />`
-    : '';
+  const subtitleSvg = subtitleLines.map((line, index) => `<text class="node-subtitle" x="${subtitleX}" y="${currentY + 12 + index * 16}">${escapeXml(line)}</text>`).join('');
 
-  return `<g>
-    <rect x="${x}" y="${y}" width="${width}" height="${height}" rx="24" fill="${options.palette.bgPrimary}" stroke="${borderColor}" stroke-width="${options.style === 'clean' ? 1.8 : 1.2}" />
-    ${containerSvg}
-    ${badgeSvg}
-    ${titleSvg}
-    ${healthSvg}
-    ${subtitleSvg}
-  </g>`;
+  return `<g>${shell}${containerSvg}${badgeSvg}${titleSvg}${healthSvg}${subtitleSvg}</g>`;
 }
 
 function renderMockShell(
@@ -500,7 +517,12 @@ function renderEmptyState(contentWidth: number, contentHeight: number, palette: 
   </g>`;
 }
 
-function getDiagramBounds(spec: FlowSpec, nodeMap: Map<string, FlowSpec['nodes'][number]>, padding: number) {
+function getDiagramBounds(
+  spec: FlowSpec,
+  nodeMap: Map<string, FlowSpec['nodes'][number]>,
+  entitiesByKey: Map<string, Entity>,
+  padding: number
+) {
   if (spec.nodes.length === 0) {
     return {
       minX: 0,
@@ -519,7 +541,7 @@ function getDiagramBounds(spec: FlowSpec, nodeMap: Map<string, FlowSpec['nodes']
 
   for (const node of spec.nodes) {
     const absPos = getAbsolutePosition(node, nodeMap);
-    const size = getNodeDimensions(node);
+    const size = getNodeDimensions(node, { title: nodeTitle(node, entitiesByKey), subtitle: nodeSubtitle(node) });
     minX = Math.min(minX, absPos.x);
     minY = Math.min(minY, absPos.y);
     maxX = Math.max(maxX, absPos.x + size.width);

--- a/web/src/lib/flow-export.ts
+++ b/web/src/lib/flow-export.ts
@@ -372,11 +372,16 @@ function renderMockNode(
     : '';
 
   if (node.shape === 'diamond') {
-    let currentY = y + (badge ? 28 : 22);
+    const blockHeight =
+      (badge ? 18 + 8 : 0) +
+      titleLines.length * 18 +
+      (subtitleLines.length > 0 ? 8 + subtitleLines.length * 16 : 0);
+    let currentY = y + height / 2 - blockHeight / 2;
     const badgeSvg = badge
-      ? `<rect x="${x + width / 2 - Math.min(72, badge.length * 4.3 + 16)}" y="${y + 18}" width="${Math.min(144, badge.length * 8.6 + 32)}" height="18" rx="9" fill="${badgeColor}" />
-         <text class="node-badge" x="${x + width / 2}" y="${y + 31}" text-anchor="middle" fill="${color}">${escapeXml(badge)}</text>`
+      ? `<rect x="${x + width / 2 - Math.min(72, badge.length * 4.3 + 16)}" y="${currentY}" width="${Math.min(144, badge.length * 8.6 + 32)}" height="18" rx="9" fill="${badgeColor}" />
+         <text class="node-badge" x="${x + width / 2}" y="${currentY + 13}" text-anchor="middle" fill="${color}">${escapeXml(badge)}</text>`
       : '';
+    currentY += badge ? 26 : 0;
     const titleSvg = titleLines.map((line) => {
       const next = `<text class="node-title" x="${x + width / 2}" y="${currentY + 16}" text-anchor="middle">${escapeXml(line)}</text>`;
       currentY += 18;
@@ -392,7 +397,12 @@ function renderMockNode(
   }
 
   const horizontalInset = node.shape === 'pill' ? 28 : node.shape === 'note' ? 24 : 18;
-  let currentY = y + 22;
+  const shouldCenter = node.shape === 'pill';
+  const blockHeight =
+    (badge ? 18 + 6 : 0) +
+    titleLines.length * 18 +
+    (subtitleLines.length > 0 ? 8 + subtitleLines.length * 16 : 0);
+  let currentY = shouldCenter ? y + height / 2 - blockHeight / 2 : y + 22;
   const badgeSvg = badge
     ? `<rect x="${x + horizontalInset}" y="${currentY - 2}" width="${Math.min(150, badge.length * 8.5 + 22)}" height="18" rx="9" fill="${badgeColor}" />
        <text class="node-badge" x="${x + horizontalInset + 11}" y="${currentY + 11}" fill="${color}">${escapeXml(badge)}</text>`
@@ -439,11 +449,17 @@ function renderEntityNode(
     : '';
 
   if (shape === 'diamond') {
-    let currentY = y + (badge ? 28 : 22);
+    const subtitleIndent = healthColor ? 10 : 0;
+    const blockHeight =
+      (badge ? 18 + 8 : 0) +
+      titleLines.length * 18 +
+      (subtitleLines.length > 0 ? 10 + subtitleLines.length * 16 : 0);
+    let currentY = y + height / 2 - blockHeight / 2;
     const badgeSvg = badge
-      ? `<rect x="${x + width / 2 - Math.min(72, badge.length * 4.3 + 16)}" y="${y + 18}" width="${Math.min(144, badge.length * 8.6 + 32)}" height="18" rx="9" fill="${badgeColor}" />
-         <text class="node-badge" x="${x + width / 2}" y="${y + 31}" text-anchor="middle" fill="${color}">${escapeXml(badge)}</text>`
+      ? `<rect x="${x + width / 2 - Math.min(72, badge.length * 4.3 + 16)}" y="${currentY}" width="${Math.min(144, badge.length * 8.6 + 32)}" height="18" rx="9" fill="${badgeColor}" />
+         <text class="node-badge" x="${x + width / 2}" y="${currentY + 13}" text-anchor="middle" fill="${color}">${escapeXml(badge)}</text>`
       : '';
+    currentY += badge ? 26 : 0;
     const titleSvg = titleLines.map((line) => {
       const next = `<text class="node-title" x="${x + width / 2}" y="${currentY + 16}" text-anchor="middle">${escapeXml(line)}</text>`;
       currentY += 18;
@@ -453,13 +469,18 @@ function renderEntityNode(
     const healthSvg = healthColor
       ? `<circle cx="${x + width / 2 - 34}" cy="${currentY + 4}" r="4" fill="${healthColor}" />`
       : '';
-    const subtitleX = x + width / 2 + (healthColor ? 10 : 0);
+    const subtitleX = x + width / 2 + subtitleIndent;
     const subtitleSvg = subtitleLines.map((line, index) => `<text class="node-subtitle" x="${subtitleX}" y="${currentY + 12 + index * 16}" text-anchor="${healthColor ? 'start' : 'middle'}">${escapeXml(line)}</text>`).join('');
     return `<g>${shell}${containerSvg}${badgeSvg}${titleSvg}${healthSvg}${subtitleSvg}</g>`;
   }
 
   const horizontalInset = shape === 'pill' ? 28 : shape === 'note' ? 24 : 18;
-  let currentY = y + 22;
+  const shouldCenter = shape === 'pill';
+  const blockHeight =
+    (badge ? 18 + 6 : 0) +
+    titleLines.length * 18 +
+    (subtitleLines.length > 0 ? 8 + subtitleLines.length * 16 : 0);
+  let currentY = shouldCenter ? y + height / 2 - blockHeight / 2 : y + 22;
   const badgeSvg = badge
     ? `<rect x="${x + horizontalInset}" y="${currentY - 2}" width="${Math.min(150, badge.length * 8.5 + 22)}" height="18" rx="9" fill="${badgeColor}" />
        <text class="node-badge" x="${x + horizontalInset + 11}" y="${currentY + 11}" fill="${color}">${escapeXml(badge)}</text>`

--- a/web/src/lib/flow.tsx
+++ b/web/src/lib/flow.tsx
@@ -70,6 +70,9 @@ export function ensureFlowSpec(spec: Record<string, any> | undefined): FlowSpec 
             name: String(node.entityRef?.name || ''),
             namespace: typeof node.entityRef?.namespace === 'string' ? node.entityRef.namespace : undefined,
           },
+          shape: MOCK_SHAPE_OPTIONS.includes(node.shape) ? node.shape : undefined,
+          width: typeof node.width === 'number' ? node.width : undefined,
+          height: typeof node.height === 'number' ? node.height : undefined,
           position,
           locked: typeof node.locked === 'boolean' ? node.locked : undefined,
           zIndex: typeof node.zIndex === 'number' ? node.zIndex : undefined,
@@ -146,6 +149,10 @@ export function nodeColor(node: FlowNode): string {
   return FLOW_KIND_COLORS[node.entityRef.kind] || '#64748B';
 }
 
+export function nodeShape(node: FlowNode): FlowMockShape {
+  return isMockNode(node) ? node.shape : node.shape || 'box';
+}
+
 export function nodeSubtitle(node: FlowNode): string {
   if (isMockNode(node)) return node.subtitle || '';
   return node.entityRef.name;
@@ -188,17 +195,31 @@ export function estimateWrappedLines(text: string, charsPerLine: number): number
     .reduce((total, line) => total + Math.max(1, Math.ceil(line.trim().length / Math.max(1, charsPerLine))), 0);
 }
 
-export function getNodeDimensions(node: FlowNode): { width: number; height: number } {
-  if (isEntityNode(node)) {
-    return { width: ENTITY_NODE_WIDTH, height: ENTITY_NODE_HEIGHT };
-  }
+export function getNodeDimensions(
+  node: FlowNode,
+  text: {
+    title?: string;
+    subtitle?: string;
+  } = {}
+): { width: number; height: number } {
+  const entityNode = isEntityNode(node);
+  const shape = nodeShape(node);
+  const title = (text.title ?? (entityNode ? node.entityRef.name : node.label)).trim();
+  const subtitle = (text.subtitle ?? nodeSubtitle(node)).trim();
+  const longestText = Math.max(title.length, subtitle.length, entityNode ? 16 : 12);
 
-  const title = node.label.trim();
-  const subtitle = (node.subtitle || '').trim();
-  const longestText = Math.max(title.length, subtitle.length, 12);
-
-  switch (node.shape) {
+  switch (shape) {
     case 'pill': {
+      if (entityNode) {
+        const baseWidth = clamp(220 + Math.max(0, longestText - 14) * 8, 220, MAX_NODE_WIDTH);
+        const width = clamp(Math.max(node.width || 0, baseWidth), 220, MAX_NODE_WIDTH);
+        const charsPerLine = Math.max(13, Math.floor((width - 68) / 8));
+        const titleLines = estimateWrappedLines(title, charsPerLine);
+        const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
+        const baseHeight = Math.max(104, 58 + titleLines * 20 + subtitleLines * 16 + 18);
+        const height = Math.max(node.height || 0, baseHeight);
+        return { width, height };
+      }
       const baseWidth = clamp(188 + Math.max(0, longestText - 12) * 7, 188, 340);
       const width = clamp(Math.max(node.width || 0, baseWidth), 188, MAX_NODE_WIDTH);
       const charsPerLine = Math.max(12, Math.floor((width - 44) / 8));
@@ -209,6 +230,16 @@ export function getNodeDimensions(node: FlowNode): { width: number; height: numb
       return { width, height };
     }
     case 'diamond': {
+      if (entityNode) {
+        const baseWidth = clamp(292 + Math.max(0, longestText - 11) * 10, 292, MAX_NODE_WIDTH);
+        const width = clamp(Math.max(node.width || 0, baseWidth), 292, MAX_NODE_WIDTH);
+        const charsPerLine = Math.max(10, Math.floor((width * 0.44) / 8));
+        const titleLines = estimateWrappedLines(title, charsPerLine);
+        const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
+        const baseHeight = clamp(136 + Math.max(0, titleLines - 1) * 22 + subtitleLines * 18, 136, 280);
+        const height = Math.max(node.height || 0, baseHeight);
+        return { width, height };
+      }
       const baseWidth = clamp(272 + Math.max(0, longestText - 10) * 10, 272, MAX_NODE_WIDTH);
       const width = clamp(Math.max(node.width || 0, baseWidth), 272, MAX_NODE_WIDTH);
       const charsPerLine = Math.max(9, Math.floor((width * 0.42) / 8));
@@ -219,6 +250,16 @@ export function getNodeDimensions(node: FlowNode): { width: number; height: numb
       return { width, height };
     }
     case 'note': {
+      if (entityNode) {
+        const baseWidth = clamp(220 + Math.max(0, longestText - 14) * 7, 220, MAX_NODE_WIDTH);
+        const width = clamp(Math.max(node.width || 0, baseWidth), 220, MAX_NODE_WIDTH);
+        const charsPerLine = Math.max(13, Math.floor((width - 62) / 8));
+        const titleLines = estimateWrappedLines(title, charsPerLine);
+        const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
+        const baseHeight = Math.max(110, 64 + titleLines * 20 + subtitleLines * 16 + 20);
+        const height = Math.max(node.height || 0, baseHeight);
+        return { width, height };
+      }
       const baseWidth = clamp(196 + Math.max(0, longestText - 14) * 7, 196, 360);
       const width = clamp(Math.max(node.width || 0, baseWidth), 196, MAX_NODE_WIDTH);
       const charsPerLine = Math.max(13, Math.floor((width - 52) / 8));
@@ -230,6 +271,16 @@ export function getNodeDimensions(node: FlowNode): { width: number; height: numb
     }
     case 'box':
     default: {
+      if (entityNode) {
+        const baseWidth = clamp(216 + Math.max(0, longestText - 14) * 7, 216, MAX_NODE_WIDTH);
+        const width = clamp(Math.max(node.width || 0, baseWidth), 216, MAX_NODE_WIDTH);
+        const charsPerLine = Math.max(14, Math.floor((width - 58) / 8));
+        const titleLines = estimateWrappedLines(title, charsPerLine);
+        const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
+        const baseHeight = Math.max(104, 58 + titleLines * 20 + subtitleLines * 16 + 18);
+        const height = Math.max(node.height || 0, baseHeight);
+        return { width, height };
+      }
       const baseWidth = clamp(180 + Math.max(0, longestText - 14) * 6, 180, 320);
       const width = clamp(Math.max(node.width || 0, baseWidth), 180, MAX_NODE_WIDTH);
       const charsPerLine = Math.max(14, Math.floor((width - 36) / 8));

--- a/web/src/lib/flow.tsx
+++ b/web/src/lib/flow.tsx
@@ -207,13 +207,14 @@ export function getNodeDimensions(
   const title = (text.title ?? (entityNode ? node.entityRef.name : node.label)).trim();
   const subtitle = (text.subtitle ?? nodeSubtitle(node)).trim();
   const longestText = Math.max(title.length, subtitle.length, entityNode ? 16 : 12);
+  const manualWidth = typeof node.width === 'number' && node.width > 0 ? node.width : null;
 
   switch (shape) {
     case 'pill': {
       if (entityNode) {
         const baseWidth = clamp(220 + Math.max(0, longestText - 14) * 8, 220, MAX_NODE_WIDTH);
-        const width = clamp(Math.max(node.width || 0, baseWidth), 220, MAX_NODE_WIDTH);
-        const charsPerLine = Math.max(13, Math.floor((width - 68) / 8));
+        const width = clamp(manualWidth ?? baseWidth, 148, MAX_NODE_WIDTH);
+        const charsPerLine = Math.max(8, Math.floor((width - 68) / 8));
         const titleLines = estimateWrappedLines(title, charsPerLine);
         const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
         const baseHeight = Math.max(104, 58 + titleLines * 20 + subtitleLines * 16 + 18);
@@ -221,8 +222,8 @@ export function getNodeDimensions(
         return { width, height };
       }
       const baseWidth = clamp(188 + Math.max(0, longestText - 12) * 7, 188, 340);
-      const width = clamp(Math.max(node.width || 0, baseWidth), 188, MAX_NODE_WIDTH);
-      const charsPerLine = Math.max(12, Math.floor((width - 44) / 8));
+      const width = clamp(manualWidth ?? baseWidth, 132, MAX_NODE_WIDTH);
+      const charsPerLine = Math.max(8, Math.floor((width - 44) / 8));
       const titleLines = estimateWrappedLines(title, charsPerLine);
       const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
       const baseHeight = Math.max(84, 48 + titleLines * 18 + subtitleLines * 16 + 18);
@@ -232,8 +233,8 @@ export function getNodeDimensions(
     case 'diamond': {
       if (entityNode) {
         const baseWidth = clamp(292 + Math.max(0, longestText - 11) * 10, 292, MAX_NODE_WIDTH);
-        const width = clamp(Math.max(node.width || 0, baseWidth), 292, MAX_NODE_WIDTH);
-        const charsPerLine = Math.max(10, Math.floor((width * 0.44) / 8));
+        const width = clamp(manualWidth ?? baseWidth, 212, MAX_NODE_WIDTH);
+        const charsPerLine = Math.max(7, Math.floor((width * 0.44) / 8));
         const titleLines = estimateWrappedLines(title, charsPerLine);
         const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
         const baseHeight = clamp(136 + Math.max(0, titleLines - 1) * 22 + subtitleLines * 18, 136, 280);
@@ -241,8 +242,8 @@ export function getNodeDimensions(
         return { width, height };
       }
       const baseWidth = clamp(272 + Math.max(0, longestText - 10) * 10, 272, MAX_NODE_WIDTH);
-      const width = clamp(Math.max(node.width || 0, baseWidth), 272, MAX_NODE_WIDTH);
-      const charsPerLine = Math.max(9, Math.floor((width * 0.42) / 8));
+      const width = clamp(manualWidth ?? baseWidth, 196, MAX_NODE_WIDTH);
+      const charsPerLine = Math.max(7, Math.floor((width * 0.42) / 8));
       const titleLines = estimateWrappedLines(title, charsPerLine);
       const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
       const baseHeight = clamp(120 + Math.max(0, titleLines - 1) * 22 + subtitleLines * 20, 120, 220);
@@ -252,8 +253,8 @@ export function getNodeDimensions(
     case 'note': {
       if (entityNode) {
         const baseWidth = clamp(220 + Math.max(0, longestText - 14) * 7, 220, MAX_NODE_WIDTH);
-        const width = clamp(Math.max(node.width || 0, baseWidth), 220, MAX_NODE_WIDTH);
-        const charsPerLine = Math.max(13, Math.floor((width - 62) / 8));
+        const width = clamp(manualWidth ?? baseWidth, 156, MAX_NODE_WIDTH);
+        const charsPerLine = Math.max(8, Math.floor((width - 62) / 8));
         const titleLines = estimateWrappedLines(title, charsPerLine);
         const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
         const baseHeight = Math.max(110, 64 + titleLines * 20 + subtitleLines * 16 + 20);
@@ -261,8 +262,8 @@ export function getNodeDimensions(
         return { width, height };
       }
       const baseWidth = clamp(196 + Math.max(0, longestText - 14) * 7, 196, 360);
-      const width = clamp(Math.max(node.width || 0, baseWidth), 196, MAX_NODE_WIDTH);
-      const charsPerLine = Math.max(13, Math.floor((width - 52) / 8));
+      const width = clamp(manualWidth ?? baseWidth, 148, MAX_NODE_WIDTH);
+      const charsPerLine = Math.max(8, Math.floor((width - 52) / 8));
       const titleLines = estimateWrappedLines(title, charsPerLine);
       const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
       const baseHeight = Math.max(MIN_NODE_HEIGHT, 56 + titleLines * 18 + subtitleLines * 16 + 24);
@@ -273,8 +274,8 @@ export function getNodeDimensions(
     default: {
       if (entityNode) {
         const baseWidth = clamp(216 + Math.max(0, longestText - 14) * 7, 216, MAX_NODE_WIDTH);
-        const width = clamp(Math.max(node.width || 0, baseWidth), 216, MAX_NODE_WIDTH);
-        const charsPerLine = Math.max(14, Math.floor((width - 58) / 8));
+        const width = clamp(manualWidth ?? baseWidth, 144, MAX_NODE_WIDTH);
+        const charsPerLine = Math.max(8, Math.floor((width - 58) / 8));
         const titleLines = estimateWrappedLines(title, charsPerLine);
         const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
         const baseHeight = Math.max(104, 58 + titleLines * 20 + subtitleLines * 16 + 18);
@@ -282,8 +283,8 @@ export function getNodeDimensions(
         return { width, height };
       }
       const baseWidth = clamp(180 + Math.max(0, longestText - 14) * 6, 180, 320);
-      const width = clamp(Math.max(node.width || 0, baseWidth), 180, MAX_NODE_WIDTH);
-      const charsPerLine = Math.max(14, Math.floor((width - 36) / 8));
+      const width = clamp(manualWidth ?? baseWidth, 128, MAX_NODE_WIDTH);
+      const charsPerLine = Math.max(8, Math.floor((width - 36) / 8));
       const titleLines = estimateWrappedLines(title, charsPerLine);
       const subtitleLines = estimateWrappedLines(subtitle, charsPerLine);
       const baseHeight = Math.max(MIN_NODE_HEIGHT, 48 + titleLines * 18 + subtitleLines * 16 + 18);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -152,6 +152,9 @@ export interface FlowEntityNode {
   id: string;
   nodeType?: 'entity';
   entityRef: FlowEntityRef;
+  shape?: FlowMockShape;
+  width?: number;
+  height?: number;
   position: {
     x: number;
     y: number;

--- a/web/src/pages/Flow.tsx
+++ b/web/src/pages/Flow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   AlertCircle,
@@ -81,6 +81,7 @@ const DUPLICATE_OFFSET = 32;
 const ALIGNMENT_SNAP_THRESHOLD = 10;
 const ARROW_NUDGE_STEP = 1;
 const ARROW_NUDGE_LARGE_STEP = 10;
+const RESIZE_EDGE_THICKNESS = 10;
 const RELATION_OPTIONS = ['calls', 'dependsOn', 'readsFrom', 'writesTo', 'publishesTo', 'subscribesTo', 'consumes', 'provides'];
 const EXPORT_STYLE_OPTIONS: Array<{ value: FlowExportStyle; label: string; description: string }> = [
   {
@@ -151,6 +152,8 @@ const MOCK_NODE_LIBRARY: Array<{ label: string; subtitle: string; shape: FlowMoc
   { label: 'Pill', subtitle: 'External actor or entry point', shape: 'pill', color: '#8B5CF6' },
   { label: 'Note', subtitle: 'Idea, future state, or comment', shape: 'note', color: '#0EA5E9' },
 ];
+type ResizeHandle = 'n' | 'e' | 's' | 'w' | 'ne' | 'se' | 'sw' | 'nw';
+const RESIZE_HANDLES: ResizeHandle[] = ['n', 'e', 's', 'w', 'ne', 'se', 'sw', 'nw'];
 
 function defaultExportStyleForFormat(format: FlowExportFormat): FlowExportStyle {
   return format === 'svg' ? 'presentation' : 'clean';
@@ -204,6 +207,84 @@ function guidesMatch(
   right: { vertical: number | null; horizontal: number | null }
 ) {
   return left.vertical === right.vertical && left.horizontal === right.horizontal;
+}
+
+function resizeCursor(handle: ResizeHandle): string {
+  if (handle === 'n' || handle === 's') return 'ns-resize';
+  if (handle === 'e' || handle === 'w') return 'ew-resize';
+  if (handle === 'ne' || handle === 'sw') return 'nesw-resize';
+  return 'nwse-resize';
+}
+
+function resizeHandleClass(handle: ResizeHandle): string {
+  switch (handle) {
+    case 'n':
+      return 'left-3 right-3 top-0 -translate-y-1/2';
+    case 's':
+      return 'bottom-0 left-3 right-3 translate-y-1/2';
+    case 'e':
+      return 'bottom-3 right-0 top-3 translate-x-1/2';
+    case 'w':
+      return 'bottom-3 left-0 top-3 -translate-x-1/2';
+    case 'ne':
+      return 'right-0 top-0 -translate-y-1/2 translate-x-1/2';
+    case 'se':
+      return 'bottom-0 right-0 translate-x-1/2 translate-y-1/2';
+    case 'sw':
+      return 'bottom-0 left-0 -translate-x-1/2 translate-y-1/2';
+    case 'nw':
+      return 'left-0 top-0 -translate-x-1/2 -translate-y-1/2';
+  }
+}
+
+function entityLinkButtonClass(shape: FlowMockShape): string {
+  switch (shape) {
+    case 'pill':
+      return 'right-5 top-1/2 -translate-y-1/2';
+    case 'note':
+      return 'right-10 top-10';
+    case 'diamond':
+      return 'right-[30%] top-[34%]';
+    case 'box':
+    default:
+      return 'right-3 top-3';
+  }
+}
+
+function shapeSelectionOverlay(shape: FlowMockShape, color: string, width: number, height: number, dashed = false) {
+  const common = {
+    fill: 'none',
+    stroke: color,
+    strokeWidth: 2,
+    strokeDasharray: dashed ? '6 5' : undefined,
+    vectorEffect: 'non-scaling-stroke' as const,
+  };
+
+  switch (shape) {
+    case 'diamond':
+      return (
+        <svg className="pointer-events-none absolute inset-0 overflow-visible" viewBox={`0 0 ${width} ${height}`} aria-hidden="true">
+          <polygon
+            points={`${width / 2},6 ${width - 14},${height / 2} ${width / 2},${height - 6} 14,${height / 2}`}
+            {...common}
+          />
+        </svg>
+      );
+    case 'pill':
+      return <div className="pointer-events-none absolute inset-x-0 inset-y-1 rounded-full" style={{ border: `${common.strokeWidth}px ${dashed ? 'dashed' : 'solid'} ${color}` }} />;
+    case 'note':
+      return (
+        <svg className="pointer-events-none absolute inset-0 overflow-visible" viewBox={`0 0 ${width} ${height}`} aria-hidden="true">
+          <path
+            d={`M 14 8 H ${width - 34} L ${width - 14} 28 V ${height - 14} Q ${width - 14} ${height - 8} ${width - 22} ${height - 8} H 22 Q 14 ${height - 8} 14 ${height - 16} Z`}
+            {...common}
+          />
+        </svg>
+      );
+    case 'box':
+    default:
+      return <div className="pointer-events-none absolute inset-0 rounded-2xl" style={{ border: `${common.strokeWidth}px ${dashed ? 'dashed' : 'solid'} ${color}` }} />;
+  }
 }
 
 
@@ -401,7 +482,16 @@ export default function Flow() {
   const [nestTarget, setNestTarget] = useState<string | null>(null);
   const nestTargetRef = useRef<string | null>(null);
   const [dragging, setDragging] = useState<{ nodeId: string; nodeIds: string[]; offsetX: number; offsetY: number } | null>(null);
-  const [resizing, setResizing] = useState<{ nodeId: string; startClientX: number; startClientY: number; startWidth: number; startHeight: number } | null>(null);
+  const [resizing, setResizing] = useState<{
+    nodeId: string;
+    handle: ResizeHandle;
+    startClientX: number;
+    startClientY: number;
+    startWidth: number;
+    startHeight: number;
+    startX: number;
+    startY: number;
+  } | null>(null);
   const [panning, setPanning] = useState<{ startX: number; startY: number; originX: number; originY: number } | null>(null);
   const [canvasZoom, setCanvasZoom] = useState(1);
   const [zoomMode, setZoomMode] = useState<'fit' | 'manual'>('fit');
@@ -767,32 +857,79 @@ export default function Flow() {
     const currentResize = resizing;
 
     function handleMove(event: MouseEvent) {
-      const nextWidth = currentResize.startWidth + (event.clientX - currentResize.startClientX) / canvasZoom;
-      const nextHeight = currentResize.startHeight + (event.clientY - currentResize.startClientY) / canvasZoom;
+      suppressNodeClickRef.current = true;
+      const dx = (event.clientX - currentResize.startClientX) / canvasZoom;
+      const dy = (event.clientY - currentResize.startClientY) / canvasZoom;
+      const minWidth = 96;
+      const minHeight = 64;
+      const dragLeft = currentResize.handle.includes('w');
+      const dragRight = currentResize.handle.includes('e');
+      const dragTop = currentResize.handle.includes('n');
+      const dragBottom = currentResize.handle.includes('s');
 
       setFlowSpec((prev) => ({
         ...prev,
-        nodes: prev.nodes.map((node) => (
-          node.id === currentResize.nodeId
-            ? {
-                ...node,
-                width: clamp(nextWidth, 96, MAX_NODE_WIDTH),
-                height: Math.max(64, nextHeight),
-              }
-            : node
-        )),
+        nodes: prev.nodes.map((node) => {
+          if (node.id !== currentResize.nodeId) return node;
+
+          let nextX = currentResize.startX;
+          let nextY = currentResize.startY;
+          let nextWidth = currentResize.startWidth;
+          let nextHeight = currentResize.startHeight;
+
+          if (dragRight) {
+            nextWidth = currentResize.startWidth + dx;
+          }
+          if (dragLeft) {
+            nextWidth = currentResize.startWidth - dx;
+            nextX = currentResize.startX + dx;
+          }
+          if (dragBottom) {
+            nextHeight = currentResize.startHeight + dy;
+          }
+          if (dragTop) {
+            nextHeight = currentResize.startHeight - dy;
+            nextY = currentResize.startY + dy;
+          }
+
+          if (nextWidth < minWidth) {
+            if (dragLeft) nextX = currentResize.startX + currentResize.startWidth - minWidth;
+            nextWidth = minWidth;
+          }
+          if (nextWidth > MAX_NODE_WIDTH) {
+            if (dragLeft) nextX = currentResize.startX + currentResize.startWidth - MAX_NODE_WIDTH;
+            nextWidth = MAX_NODE_WIDTH;
+          }
+          if (nextHeight < minHeight) {
+            if (dragTop) nextY = currentResize.startY + currentResize.startHeight - minHeight;
+            nextHeight = minHeight;
+          }
+
+          return {
+            ...node,
+            position: {
+              x: nextX,
+              y: nextY,
+            },
+            width: nextWidth,
+            height: nextHeight,
+          };
+        }),
       }));
       setDirty(true);
     }
 
     function handleUp() {
+      document.body.style.cursor = '';
       setResizing(null);
     }
 
+    document.body.style.cursor = resizeCursor(currentResize.handle);
     window.addEventListener('mousemove', handleMove);
     window.addEventListener('mouseup', handleUp);
 
     return () => {
+      document.body.style.cursor = '';
       window.removeEventListener('mousemove', handleMove);
       window.removeEventListener('mouseup', handleUp);
     };
@@ -2188,6 +2325,25 @@ export default function Flow() {
                       : multiSelected
                       ? 'var(--gantry-accent)'
                       : 'var(--gantry-border)';
+                    const startNodeResize = (event: ReactMouseEvent, handle: ResizeHandle) => {
+                      event.stopPropagation();
+                      event.preventDefault();
+                      suppressNodeClickRef.current = false;
+                      setSelectedNodeId(node.id);
+                      setSelectedNodeIds(new Set([node.id]));
+                      setSelectedEdgeId(null);
+                      setRenderBounds(flowBounds);
+                      setResizing({
+                        nodeId: node.id,
+                        handle,
+                        startClientX: event.clientX,
+                        startClientY: event.clientY,
+                        startWidth: nodeSize.width,
+                        startHeight: nodeSize.height,
+                        startX: node.position.x,
+                        startY: node.position.y,
+                      });
+                    };
 
                     return (
                       <div
@@ -2197,8 +2353,6 @@ export default function Flow() {
                         onDragStart={(event) => event.preventDefault()}
                         className={`group absolute select-none rounded-2xl shadow-sm transition-shadow ${
                           active || connectSource ? 'shadow-lg' : 'hover:shadow-md'
-                        } ${isNestTarget ? 'ring-2 ring-[var(--gantry-accent)] ring-offset-1' : ''} ${
-                          multiSelected && !active ? 'ring-2 ring-[var(--gantry-accent)]/60' : ''
                         } ${isContainer && !isMockNode(node) ? 'outline outline-1 outline-dashed outline-[var(--gantry-border)]' : ''}`}
                         style={nodeOuterStyle}
                         onMouseDown={(event) => {
@@ -2258,6 +2412,10 @@ export default function Flow() {
                             />
                           )}
                           {renderMockNodeShell(shape, baseBorderColor, color, nodeSize.width, nodeSize.height)}
+                          {active && shapeSelectionOverlay(shape, color, nodeSize.width, nodeSize.height)}
+                          {connectSource && !active && shapeSelectionOverlay(shape, color, nodeSize.width, nodeSize.height)}
+                          {isNestTarget && shapeSelectionOverlay(shape, 'var(--gantry-accent)', nodeSize.width, nodeSize.height)}
+                          {multiSelected && !active && shapeSelectionOverlay(shape, 'var(--gantry-accent)', nodeSize.width, nodeSize.height, true)}
 
                           {isMockNode(node) ? (
                             <div className={`relative flex h-full min-h-0 flex-col overflow-hidden ${mockContentClasses(shape)}`}>
@@ -2290,7 +2448,7 @@ export default function Flow() {
                               )}
                             </div>
                           ) : (
-                            <div className={`relative flex h-full min-h-0 flex-col overflow-hidden ${mockContentClasses(shape)} ${shape === 'diamond' ? 'pr-16' : 'pr-14'}`}>
+                            <div className={`relative flex h-full min-h-0 flex-col overflow-hidden ${mockContentClasses(shape)} ${shape === 'diamond' ? '' : 'pr-14'}`}>
                               <button
                                 onMouseDown={(event) => {
                                   event.stopPropagation();
@@ -2299,7 +2457,7 @@ export default function Flow() {
                                   event.stopPropagation();
                                   navigate(entityPath(node.entityRef.kind, node.entityRef.name, node.entityRef.namespace));
                                 }}
-                                className="absolute right-3 top-3 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]/90 p-1.5 text-[var(--gantry-text-secondary)] backdrop-blur-sm hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-text-primary)]"
+                                className={`absolute z-20 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]/90 p-1.5 text-[var(--gantry-text-secondary)] backdrop-blur-sm hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-text-primary)] ${entityLinkButtonClass(shape)}`}
                                 title="Open entity"
                               >
                                 <ExternalLink className="h-3.5 w-3.5" />
@@ -2346,34 +2504,52 @@ export default function Flow() {
                             </div>
                           )}
 
-                          {!readOnly && flowSettings.canEdit && (
-                            <button
-                              type="button"
-                              data-flow-resize="true"
-                              onMouseDown={(event) => {
-                                event.stopPropagation();
-                                event.preventDefault();
-                                setRenderBounds(flowBounds);
-                                setResizing({
-                                  nodeId: node.id,
-                                  startClientX: event.clientX,
-                                  startClientY: event.clientY,
-                                  startWidth: nodeSize.width,
-                                  startHeight: nodeSize.height,
-                                });
-                              }}
-                              className={`absolute -bottom-2.5 -right-2.5 flex h-6 w-6 cursor-se-resize items-center justify-center rounded-full border shadow-lg transition-all ${
-                                active
-                                  ? 'border-[var(--gantry-accent)] bg-[var(--gantry-accent)] text-[var(--gantry-bg-primary)] opacity-100'
-                                  : 'border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] text-[var(--gantry-text-secondary)] opacity-0 group-hover:opacity-100'
-                              }`}
-                              title="Resize node"
-                            >
-                              <span className="pointer-events-none relative block h-2.5 w-2.5">
-                                <span className="absolute bottom-0 right-0 h-2.5 w-2.5 border-b-2 border-r-2 border-current" />
-                                <span className="absolute bottom-0.5 right-0.5 h-1.5 w-1.5 border-b-2 border-r-2 border-current opacity-80" />
-                              </span>
-                            </button>
+                          {!readOnly && flowSettings.canEdit && !node.locked && (
+                            shape === 'diamond' ? (
+                              <svg
+                                className="absolute inset-0 z-10 overflow-visible"
+                                viewBox={`0 0 ${nodeSize.width} ${nodeSize.height}`}
+                                aria-hidden="true"
+                              >
+                                {[
+                                  { handle: 'ne' as ResizeHandle, x1: nodeSize.width / 2, y1: 6, x2: nodeSize.width - 14, y2: nodeSize.height / 2 },
+                                  { handle: 'se' as ResizeHandle, x1: nodeSize.width - 14, y1: nodeSize.height / 2, x2: nodeSize.width / 2, y2: nodeSize.height - 6 },
+                                  { handle: 'sw' as ResizeHandle, x1: nodeSize.width / 2, y1: nodeSize.height - 6, x2: 14, y2: nodeSize.height / 2 },
+                                  { handle: 'nw' as ResizeHandle, x1: 14, y1: nodeSize.height / 2, x2: nodeSize.width / 2, y2: 6 },
+                                ].map((edge) => (
+                                  <line
+                                    key={edge.handle}
+                                    data-flow-resize="true"
+                                    x1={edge.x1}
+                                    y1={edge.y1}
+                                    x2={edge.x2}
+                                    y2={edge.y2}
+                                    stroke="transparent"
+                                    strokeWidth={18}
+                                    strokeLinecap="round"
+                                    style={{ cursor: resizeCursor(edge.handle), pointerEvents: 'stroke' }}
+                                    onMouseDown={(event) => startNodeResize(event, edge.handle)}
+                                  />
+                                ))}
+                              </svg>
+                            ) : (
+                              RESIZE_HANDLES.map((handle) => (
+                                <div
+                                  key={handle}
+                                  data-flow-resize="true"
+                                  className={`absolute z-10 rounded-sm transition-colors ${resizeHandleClass(handle)} ${
+                                    active ? 'bg-[var(--gantry-accent)]/10 hover:bg-[var(--gantry-accent)]/25' : 'bg-transparent'
+                                  }`}
+                                  style={{
+                                    cursor: resizeCursor(handle),
+                                    height: handle === 'n' || handle === 's' ? RESIZE_EDGE_THICKNESS : handle.length === 2 ? RESIZE_EDGE_THICKNESS * 1.8 : undefined,
+                                    width: handle === 'e' || handle === 'w' ? RESIZE_EDGE_THICKNESS : handle.length === 2 ? RESIZE_EDGE_THICKNESS * 1.8 : undefined,
+                                  }}
+                                  title="Resize node"
+                                  onMouseDown={(event) => startNodeResize(event, handle)}
+                                />
+                              ))
+                            )
                           )}
                         </div>
                       </div>

--- a/web/src/pages/Flow.tsx
+++ b/web/src/pages/Flow.tsx
@@ -63,6 +63,7 @@ import {
   nodeBadge,
   nodeColor,
   nodeEntityKey,
+  nodeShape,
   nodeSubtitle,
   renderMockNodeShell,
 } from '../lib/flow';
@@ -77,6 +78,9 @@ const ZOOM_STEP = 0.15;
 const FIT_PADDING = 48;
 const CONTENT_PADDING = 64;
 const DUPLICATE_OFFSET = 32;
+const ALIGNMENT_SNAP_THRESHOLD = 10;
+const ARROW_NUDGE_STEP = 1;
+const ARROW_NUDGE_LARGE_STEP = 10;
 const RELATION_OPTIONS = ['calls', 'dependsOn', 'readsFrom', 'writesTo', 'publishesTo', 'subscribesTo', 'consumes', 'provides'];
 const EXPORT_STYLE_OPTIONS: Array<{ value: FlowExportStyle; label: string; description: string }> = [
   {
@@ -183,7 +187,23 @@ function nodeTitle(node: FlowNode, entityMap: Map<string, Entity>): string {
 
 function nodeMeta(node: FlowNode): string {
   if (isMockNode(node)) return `Mock · ${node.shape}`;
-  return `${node.entityRef.kind} · ${node.entityRef.name}`;
+  return `${node.entityRef.kind} · ${node.entityRef.name}${node.shape && node.shape !== 'box' ? ` · ${mockShapeLabel(node.shape)}` : ''}`;
+}
+
+function clampText(lines: number): CSSProperties {
+  return {
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: lines,
+    overflow: 'hidden',
+  };
+}
+
+function guidesMatch(
+  left: { vertical: number | null; horizontal: number | null },
+  right: { vertical: number | null; horizontal: number | null }
+) {
+  return left.vertical === right.vertical && left.horizontal === right.horizontal;
 }
 
 
@@ -248,7 +268,13 @@ function cloneFlowSpecWithNewIDs(spec: FlowSpec): FlowSpec {
 }
 
 
-function getFlowBounds(spec: FlowSpec) {
+function getFlowBounds(
+  spec: FlowSpec,
+  resolveText?: (node: FlowNode) => {
+    title?: string;
+    subtitle?: string;
+  }
+) {
   if (spec.nodes.length === 0) {
     return {
       minX: 0,
@@ -267,7 +293,7 @@ function getFlowBounds(spec: FlowSpec) {
   let maxY = -Infinity;
 
   for (const node of spec.nodes) {
-    const size = getNodeDimensions(node);
+    const size = getNodeDimensions(node, resolveText?.(node));
     const absPos = getAbsolutePosition(node, nodeMap);
     minX = Math.min(minX, absPos.x);
     minY = Math.min(minY, absPos.y);
@@ -290,12 +316,20 @@ function getFlowBounds(spec: FlowSpec) {
   };
 }
 
-function getFitViewState(width: number, height: number, spec: FlowSpec) {
+function getFitViewState(
+  width: number,
+  height: number,
+  spec: FlowSpec,
+  resolveText?: (node: FlowNode) => {
+    title?: string;
+    subtitle?: string;
+  }
+) {
   if (width <= 0 || height <= 0) {
     return { zoom: 1, offset: { x: 24, y: 24 } };
   }
 
-  const bounds = getFlowBounds(spec);
+  const bounds = getFlowBounds(spec, resolveText);
   const stageMinX = Math.min(0, bounds.minX);
   const stageMinY = Math.min(0, bounds.minY);
   const renderMinX = bounds.minX - stageMinX;
@@ -360,6 +394,10 @@ export default function Flow() {
   const [dirty, setDirty] = useState(false);
   const [selectedNodeIds, setSelectedNodeIds] = useState<Set<string>>(new Set());
   const [snapToGrid, setSnapToGrid] = useState(false);
+  const [alignmentGuides, setAlignmentGuides] = useState<{ vertical: number | null; horizontal: number | null }>({
+    vertical: null,
+    horizontal: null,
+  });
   const [nestTarget, setNestTarget] = useState<string | null>(null);
   const nestTargetRef = useRef<string | null>(null);
   const [dragging, setDragging] = useState<{ nodeId: string; nodeIds: string[]; offsetX: number; offsetY: number } | null>(null);
@@ -372,8 +410,20 @@ export default function Flow() {
   const requestedFlow = searchParams.get('flow') || '';
   const requestedNamespace = searchParams.get('namespace') || 'default';
   const requestedMode = searchParams.get('mode') === 'edit' ? 'edit' : 'view';
-  const flowBounds = useMemo(() => getFlowBounds(flowSpec), [flowSpec]);
-  const [renderBounds, setRenderBounds] = useState(flowBounds);
+  const entityMap = useMemo(
+    () => new Map(availableEntities.map((entity) => [entityKey(entity), entity])),
+    [availableEntities]
+  );
+  const resolveNodeText = useCallback((node: FlowNode) => ({
+    title: nodeTitle(node, entityMap),
+    subtitle: nodeSubtitle(node),
+  }), [entityMap]);
+  const getRenderedNodeDimensions = useCallback(
+    (node: FlowNode) => getNodeDimensions(node, resolveNodeText(node)),
+    [resolveNodeText]
+  );
+  const flowBounds = useMemo(() => getFlowBounds(flowSpec, resolveNodeText), [flowSpec, resolveNodeText]);
+  const [renderBounds, setRenderBounds] = useState(() => getFlowBounds(defaultFlowSpec()));
   const activeBounds = dragging || resizing ? renderBounds : flowBounds;
   const healthStatuses = useFlowHealth(flowSpec.nodes, availableEntities);
   const stageMinX = Math.min(0, activeBounds.minX);
@@ -428,7 +478,7 @@ export default function Flow() {
   function fitCanvas() {
     setZoomMode('fit');
     const { width, height } = getViewportDimensions();
-    const nextView = getFitViewState(width, height, flowSpec);
+    const nextView = getFitViewState(width, height, flowSpec, resolveNodeText);
     setPanOffset(nextView.offset);
     setCanvasZoom(nextView.zoom);
   }
@@ -440,6 +490,84 @@ export default function Flow() {
       x: (clientX - rect.left) / canvasZoom - contentOffsetX,
       y: (clientY - rect.top) / canvasZoom - contentOffsetY,
     };
+  }
+
+  const getAlignmentPosition = useCallback((
+    primaryNode: FlowNode,
+    rawAbsX: number,
+    rawAbsY: number,
+    nodeMap: Map<string, FlowNode>,
+    draggingSet: Set<string>
+  ) => {
+    const primarySize = getRenderedNodeDimensions(primaryNode);
+    const movingX = [rawAbsX, rawAbsX + primarySize.width / 2, rawAbsX + primarySize.width];
+    const movingY = [rawAbsY, rawAbsY + primarySize.height / 2, rawAbsY + primarySize.height];
+
+    let bestX: { delta: number; guide: number } | null = null;
+    let bestY: { delta: number; guide: number } | null = null;
+
+    for (const node of nodeMap.values()) {
+      if (draggingSet.has(node.id)) continue;
+
+      const nodeAbs = getAbsolutePosition(node, nodeMap);
+      const nodeSize = getRenderedNodeDimensions(node);
+      const targetX = [nodeAbs.x, nodeAbs.x + nodeSize.width / 2, nodeAbs.x + nodeSize.width];
+      const targetY = [nodeAbs.y, nodeAbs.y + nodeSize.height / 2, nodeAbs.y + nodeSize.height];
+
+      for (const source of movingX) {
+        for (const target of targetX) {
+          const delta = target - source;
+          if (Math.abs(delta) > ALIGNMENT_SNAP_THRESHOLD) continue;
+          if (!bestX || Math.abs(delta) < Math.abs(bestX.delta)) {
+            bestX = { delta, guide: target };
+          }
+        }
+      }
+
+      for (const source of movingY) {
+        for (const target of targetY) {
+          const delta = target - source;
+          if (Math.abs(delta) > ALIGNMENT_SNAP_THRESHOLD) continue;
+          if (!bestY || Math.abs(delta) < Math.abs(bestY.delta)) {
+            bestY = { delta, guide: target };
+          }
+        }
+      }
+    }
+
+    return {
+      x: rawAbsX + (bestX?.delta || 0),
+      y: rawAbsY + (bestY?.delta || 0),
+      guides: {
+        vertical: bestX?.guide ?? null,
+        horizontal: bestY?.guide ?? null,
+      },
+    };
+  }, [getRenderedNodeDimensions]);
+
+  function nudgeSelectedNodes(dx: number, dy: number) {
+    if (!flowSettings.canEdit || selectedNodeIds.size === 0) return;
+    const ids = selectedNodeIds;
+    let moved = false;
+    setFlowSpec((prev) => ({
+      ...prev,
+      nodes: prev.nodes.map((node) => {
+        if (!ids.has(node.id) || node.locked) return node;
+        if (node.parentId && ids.has(node.parentId)) return node;
+        moved = true;
+        return {
+          ...node,
+          position: {
+            x: node.position.x + dx,
+            y: node.position.y + dy,
+          },
+        };
+      }),
+    }));
+    if (moved) {
+      setDirty(true);
+      setNotice('');
+    }
   }
 
   useEffect(() => {
@@ -503,16 +631,23 @@ export default function Flow() {
     function handleMove(event: MouseEvent) {
       if (!viewportRef.current) return;
       suppressNodeClickRef.current = true;
+      let nextGuides = { vertical: null as number | null, horizontal: null as number | null };
 
       setFlowSpec((prev) => {
         const nodeMap = new Map(prev.nodes.map((n) => [n.id, n]));
         const primaryNode = nodeMap.get(currentDrag.nodeId);
         if (!primaryNode) return prev;
+        const draggingSet = new Set(currentDrag.nodeIds);
 
         // Compute where the primary node wants to go
         const nextPoint = clientPointToCanvas(event.clientX, event.clientY);
-        let nextX = snapVal(nextPoint.x - currentDrag.offsetX);
-        let nextY = snapVal(nextPoint.y - currentDrag.offsetY);
+        const rawAbsX = snapVal(nextPoint.x - currentDrag.offsetX);
+        const rawAbsY = snapVal(nextPoint.y - currentDrag.offsetY);
+        const aligned = getAlignmentPosition(primaryNode, rawAbsX, rawAbsY, nodeMap, draggingSet);
+        nextGuides = aligned.guides;
+
+        let nextX = aligned.x;
+        let nextY = aligned.y;
 
         // If the primary node has a parent, constrain movement to relative space
         // (the absolute canvas position minus parent absolute position)
@@ -521,15 +656,13 @@ export default function Flow() {
           const parent = nodeMap.get(parentId);
           if (parent) {
             const parentAbs = getAbsolutePosition(parent, nodeMap);
-            nextX = snapVal(nextPoint.x - currentDrag.offsetX - parentAbs.x);
-            nextY = snapVal(nextPoint.y - currentDrag.offsetY - parentAbs.y);
+            nextX = snapVal(aligned.x - parentAbs.x);
+            nextY = snapVal(aligned.y - parentAbs.y);
           }
         }
 
         const dx = nextX - primaryNode.position.x;
         const dy = nextY - primaryNode.position.y;
-
-        const draggingSet = new Set(currentDrag.nodeIds);
 
         const primaryHasSelectedParent = Boolean(primaryNode.parentId && draggingSet.has(primaryNode.parentId));
         const updatedNodes = prev.nodes.map((node) => {
@@ -551,9 +684,9 @@ export default function Flow() {
 
         // Detect nest target: top-level node hovering over another non-selected, non-descendant node
         if (!primaryNode.parentId) {
-          const absX = nextPoint.x - currentDrag.offsetX;
-          const absY = nextPoint.y - currentDrag.offsetY;
-          const primarySize = getNodeDimensions(primaryNode);
+          const absX = aligned.x;
+          const absY = aligned.y;
+          const primarySize = getRenderedNodeDimensions(primaryNode);
           const midX = absX + primarySize.width / 2;
           const midY = absY + primarySize.height / 2;
           const descendants = collectDescendants(primaryNode.id, prev.nodes);
@@ -563,7 +696,7 @@ export default function Flow() {
             if (draggingSet.has(node.id)) continue;
             if (descendants.has(node.id)) continue;
             const nodeAbs = getAbsolutePosition(node, nodeMap);
-            const nodeSize = getNodeDimensions(node);
+            const nodeSize = getRenderedNodeDimensions(node);
             if (
               midX > nodeAbs.x && midX < nodeAbs.x + nodeSize.width &&
               midY > nodeAbs.y && midY < nodeAbs.y + nodeSize.height
@@ -580,6 +713,7 @@ export default function Flow() {
 
         return { ...prev, nodes: updatedNodes };
       });
+      setAlignmentGuides((prev) => (guidesMatch(prev, nextGuides) ? prev : nextGuides));
       setDirty(true);
     }
 
@@ -615,6 +749,7 @@ export default function Flow() {
       }
       nestTargetRef.current = null;
       setNestTarget(null);
+      setAlignmentGuides({ vertical: null, horizontal: null });
       setDragging(null);
     }
 
@@ -625,7 +760,7 @@ export default function Flow() {
       window.removeEventListener('mousemove', handleMove);
       window.removeEventListener('mouseup', handleUp);
     };
-  }, [dragging, canvasZoom, snapToGrid]);
+  }, [dragging, canvasZoom, snapToGrid, getAlignmentPosition, getRenderedNodeDimensions]);
 
   useEffect(() => {
     if (!resizing) return;
@@ -638,11 +773,11 @@ export default function Flow() {
       setFlowSpec((prev) => ({
         ...prev,
         nodes: prev.nodes.map((node) => (
-          node.id === currentResize.nodeId && isMockNode(node)
+          node.id === currentResize.nodeId
             ? {
                 ...node,
-                width: clamp(nextWidth, 160, MAX_NODE_WIDTH),
-                height: Math.max(72, nextHeight),
+                width: clamp(nextWidth, 96, MAX_NODE_WIDTH),
+                height: Math.max(64, nextHeight),
               }
             : node
         )),
@@ -701,6 +836,13 @@ export default function Flow() {
         setSelectedNodeIds(new Set());
         setSelectedEdgeId(null);
         setConnectFromId(null);
+      } else if (event.key.startsWith('Arrow') && selectedNodeIds.size > 0) {
+        event.preventDefault();
+        const step = event.shiftKey ? ARROW_NUDGE_LARGE_STEP : ARROW_NUDGE_STEP;
+        if (event.key === 'ArrowLeft') nudgeSelectedNodes(-step, 0);
+        if (event.key === 'ArrowRight') nudgeSelectedNodes(step, 0);
+        if (event.key === 'ArrowUp') nudgeSelectedNodes(0, -step);
+        if (event.key === 'ArrowDown') nudgeSelectedNodes(0, step);
       } else if (event.key === 'Delete') {
         removeSelectedNodes();
       }
@@ -742,12 +884,12 @@ export default function Flow() {
     if (zoomMode !== 'fit' || dragging || resizing) return;
     const frame = requestAnimationFrame(() => {
       const { width, height } = getViewportDimensions();
-      const nextView = getFitViewState(width, height, flowSpec);
+      const nextView = getFitViewState(width, height, flowSpec, resolveNodeText);
       setPanOffset(nextView.offset);
       setCanvasZoom(nextView.zoom);
     });
     return () => cancelAnimationFrame(frame);
-  }, [zoomMode, dragging, resizing, viewportSize.width, viewportSize.height, currentFlowName, currentNamespace, flowSpec]);
+  }, [zoomMode, dragging, resizing, viewportSize.width, viewportSize.height, currentFlowName, currentNamespace, flowSpec, resolveNodeText]);
 
   useEffect(() => {
     if (!flowSettings.canEdit && mode === 'edit') {
@@ -769,6 +911,7 @@ export default function Flow() {
     setSelectedEdgeId(null);
     setConnectFromId(null);
     setNestTarget(null);
+    setAlignmentGuides({ vertical: null, horizontal: null });
     setDirty(false);
     setNotice('');
     setError('');
@@ -789,6 +932,7 @@ export default function Flow() {
     setSelectedEdgeId(null);
     setConnectFromId(null);
     setNestTarget(null);
+    setAlignmentGuides({ vertical: null, horizontal: null });
     setDirty(false);
     setNotice('');
     setError('');
@@ -1277,7 +1421,6 @@ export default function Flow() {
 
   const selectedNode = flowSpec.nodes.find((node) => node.id === selectedNodeId) || null;
   const selectedEdge = flowSpec.edges.find((edge) => edge.id === selectedEdgeId) || null;
-  const entityMap = new Map(availableEntities.map((entity) => [entityKey(entity), entity]));
   const exportDisabled = flowSpec.nodes.length === 0 && flowSpec.edges.length === 0;
 
   const exportPreview = useMemo<FlowExportPreview | null>(() => {
@@ -1677,7 +1820,7 @@ export default function Flow() {
               <p className="mt-1 text-xs text-[var(--gantry-text-secondary)]">
                 {readOnly
                   ? 'Browse the flow diagram, scroll to zoom, and select nodes or edges for details.'
-                  : 'Drag nodes to arrange. Shift+click to multi-select. Drag onto another node to nest it inside.'}
+                  : 'Drag nodes to arrange, use arrow keys to fine-tune, and nearby nodes snap into alignment. Shift+click to multi-select and drag onto another node to nest it inside.'}
               </p>
             </div>
             <div className="flex shrink-0 items-center gap-2">
@@ -1915,8 +2058,8 @@ export default function Flow() {
                       if (!source || !target) return null;
                       const sourceAbs = getAbsolutePosition(source, nodeMap);
                       const targetAbs = getAbsolutePosition(target, nodeMap);
-                      const sourceSize = getNodeDimensions(source);
-                      const targetSize = getNodeDimensions(target);
+                      const sourceSize = getRenderedNodeDimensions(source);
+                      const targetSize = getRenderedNodeDimensions(target);
                       const path = edgePath(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
                       const labelPos = edgeLabelPosition(sourceAbs, sourceSize, targetAbs, targetSize, edge.sourceHandle, edge.targetHandle);
                       const active = edge.id === selectedEdgeId;
@@ -1998,17 +2141,40 @@ export default function Flow() {
                     })}
                   </svg>
 
+                  {alignmentGuides.vertical !== null && (
+                    <div
+                      className="pointer-events-none absolute top-0 opacity-70"
+                      style={{
+                        left: alignmentGuides.vertical,
+                        height: stageHeight,
+                        borderLeft: '1px dashed var(--gantry-accent)',
+                      }}
+                    />
+                  )}
+
+                  {alignmentGuides.horizontal !== null && (
+                    <div
+                      className="pointer-events-none absolute left-0 opacity-70"
+                      style={{
+                        top: alignmentGuides.horizontal,
+                        width: stageWidth,
+                        borderTop: '1px dashed var(--gantry-accent)',
+                      }}
+                    />
+                  )}
+
                   {sortedNodes.map((node) => {
                     const active = node.id === selectedNodeId;
                     const multiSelected = selectedNodeIds.has(node.id);
                     const connectSource = node.id === connectFromId;
                     const isNestTarget = node.id === nestTarget;
                     const isContainer = flowSpec.nodes.some((n) => n.parentId === node.id);
+                    const shape = nodeShape(node);
                     const color = nodeColor(node);
                     const title = nodeTitle(node, entityMap);
                     const subtitle = nodeSubtitle(node);
                     const badge = nodeBadge(node);
-                    const nodeSize = getNodeDimensions(node);
+                    const nodeSize = getRenderedNodeDimensions(node);
                     const absPos = getAbsolutePosition(node, nodeMap);
                     const nodeOuterStyle: CSSProperties = {
                       left: absPos.x,
@@ -2022,10 +2188,6 @@ export default function Flow() {
                       : multiSelected
                       ? 'var(--gantry-accent)'
                       : 'var(--gantry-border)';
-                    const cardStyle: CSSProperties = {
-                      borderColor: baseBorderColor,
-                      background: 'var(--gantry-bg-primary)',
-                    };
 
                     return (
                       <div
@@ -2047,6 +2209,7 @@ export default function Flow() {
                           if (typeof window !== 'undefined') window.getSelection?.()?.removeAllRanges();
                           suppressNodeClickRef.current = false;
                           setRenderBounds(flowBounds);
+                          setAlignmentGuides({ vertical: null, horizontal: null });
                           const absNodePos = getAbsolutePosition(node, nodeMap);
                           const point = clientPointToCanvas(event.clientX, event.clientY);
 
@@ -2094,17 +2257,13 @@ export default function Flow() {
                               style={{ background: `${color}08`, border: `1.5px dashed ${color}60` }}
                             />
                           )}
-                          {isMockNode(node) ? (
-                            renderMockNodeShell(node.shape, baseBorderColor, color, nodeSize.width, nodeSize.height)
-                          ) : (
-                            <div className="absolute inset-0 rounded-2xl border" style={cardStyle} />
-                          )}
+                          {renderMockNodeShell(shape, baseBorderColor, color, nodeSize.width, nodeSize.height)}
 
                           {isMockNode(node) ? (
-                            <div className={`relative flex h-full flex-col ${mockContentClasses(node.shape)}`}>
+                            <div className={`relative flex h-full min-h-0 flex-col overflow-hidden ${mockContentClasses(shape)}`}>
                               <div
-                                className={`${node.shape === 'diamond' ? 'w-full space-y-2' : ''} min-w-0`}
-                                style={mockContentStyle(node.shape, nodeSize.width)}
+                                className={`${shape === 'diamond' ? 'w-full space-y-2' : ''} min-w-0`}
+                                style={mockContentStyle(shape, nodeSize.width)}
                               >
                                 {badge && (
                                   <div
@@ -2114,44 +2273,57 @@ export default function Flow() {
                                     {badge}
                                   </div>
                                 )}
-                                <div className={`${badge ? 'mt-2' : ''} break-words whitespace-pre-wrap text-sm font-semibold leading-5 text-[var(--gantry-text-primary)] ${node.shape === 'diamond' ? 'text-center' : ''}`}>
+                                <div
+                                  className={`${badge ? 'mt-2' : ''} break-words text-sm font-semibold leading-5 text-[var(--gantry-text-primary)] ${shape === 'diamond' ? 'text-center' : ''}`}
+                                  style={clampText(4)}
+                                >
                                   {title}
                                 </div>
                               </div>
                               {subtitle && (
                                 <div
-                                  className={`min-w-0 break-words whitespace-pre-wrap text-xs leading-4 text-[var(--gantry-text-secondary)] ${node.shape === 'diamond' ? 'text-center' : ''}`}
-                                  style={mockContentStyle(node.shape, nodeSize.width)}
+                                  className={`min-w-0 break-words text-xs leading-4 text-[var(--gantry-text-secondary)] ${shape === 'diamond' ? 'text-center' : ''}`}
+                                  style={{ ...mockContentStyle(shape, nodeSize.width), ...clampText(3) }}
                                 >
                                   {subtitle}
                                 </div>
                               )}
                             </div>
                           ) : (
-                            <div className="relative flex h-full flex-col justify-between p-3">
-                              <div className="flex items-start justify-between gap-3">
-                                <div>
-                                  {badge && (
-                                    <div className="inline-flex rounded-full px-2 py-0.5 text-[11px] font-semibold" style={{ backgroundColor: `${color}1A`, color }}>
-                                      {badge}
-                                    </div>
-                                  )}
-                                  <div className={`${badge ? 'mt-2' : ''} break-words text-sm font-semibold leading-5 text-[var(--gantry-text-primary)]`}>
-                                    {title}
+                            <div className={`relative flex h-full min-h-0 flex-col overflow-hidden ${mockContentClasses(shape)} ${shape === 'diamond' ? 'pr-16' : 'pr-14'}`}>
+                              <button
+                                onMouseDown={(event) => {
+                                  event.stopPropagation();
+                                }}
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  navigate(entityPath(node.entityRef.kind, node.entityRef.name, node.entityRef.namespace));
+                                }}
+                                className="absolute right-3 top-3 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]/90 p-1.5 text-[var(--gantry-text-secondary)] backdrop-blur-sm hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-text-primary)]"
+                                title="Open entity"
+                              >
+                                <ExternalLink className="h-3.5 w-3.5" />
+                              </button>
+                              <div
+                                className={`${shape === 'diamond' ? 'w-full space-y-2' : ''} min-w-0`}
+                                style={mockContentStyle(shape, nodeSize.width)}
+                              >
+                                {badge && (
+                                  <div className="inline-flex rounded-full px-2 py-0.5 text-[11px] font-semibold" style={{ backgroundColor: `${color}1A`, color }}>
+                                    {badge}
                                   </div>
-                                </div>
-                                <button
-                                  onClick={(event) => {
-                                    event.stopPropagation();
-                                    navigate(entityPath(node.entityRef.kind, node.entityRef.name, node.entityRef.namespace));
-                                  }}
-                                  className="rounded-lg border border-[var(--gantry-border)] p-1.5 text-[var(--gantry-text-secondary)] hover:bg-[var(--gantry-bg-tertiary)] hover:text-[var(--gantry-text-primary)]"
-                                  title="Open entity"
+                                )}
+                                <div
+                                  className={`${badge ? 'mt-2' : ''} break-words text-sm font-semibold leading-5 text-[var(--gantry-text-primary)] ${shape === 'diamond' ? 'text-center' : ''}`}
+                                  style={clampText(4)}
                                 >
-                                  <ExternalLink className="h-3.5 w-3.5" />
-                                </button>
+                                  {title}
+                                </div>
                               </div>
-                              <div className="flex items-center gap-1.5 break-words text-xs leading-4 text-[var(--gantry-text-secondary)]">
+                              <div
+                                className={`flex min-w-0 items-start gap-1.5 break-words text-xs leading-4 text-[var(--gantry-text-secondary)] ${shape === 'diamond' ? 'justify-center text-center' : ''}`}
+                                style={mockContentStyle(shape, nodeSize.width)}
+                              >
                                 {(() => {
                                   const healthKey = isEntityNode(node) ? nodeEntityKey(node) : '';
                                   const health = healthStatuses.get(healthKey);
@@ -2163,7 +2335,7 @@ export default function Flow() {
                                     />
                                   );
                                 })()}
-                                {subtitle}
+                                <span className="min-w-0 break-words" style={clampText(3)}>{subtitle}</span>
                               </div>
                             </div>
                           )}
@@ -2174,7 +2346,7 @@ export default function Flow() {
                             </div>
                           )}
 
-                          {!readOnly && flowSettings.canEdit && isMockNode(node) && (
+                          {!readOnly && flowSettings.canEdit && (
                             <button
                               type="button"
                               data-flow-resize="true"
@@ -2195,7 +2367,7 @@ export default function Flow() {
                                   ? 'border-[var(--gantry-accent)] bg-[var(--gantry-accent)] text-[var(--gantry-bg-primary)] opacity-100'
                                   : 'border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] text-[var(--gantry-text-secondary)] opacity-0 group-hover:opacity-100'
                               }`}
-                              title="Resize shape"
+                              title="Resize node"
                             >
                               <span className="pointer-events-none relative block h-2.5 w-2.5">
                                 <span className="absolute bottom-0 right-0 h-2.5 w-2.5 border-b-2 border-r-2 border-current" />
@@ -2575,6 +2747,18 @@ export default function Flow() {
                   className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
                 />
               </label>
+              <label className="space-y-1.5">
+                <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Shape</span>
+                <select
+                  value={nodeShape(selectedNode)}
+                  onChange={(event) => updateNode(selectedNode.id, { shape: event.target.value as FlowMockShape })}
+                  className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+                >
+                  {MOCK_SHAPE_OPTIONS.map((shape) => (
+                    <option key={shape} value={shape}>{mockShapeLabel(shape)}</option>
+                  ))}
+                </select>
+              </label>
               {isMockNode(selectedNode) && (
                 <>
                   <label className="space-y-1.5">
@@ -2594,51 +2778,37 @@ export default function Flow() {
                       className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
                     />
                   </label>
-                  <div className="grid grid-cols-[minmax(0,1fr)_6rem] gap-3">
-                    <label className="space-y-1.5">
-                      <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Shape</span>
-                      <select
-                        value={selectedNode.shape}
-                        onChange={(event) => updateNode(selectedNode.id, { shape: event.target.value as FlowMockShape } as Partial<FlowMockNode>)}
-                        className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-                      >
-                        {MOCK_SHAPE_OPTIONS.map((shape) => (
-                          <option key={shape} value={shape}>{mockShapeLabel(shape)}</option>
-                        ))}
-                      </select>
-                    </label>
-                    <label className="space-y-1.5">
-                      <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Color</span>
-                      <input
-                        type="color"
-                        value={selectedNode.color || '#64748B'}
-                        onChange={(event) => updateNode(selectedNode.id, { color: event.target.value } as Partial<FlowMockNode>)}
-                        className="h-10 w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-1 py-1"
-                      />
-                    </label>
-                  </div>
-                  <div className="grid grid-cols-2 gap-3">
-                    <label className="space-y-1.5">
-                      <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Width</span>
-                      <input
-                        type="number"
-                        value={Math.round(getNodeDimensions(selectedNode).width)}
-                        onChange={(event) => updateNode(selectedNode.id, { width: Number(event.target.value) } as Partial<FlowMockNode>)}
-                        className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-                      />
-                    </label>
-                    <label className="space-y-1.5">
-                      <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Height</span>
-                      <input
-                        type="number"
-                        value={Math.round(getNodeDimensions(selectedNode).height)}
-                        onChange={(event) => updateNode(selectedNode.id, { height: Number(event.target.value) } as Partial<FlowMockNode>)}
-                        className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
-                      />
-                    </label>
-                  </div>
+                  <label className="space-y-1.5">
+                    <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Color</span>
+                    <input
+                      type="color"
+                      value={selectedNode.color || '#64748B'}
+                      onChange={(event) => updateNode(selectedNode.id, { color: event.target.value } as Partial<FlowMockNode>)}
+                      className="h-10 w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-1 py-1"
+                    />
+                  </label>
                 </>
               )}
+              <div className="grid grid-cols-2 gap-3">
+                <label className="space-y-1.5">
+                  <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Width</span>
+                  <input
+                    type="number"
+                    value={Math.round(getRenderedNodeDimensions(selectedNode).width)}
+                    onChange={(event) => updateNode(selectedNode.id, { width: Number(event.target.value) })}
+                    className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+                  />
+                </label>
+                <label className="space-y-1.5">
+                  <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Height</span>
+                  <input
+                    type="number"
+                    value={Math.round(getRenderedNodeDimensions(selectedNode).height)}
+                    onChange={(event) => updateNode(selectedNode.id, { height: Number(event.target.value) })}
+                    className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none"
+                  />
+                </label>
+              </div>
               <div className="grid grid-cols-2 gap-3">
                 <label className="space-y-1.5">
                   <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">X</span>


### PR DESCRIPTION
## Summary
- Allow manual node widths to take effect instead of being forced back to auto-sized text width
- Lower minimum widths and increase wrapping aggressiveness so long labels can fit in narrower nodes
- Keep editor, preview, and export sizing logic aligned through the shared Flow helper

## Testing
- `npx tsc --noEmit` for the web app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entity nodes now support custom shapes (box, pill, diamond, note) with configurable width and height.
  * Added alignment guides for snap-to-grid positioning when dragging nodes.
  * Arrow key shortcuts enable fine-tuning of selected node positions.
  * Enhanced node resizing with 8-directional handle support and visual feedback.
  * Improved text layout ensures node dimensions match rendered content accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->