### PR TITLE
fix: Fix invalid entity name handling for existing Flow entities

### DIFF
--- a/internal/api/handlers/entities.go
+++ b/internal/api/handlers/entities.go
@@ -190,9 +190,14 @@ func (h *Handlers) CreateEntity(w http.ResponseWriter, r *http.Request) {
 // Parses body, validates, updates in DB, publishes EntityUpdated, and writes audit.
 func (h *Handlers) UpdateEntity(w http.ResponseWriter, r *http.Request) {
 	kind := chi.URLParam(r, "kind")
-	name := chi.URLParam(r, "name")
+	oldName := chi.URLParam(r, "name")
 	if kind == "Flow" && !h.ensureFlowWriteAccess(w, r) {
 		return
+	}
+
+	oldNamespace := r.URL.Query().Get("namespace")
+	if oldNamespace == "" {
+		oldNamespace = entity.DefaultNamespace
 	}
 
 	var e entity.Entity
@@ -201,9 +206,15 @@ func (h *Handlers) UpdateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Ensure the URL path values take precedence.
+	// The URL identifies the existing row; the body carries the desired state.
+	// This allows older entities with invalid names to be renamed to a valid slug.
 	e.Kind = kind
-	e.Metadata.Name = name
+	if strings.TrimSpace(e.Metadata.Name) == "" {
+		e.Metadata.Name = oldName
+	}
+	if strings.TrimSpace(e.Metadata.Namespace) == "" {
+		e.Metadata.Namespace = oldNamespace
+	}
 
 	// Set defaults.
 	e.SetDefaults()
@@ -215,18 +226,18 @@ func (h *Handlers) UpdateEntity(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Capture before state for audit log.
-	ns := e.Metadata.Namespace
-	if ns == "" {
-		ns = entity.DefaultNamespace
-	}
 	var beforeState string
-	if prev, err := h.DB.GetEntity(r.Context(), e.Kind, ns, e.Metadata.Name); err == nil {
+	if prev, err := h.DB.GetEntity(r.Context(), kind, oldNamespace, oldName); err == nil {
 		beforeState = marshalEntityState(prev)
 	}
 
-	if err := h.DB.UpdateEntity(r.Context(), &e); err != nil {
+	if err := h.DB.UpdateEntityByRef(r.Context(), kind, oldNamespace, oldName, &e); err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			writeError(w, http.StatusNotFound, entityNotFoundMessage(e.Kind, ns, e.Metadata.Name))
+			writeError(w, http.StatusNotFound, entityNotFoundMessage(kind, oldNamespace, oldName))
+			return
+		}
+		if errors.Is(err, entity.ErrEntityAlreadyExists) {
+			writeError(w, http.StatusConflict, "entity already exists")
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "failed to update entity")
@@ -237,9 +248,11 @@ func (h *Handlers) UpdateEntity(w http.ResponseWriter, r *http.Request) {
 	h.Events.Publish(events.Event{
 		Type: events.EntityUpdated,
 		Data: map[string]any{
-			"kind":      e.Kind,
-			"name":      e.Metadata.Name,
-			"namespace": e.Metadata.Namespace,
+			"kind":         e.Kind,
+			"name":         e.Metadata.Name,
+			"namespace":    e.Metadata.Namespace,
+			"oldName":      oldName,
+			"oldNamespace": oldNamespace,
 		},
 	})
 

--- a/internal/api/handlers/flow.go
+++ b/internal/api/handlers/flow.go
@@ -185,7 +185,12 @@ func (h *Handlers) UpdateFlowEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	name := chi.URLParam(r, "name")
+	oldName := chi.URLParam(r, "name")
+	oldNamespace := r.URL.Query().Get("namespace")
+	if oldNamespace == "" {
+		oldNamespace = entity.DefaultNamespace
+	}
+
 	var e entity.Entity
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxFlowEntityRequestBytes)).Decode(&e); err != nil {
 		var maxErr *http.MaxBytesError
@@ -202,7 +207,12 @@ func (h *Handlers) UpdateFlowEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	e.Kind = "Flow"
-	e.Metadata.Name = name
+	if strings.TrimSpace(e.Metadata.Name) == "" {
+		e.Metadata.Name = oldName
+	}
+	if strings.TrimSpace(e.Metadata.Namespace) == "" {
+		e.Metadata.Namespace = oldNamespace
+	}
 	e.SetDefaults()
 
 	if err := h.Validator.Validate(&e); err != nil {
@@ -210,19 +220,18 @@ func (h *Handlers) UpdateFlowEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ns := e.Metadata.Namespace
-	if ns == "" {
-		ns = entity.DefaultNamespace
-	}
-
 	var beforeState string
-	if prev, err := h.DB.GetEntity(r.Context(), e.Kind, ns, e.Metadata.Name); err == nil {
+	if prev, err := h.DB.GetEntity(r.Context(), "Flow", oldNamespace, oldName); err == nil {
 		beforeState = marshalEntityState(prev)
 	}
 
-	if err := h.DB.UpdateEntity(r.Context(), &e); err != nil {
+	if err := h.DB.UpdateEntityByRef(r.Context(), "Flow", oldNamespace, oldName, &e); err != nil {
 		if errors.Is(err, entity.ErrEntityNotFound) {
-			writeError(w, http.StatusNotFound, entityNotFoundMessage(e.Kind, ns, e.Metadata.Name))
+			writeError(w, http.StatusNotFound, entityNotFoundMessage("Flow", oldNamespace, oldName))
+			return
+		}
+		if errors.Is(err, entity.ErrEntityAlreadyExists) {
+			writeError(w, http.StatusConflict, "entity already exists")
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "failed to update flow")

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -231,6 +231,10 @@ func unmarshalAnyMap(s string) map[string]any {
 // CreateEntity inserts a new entity into the database.
 // It generates a UUID for the entity and sets timestamps.
 func (d *DB) CreateEntity(ctx context.Context, e *entity.Entity) error {
+	if err := e.Validate(); err != nil {
+		return fmt.Errorf("%w: %v", entity.ErrInvalidEntity, err)
+	}
+
 	id := newUUID()
 	now := time.Now().UTC()
 
@@ -347,6 +351,10 @@ func (d *DB) CountEntitiesByKind(ctx context.Context) (map[string]int64, error) 
 // UpdateEntity updates an existing entity identified by kind, namespace, and name.
 // It updates all mutable fields and bumps the updated_at timestamp.
 func (d *DB) UpdateEntity(ctx context.Context, e *entity.Entity) error {
+	if err := e.Validate(); err != nil {
+		return fmt.Errorf("%w: %v", entity.ErrInvalidEntity, err)
+	}
+
 	e.Metadata.UpdatedAt = time.Now().UTC()
 
 	tags := marshalJSON(e.Metadata.Tags)
@@ -375,6 +383,60 @@ func (d *DB) UpdateEntity(ctx context.Context, e *entity.Entity) error {
 		e.Metadata.Name,
 	)
 	if err != nil {
+		return fmt.Errorf("updating entity: %w", err)
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking rows affected: %w", err)
+	}
+	if n == 0 {
+		return entity.ErrEntityNotFound
+	}
+	return nil
+}
+
+// UpdateEntityByRef updates an existing entity identified by oldKind, oldNamespace,
+// and oldName. The entity payload may carry a new valid metadata.name/namespace,
+// which lets operators repair older records created with invalid identifiers.
+func (d *DB) UpdateEntityByRef(ctx context.Context, oldKind, oldNamespace, oldName string, e *entity.Entity) error {
+	if err := e.Validate(); err != nil {
+		return fmt.Errorf("%w: %v", entity.ErrInvalidEntity, err)
+	}
+
+	e.Metadata.UpdatedAt = time.Now().UTC()
+
+	tags := marshalJSON(e.Metadata.Tags)
+	annotations := marshalJSON(e.Metadata.Annotations)
+	labels := marshalJSON(e.Metadata.Labels)
+	spec := marshalJSON(e.Spec)
+
+	result, err := d.exec(ctx,
+		`UPDATE entities
+		 SET api_version = ?, name = ?, namespace = ?, title = ?, description = ?, owner = ?,
+		     tags = ?, annotations = ?, labels = ?, spec = ?,
+		     updated_at = ?, created_by = ?
+		 WHERE kind = ? AND namespace = ? AND name = ?`,
+		e.APIVersion,
+		e.Metadata.Name,
+		e.Metadata.Namespace,
+		e.Metadata.Title,
+		e.Metadata.Description,
+		e.Metadata.Owner,
+		tags,
+		annotations,
+		labels,
+		spec,
+		e.Metadata.UpdatedAt,
+		e.Metadata.CreatedBy,
+		oldKind,
+		oldNamespace,
+		oldName,
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return entity.ErrEntityAlreadyExists
+		}
 		return fmt.Errorf("updating entity: %w", err)
 	}
 

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/go2engle/gantry/internal/config"
+	"github.com/go2engle/gantry/internal/entity"
+)
+
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+
+	dataDir := t.TempDir()
+	cfg := config.Default()
+	cfg.DataDir = dataDir
+	cfg.DBDSN = filepath.Join(dataDir, "gantry.db")
+	database, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	if err := database.Migrate(); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	return database
+}
+
+func TestUpdateEntityByRefRepairsInvalidExistingName(t *testing.T) {
+	ctx := context.Background()
+	database := newTestDB(t)
+
+	_, err := database.exec(ctx,
+		`INSERT INTO entities (id, kind, api_version, name, namespace, title) VALUES (?, ?, ?, ?, ?, ?)`,
+		newUUID(), "Flow", entity.DefaultAPIVersion, "Future State (Draft)", entity.DefaultNamespace, "Future State (Draft)",
+	)
+	if err != nil {
+		t.Fatalf("insert invalid existing entity: %v", err)
+	}
+
+	repaired := &entity.Entity{
+		Kind:       "Flow",
+		APIVersion: entity.DefaultAPIVersion,
+		Metadata: entity.EntityMetadata{
+			Name:      "future-state-draft",
+			Namespace: entity.DefaultNamespace,
+			Title:     "Future State (Draft)",
+		},
+		Spec: map[string]any{},
+	}
+	if err := database.UpdateEntityByRef(ctx, "Flow", entity.DefaultNamespace, "Future State (Draft)", repaired); err != nil {
+		t.Fatalf("UpdateEntityByRef() error = %v", err)
+	}
+
+	if _, err := database.GetEntity(ctx, "Flow", entity.DefaultNamespace, "Future State (Draft)"); err == nil {
+		t.Fatalf("old invalid entity still exists")
+	}
+	if _, err := database.GetEntity(ctx, "Flow", entity.DefaultNamespace, "future-state-draft"); err != nil {
+		t.Fatalf("repaired entity lookup failed: %v", err)
+	}
+}
+
+func TestDeleteEntityRemovesInvalidExistingName(t *testing.T) {
+	ctx := context.Background()
+	database := newTestDB(t)
+
+	_, err := database.exec(ctx,
+		`INSERT INTO entities (id, kind, api_version, name, namespace) VALUES (?, ?, ?, ?, ?)`,
+		newUUID(), "Flow", entity.DefaultAPIVersion, "Future State (Draft)", entity.DefaultNamespace,
+	)
+	if err != nil {
+		t.Fatalf("insert invalid existing entity: %v", err)
+	}
+
+	if err := database.DeleteEntity(ctx, "Flow", entity.DefaultNamespace, "Future State (Draft)"); err != nil {
+		t.Fatalf("DeleteEntity() error = %v", err)
+	}
+}

--- a/internal/entity/entity.go
+++ b/internal/entity/entity.go
@@ -6,6 +6,7 @@ package entity
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -16,7 +17,11 @@ const (
 
 	// DefaultNamespace is the default namespace assigned to entities.
 	DefaultNamespace = "default"
+
+	maxEntityNameLength = 253
 )
+
+var entityNamePattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$`)
 
 // Entity represents a catalog item in Gantry.
 type Entity struct {
@@ -52,6 +57,12 @@ func (e *Entity) Validate() error {
 
 	if strings.TrimSpace(e.Metadata.Name) == "" {
 		errs = append(errs, "metadata.name is required")
+	} else if !IsValidName(e.Metadata.Name) {
+		errs = append(errs, "metadata.name must be a URL-safe slug: use lowercase letters, numbers, hyphens, or dots, and start and end with a letter or number")
+	}
+
+	if strings.TrimSpace(e.Metadata.Namespace) != "" && !IsValidName(e.Metadata.Namespace) {
+		errs = append(errs, "metadata.namespace must be a URL-safe slug: use lowercase letters, numbers, hyphens, or dots, and start and end with a letter or number")
 	}
 
 	if len(errs) > 0 {
@@ -59,6 +70,15 @@ func (e *Entity) Validate() error {
 	}
 
 	return nil
+}
+
+// IsValidName reports whether a metadata name or namespace is a stable,
+// URL-safe entity identifier. Display text belongs in metadata.title.
+func IsValidName(value string) bool {
+	if value == "" || len(value) > maxEntityNameLength {
+		return false
+	}
+	return entityNamePattern.MatchString(value)
 }
 
 // SetDefaults populates default values for optional fields that are empty.

--- a/internal/entity/validation_test.go
+++ b/internal/entity/validation_test.go
@@ -2,6 +2,59 @@ package entity
 
 import "testing"
 
+func TestEntityValidateRejectsDisplayNameAsMetadataName(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityName string
+	}{
+		{name: "spaces", entityName: "Future State"},
+		{name: "parentheses", entityName: "future-state-(draft)"},
+		{name: "uppercase", entityName: "Future-state"},
+		{name: "leading hyphen", entityName: "-future-state"},
+		{name: "trailing dot", entityName: "future-state."},
+		{name: "underscore", entityName: "future_state"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Entity{
+				Kind: "Flow",
+				Metadata: EntityMetadata{
+					Name: tt.entityName,
+				},
+			}
+
+			if err := e.Validate(); err == nil {
+				t.Fatalf("Validate() error = nil, want invalid metadata.name")
+			}
+		})
+	}
+}
+
+func TestEntityValidateAllowsURLSafeMetadataName(t *testing.T) {
+	tests := []string{
+		"future-state-draft",
+		"payment-api-v2",
+		"service.tenant-a",
+		"a1",
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := &Entity{
+				Kind: "Service",
+				Metadata: EntityMetadata{
+					Name: name,
+				},
+			}
+
+			if err := e.Validate(); err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestSchemaValidatorAllowsHealthCheckURLForAPIAndInfrastructure(t *testing.T) {
 	validator, err := NewSchemaValidator("")
 	if err != nil {

--- a/internal/gitops/serializer.go
+++ b/internal/gitops/serializer.go
@@ -13,9 +13,9 @@ import (
 
 // yamlEntity mirrors entity.Entity but with YAML tags and omits server-managed fields.
 type yamlEntity struct {
-	Kind       string       `yaml:"kind"`
-	APIVersion string       `yaml:"apiVersion"`
-	Metadata   yamlMetadata `yaml:"metadata"`
+	Kind       string         `yaml:"kind"`
+	APIVersion string         `yaml:"apiVersion"`
+	Metadata   yamlMetadata   `yaml:"metadata"`
 	Spec       map[string]any `yaml:"spec,omitempty"`
 }
 
@@ -91,6 +91,9 @@ func DeserializeEntity(data []byte) (*entity.Entity, error) {
 		Spec: ye.Spec,
 	}
 	e.SetDefaults()
+	if err := e.Validate(); err != nil {
+		return nil, err
+	}
 	return e, nil
 }
 

--- a/internal/gitops/serializer_test.go
+++ b/internal/gitops/serializer_test.go
@@ -1,0 +1,17 @@
+package gitops
+
+import "testing"
+
+func TestDeserializeEntityRejectsInvalidMetadataName(t *testing.T) {
+	data := []byte(`
+kind: Flow
+apiVersion: gantry.io/v1
+metadata:
+  name: Future State (Draft)
+spec: {}
+`)
+
+	if _, err := DeserializeEntity(data); err == nil {
+		t.Fatalf("DeserializeEntity() error = nil, want invalid metadata.name")
+	}
+}

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Search, Server, Globe, Database, Users, Cloud, FileText, Box, Workflow } from 'lucide-react';
 import { api } from '../lib/api';
 import type { SearchResult } from '../lib/types';
+import { catalogEntityPath } from '../lib/utils';
 
 const kindIcons: Record<string, React.ComponentType<{ className?: string }>> = {
   Service: Server,
@@ -71,7 +72,7 @@ export default function CommandPalette() {
         const result = resultsRef.current[selectedIndexRef.current];
         if (result) {
           setOpen(false);
-          navigate(`/catalog/${result.kind}/${result.name}${result.namespace && result.namespace !== 'default' ? `?namespace=${encodeURIComponent(result.namespace)}` : ''}`);
+          navigate(catalogEntityPath(result.kind, result.name, result.namespace));
         }
       } else if (e.key === 'Escape') {
         setOpen(false);
@@ -112,7 +113,7 @@ export default function CommandPalette() {
 
   const selectResult = (result: SearchResult) => {
     setOpen(false);
-    navigate(`/catalog/${result.kind}/${result.name}${result.namespace && result.namespace !== 'default' ? `?namespace=${encodeURIComponent(result.namespace)}` : ''}`);
+    navigate(catalogEntityPath(result.kind, result.name, result.namespace));
   };
 
   const grouped = results.reduce<Record<string, SearchResult[]>>((acc, r) => {

--- a/web/src/components/EntityCard.tsx
+++ b/web/src/components/EntityCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { Server, Globe, Database, Users, Cloud, FileText, Box, Workflow } from 'lucide-react';
 import type { Entity } from '../lib/types';
+import { catalogEntityPath } from '../lib/utils';
 
 const kindIcons: Record<string, React.ComponentType<{ className?: string }>> = {
   Service: Server,
@@ -32,7 +33,7 @@ export default function EntityCard({ entity }: EntityCardProps) {
 
   return (
     <Link
-      to={`/catalog/${entity.kind}/${entity.metadata.name}${entity.metadata.namespace && entity.metadata.namespace !== 'default' ? `?namespace=${encodeURIComponent(entity.metadata.namespace)}` : ''}`}
+      to={catalogEntityPath(entity.kind, entity.metadata.name, entity.metadata.namespace)}
       className="group block rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-5 transition-all hover:shadow-md"
     >
       <div className="flex items-start justify-between">

--- a/web/src/components/EntityGraph.tsx
+++ b/web/src/components/EntityGraph.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { GraphData, GraphNode, GraphEdge } from '../lib/types';
+import { catalogEntityPath } from '../lib/utils';
 
 const NODE_W = 156;
 const NODE_H = 54;
@@ -252,7 +253,7 @@ function ListView({
   const renderRow = (node: GraphNode, relation: string) => {
     const color = kindColor(node.kind);
     const label = node.title && node.title !== node.name ? node.title : node.name;
-    const url = `/catalog/${node.kind}/${node.name}${node.namespace && node.namespace !== 'default' ? `?namespace=${encodeURIComponent(node.namespace)}` : ''}`;
+    const url = catalogEntityPath(node.kind, node.name, node.namespace);
 
     return (
       <button
@@ -504,7 +505,7 @@ export default function EntityGraph({
                     pos={pos}
                     isHovered={hoveredNode === node.id}
                     onMouseDown={nodeMouseDown}
-                    onClick={() => navigate(`/catalog/${node.kind}/${node.name}${node.namespace && node.namespace !== 'default' ? `?namespace=${encodeURIComponent(node.namespace)}` : ''}`)}
+                    onClick={() => navigate(catalogEntityPath(node.kind, node.name, node.namespace))}
                     onMouseEnter={() => setHoveredNode(node.id)}
                     onMouseLeave={() => setHoveredNode(null)}
                   />

--- a/web/src/components/EntityTable.tsx
+++ b/web/src/components/EntityTable.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 import type { Entity } from '../lib/types';
+import { catalogEntityPath } from '../lib/utils';
 
 interface EntityTableProps {
   entities: Entity[];
@@ -113,7 +114,7 @@ export default function EntityTable({ entities }: EntityTableProps) {
               className={`cursor-pointer border-b border-[var(--gantry-border)] transition-colors hover:bg-[var(--gantry-bg-tertiary)] ${
                 i % 2 === 0 ? 'bg-[var(--gantry-bg-primary)]' : 'bg-[var(--gantry-bg-secondary)]'
               }`}
-              onClick={() => navigate(`/catalog/${entity.kind}/${entity.metadata.name}${entity.metadata.namespace && entity.metadata.namespace !== 'default' ? `?namespace=${encodeURIComponent(entity.metadata.namespace)}` : ''}`)}
+              onClick={() => navigate(catalogEntityPath(entity.kind, entity.metadata.name, entity.metadata.namespace))}
             >
               <td className="px-4 py-3">
                 <div>

--- a/web/src/components/SchemaForm.tsx
+++ b/web/src/components/SchemaForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import type { JsonSchema } from '../lib/types';
+import { sanitizeEntityNameInput } from '../lib/utils';
 import EntityPicker from './EntityPicker';
 
 const ENTITY_KINDS = [
@@ -122,6 +123,8 @@ interface FieldProps {
 function FormField({ name, schema, value, onChange, required, error }: FieldProps) {
   const label = schema.title || name;
   const description = schema.description;
+  const isSlug = schema['x-slug'] === true;
+  const handleStringChange = (nextValue: string) => onChange(isSlug ? sanitizeEntityNameInput(nextValue) : nextValue);
   const borderClass = error
     ? 'border-[var(--gantry-danger)] focus:border-[var(--gantry-danger)] focus:ring-[var(--gantry-danger)]'
     : 'border-[var(--gantry-border)] focus:border-[var(--gantry-accent)] focus:ring-[var(--gantry-accent)]';
@@ -345,7 +348,7 @@ function FormField({ name, schema, value, onChange, required, error }: FieldProp
 
   // Default: string input (or textarea for long text / format: textarea)
   const isMultiline =
-    schema.format === 'textarea' || (schema.maxLength && schema.maxLength > 200);
+    !isSlug && (schema.format === 'textarea' || (schema.maxLength && schema.maxLength > 200));
 
   if (isMultiline) {
     return (
@@ -359,7 +362,7 @@ function FormField({ name, schema, value, onChange, required, error }: FieldProp
         )}
         <textarea
           value={value ?? ''}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => handleStringChange(e.target.value)}
           rows={4}
           maxLength={schema.maxLength}
           className={`w-full rounded-lg border bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:outline-none focus:ring-1 ${borderClass}`}
@@ -381,7 +384,7 @@ function FormField({ name, schema, value, onChange, required, error }: FieldProp
       <input
         type={schema.format === 'password' ? 'password' : schema.format === 'email' ? 'email' : schema.format === 'uri' ? 'url' : 'text'}
         value={value ?? ''}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => handleStringChange(e.target.value)}
         minLength={schema.minLength}
         maxLength={schema.maxLength}
         pattern={schema.pattern}

--- a/web/src/components/SchemaForm.tsx
+++ b/web/src/components/SchemaForm.tsx
@@ -384,6 +384,8 @@ function FormField({ name, schema, value, onChange, required, error }: FieldProp
         onChange={(e) => onChange(e.target.value)}
         minLength={schema.minLength}
         maxLength={schema.maxLength}
+        pattern={schema.pattern}
+        title={schema.pattern ? description : undefined}
         className={`w-full rounded-lg border bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:outline-none focus:ring-1 ${borderClass}`}
       />
       {error && <p className="text-xs text-[var(--gantry-danger)]">This field is required</p>}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse, NexusComponent, NexusAsset, NexusRepository, TopologyData, TopologyStatusMap, FlowPluginSettings, FlowSpec } from './types';
+import { encodePathSegment } from './utils';
 
 export const AUTH_UNAUTHORIZED_EVENT = 'auth:unauthorized';
 export const PLUGINS_UPDATED_EVENT = 'gantry:plugins-updated';
@@ -54,19 +55,19 @@ export const api = {
   logout: () => request<void>('POST', '/auth/logout'),
 
   listEntities: (kind?: string) =>
-    request<Entity[]>('GET', kind ? `/entities/${kind}` : '/entities'),
+    request<Entity[]>('GET', kind ? `/entities/${encodePathSegment(kind)}` : '/entities'),
 
   getEntity: (kind: string, name: string, namespace?: string) =>
-    request<Entity>('GET', `/entities/${encodeURIComponent(kind)}/${encodeURIComponent(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
+    request<Entity>('GET', `/entities/${encodePathSegment(kind)}/${encodePathSegment(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
 
   createEntity: (entity: Entity) =>
     request<Entity>('POST', '/entities', entity),
 
   updateEntity: (kind: string, name: string, entity: Entity, namespace?: string) =>
-    request<Entity>('PUT', `/entities/${encodeURIComponent(kind)}/${encodeURIComponent(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`, entity),
+    request<Entity>('PUT', `/entities/${encodePathSegment(kind)}/${encodePathSegment(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`, entity),
 
   deleteEntity: (kind: string, name: string, namespace?: string) =>
-    request<void>('DELETE', `/entities/${encodeURIComponent(kind)}/${encodeURIComponent(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
+    request<void>('DELETE', `/entities/${encodePathSegment(kind)}/${encodePathSegment(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
 
   search: (q: string) =>
     request<SearchResult[]>('GET', `/search?q=${encodeURIComponent(q)}`),
@@ -123,7 +124,7 @@ export const api = {
     request<void>('DELETE', `/auth/apikeys/${id}`),
 
   getEntityGraph: (kind: string, name: string, namespace?: string) =>
-    request<GraphData>('GET', `/graph/${kind}/${name}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
+    request<GraphData>('GET', `/graph/${encodePathSegment(kind)}/${encodePathSegment(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
 
   // Plugin marketplace
   listPlugins: () => request<PluginRegistryEntry[]>('GET', '/plugins'),
@@ -222,7 +223,7 @@ export const api = {
   createFlow: (metadata: Entity['metadata'], spec: FlowSpec) =>
     request<Entity>('POST', '/plugins/flow/entities', { kind: 'Flow', apiVersion: 'gantry.io/v1', metadata, spec }),
   updateFlow: (name: string, metadata: Entity['metadata'], spec: FlowSpec, namespace?: string) =>
-    request<Entity>('PUT', `/plugins/flow/entities/${encodeURIComponent(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`, {
+    request<Entity>('PUT', `/plugins/flow/entities/${encodePathSegment(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`, {
       kind: 'Flow',
       apiVersion: 'gantry.io/v1',
       metadata: {
@@ -232,7 +233,7 @@ export const api = {
       spec,
     }),
   deleteFlow: (name: string, namespace?: string) =>
-    request<void>('DELETE', `/plugins/flow/entities/${encodeURIComponent(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
+    request<void>('DELETE', `/plugins/flow/entities/${encodePathSegment(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
 
   // Health check proxy
   checkHealth: (url: string, signal?: AbortSignal) =>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -108,6 +108,7 @@ export interface JsonSchema {
   maximum?: number;
   minLength?: number;
   maxLength?: number;
+  pattern?: string;
   /** Custom extension: entity kind this field references (e.g. "API", "Team"). */
   'x-entity-ref'?: string;
   /** Custom extension: render a dropdown of Gantry roles. */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -111,6 +111,8 @@ export interface JsonSchema {
   pattern?: string;
   /** Custom extension: entity kind this field references (e.g. "API", "Team"). */
   'x-entity-ref'?: string;
+  /** Custom extension: keep this string as a URL-safe entity slug. */
+  'x-slug'?: boolean;
   /** Custom extension: render a dropdown of Gantry roles. */
   'x-role-picker'?: boolean;
 }

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -16,6 +16,33 @@ export function pruneEmpty(obj: Record<string, any>): Record<string, any> {
   return result;
 }
 
+export function encodePathSegment(value: string): string {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (char) =>
+    `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+export function catalogEntityPath(kind: string, name: string, namespace?: string): string {
+  const namespaceSuffix = namespace && namespace !== 'default'
+    ? `?namespace=${encodeURIComponent(namespace)}`
+    : '';
+  return `/catalog/${encodePathSegment(kind)}/${encodePathSegment(name)}${namespaceSuffix}`;
+}
+
+export function sanitizeEntityName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9.-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
+}
+
+export function isValidEntityName(value: string): boolean {
+  return /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/.test(value) && value.length <= 253;
+}
+
 function pruneValue(value: any): any {
   if (value === undefined || value === null || value === '') return undefined;
 

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -30,13 +30,18 @@ export function catalogEntityPath(kind: string, name: string, namespace?: string
 }
 
 export function sanitizeEntityName(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
+  return sanitizeEntityNameInput(value).replace(/[^a-z0-9]+$/g, '');
+}
+
+export function sanitizeEntityNameInput(value: string): string {
+  const next = value.toLowerCase().trimStart();
+  const allowTrailingSeparator = /[\s.-]$/.test(next);
+  const sanitized = next
     .replace(/\s+/g, '-')
     .replace(/[^a-z0-9.-]/g, '-')
     .replace(/-+/g, '-')
-    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
+    .replace(/^[^a-z0-9]+/g, '');
+  return allowTrailingSeparator ? sanitized : sanitized.replace(/[^a-z0-9]+$/g, '');
 }
 
 export function isValidEntityName(value: string): boolean {

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react';
 import { api, PLUGINS_UPDATED_EVENT } from '../lib/api';
 import { ENTITY_KINDS, filterEntityKindsByPlugins } from '../lib/types';
-import { pruneEmpty } from '../lib/utils';
+import { pruneEmpty, sanitizeEntityName } from '../lib/utils';
 import type { Entity, JsonSchema, PluginRegistryEntry } from '../lib/types';
 import EntityCard from '../components/EntityCard';
 import EntityTable from '../components/EntityTable';
@@ -193,7 +193,7 @@ export default function Catalog() {
         return;
       }
 
-      const name = (raw._name as string) || '';
+      const name = sanitizeEntityName((raw._name as string) || '');
       const title = (raw._title as string) || '';
       const owner = (raw._owner as string) || '';
       const description = (raw._description as string) || '';
@@ -249,6 +249,7 @@ export default function Catalog() {
           description: 'Unique URL-safe identifier. Use lowercase letters, numbers, hyphens, or dots.',
           pattern: '[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?',
           maxLength: 253,
+          'x-slug': true,
         },
         _title: { type: 'string', title: 'Title', description: 'Display name' },
         _owner: { type: 'string', title: 'Owner', description: 'Team or user that owns this entity', 'x-entity-ref': 'Team' },

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -243,7 +243,13 @@ export default function Catalog() {
     return {
       type: 'object',
       properties: {
-        _name: { type: 'string', title: 'Name', description: 'Unique identifier' },
+        _name: {
+          type: 'string',
+          title: 'Name',
+          description: 'Unique URL-safe identifier. Use lowercase letters, numbers, hyphens, or dots.',
+          pattern: '[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?',
+          maxLength: 253,
+        },
         _title: { type: 'string', title: 'Title', description: 'Display name' },
         _owner: { type: 'string', title: 'Owner', description: 'Team or user that owns this entity', 'x-entity-ref': 'Team' },
         _description: { type: 'string', title: 'Description' },

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -62,6 +62,7 @@ import type {
   TopologyData,
 } from '../lib/types';
 import { ENTITY_KINDS } from '../lib/types';
+import { catalogEntityPath } from '../lib/utils';
 
 const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   Server,
@@ -757,7 +758,7 @@ export default function Dashboard() {
                 return (
                   <Link
                     key={`${entity.kind}-${entity.metadata.name}`}
-                    to={`/catalog/${entity.kind}/${entity.metadata.name}${entity.metadata.namespace && entity.metadata.namespace !== 'default' ? `?namespace=${encodeURIComponent(entity.metadata.namespace)}` : ''}`}
+                    to={catalogEntityPath(entity.kind, entity.metadata.name, entity.metadata.namespace)}
                     className="flex items-center gap-4 px-6 py-3 transition-colors hover:bg-[var(--gantry-bg-secondary)]"
                   >
                     <Icon className="h-4 w-4 shrink-0 text-[var(--gantry-text-secondary)]" />
@@ -789,7 +790,7 @@ export default function Dashboard() {
                 return (
                   <Link
                     key={`${entity.kind}-${entity.metadata.name}`}
-                    to={`/catalog/${entity.kind}/${entity.metadata.name}${entity.metadata.namespace && entity.metadata.namespace !== 'default' ? `?namespace=${encodeURIComponent(entity.metadata.namespace)}` : ''}`}
+                    to={catalogEntityPath(entity.kind, entity.metadata.name, entity.metadata.namespace)}
                     className="flex items-center gap-4 px-6 py-3 transition-colors hover:bg-[var(--gantry-bg-secondary)]"
                   >
                     <Icon className="h-5 w-5 shrink-0 text-[var(--gantry-text-secondary)]" />
@@ -851,7 +852,7 @@ export default function Dashboard() {
                 return (
                   <Link
                     key={p.id}
-                    to={`/catalog/${p.kind}/${p.name}`}
+                    to={catalogEntityPath(p.kind, p.name)}
                     className="flex items-center gap-1.5 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] transition-colors hover:border-[var(--gantry-accent)] hover:text-[var(--gantry-accent)]"
                   >
                     <Icon className="h-4 w-4 shrink-0" />
@@ -881,7 +882,7 @@ export default function Dashboard() {
                   return (
                     <Link
                       key={`${entry.kind}-${entry.name}-${entry.namespace}`}
-                      to={`/catalog/${entry.kind}/${entry.name}${entry.namespace && entry.namespace !== 'default' ? `?namespace=${encodeURIComponent(entry.namespace)}` : ''}`}
+                      to={catalogEntityPath(entry.kind, entry.name, entry.namespace)}
                       className="flex items-center gap-4 px-6 py-3 transition-colors hover:bg-[var(--gantry-bg-secondary)]"
                     >
                       <Icon className="h-4 w-4 shrink-0 text-[var(--gantry-text-secondary)]" />

--- a/web/src/pages/EntityDetail.tsx
+++ b/web/src/pages/EntityDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { ChevronRight, Pencil, Trash2, X, ExternalLink, LayoutDashboard, BookOpen, FileText, Github, MessageSquare, Bell, Activity, Cpu, CircleHelp, RefreshCw, Workflow } from 'lucide-react';
 import { api } from '../lib/api';
-import { pruneEmpty } from '../lib/utils';
+import { catalogEntityPath, isValidEntityName, pruneEmpty, sanitizeEntityName } from '../lib/utils';
 import { useAuth } from '../hooks/useAuth';
 import type { Entity, JsonSchema, AuditEntry, GraphData, EntityLink, PluginRegistryEntry } from '../lib/types';
 import SchemaForm from '../components/SchemaForm';
@@ -128,7 +128,7 @@ export default function EntityDetail() {
   const [tab, setTab] = useState<Tab>('overview');
   const [editing, setEditing] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
-  const [editMeta, setEditMeta] = useState({ title: '', description: '', owner: '', tags: '', harborProject: '', harborRepository: '', nexusName: '', nexusRepository: '', nexusGroup: '' });
+  const [editMeta, setEditMeta] = useState({ name: '', title: '', description: '', owner: '', tags: '', harborProject: '', harborRepository: '', nexusName: '', nexusRepository: '', nexusGroup: '' });
   const [graphData, setGraphData] = useState<GraphData | null>(null);
   const [graphLoading, setGraphLoading] = useState(false);
   const [enabledPlugins, setEnabledPlugins] = useState<Set<string>>(new Set());
@@ -209,6 +209,7 @@ export default function EntityDetail() {
   function openEdit() {
     if (!entity) return;
     setEditMeta({
+      name: isValidEntityName(entity.metadata.name) ? entity.metadata.name : sanitizeEntityName(entity.metadata.name),
       title: entity.metadata.title ?? '',
       description: entity.metadata.description ?? '',
       owner: entity.metadata.owner ?? '',
@@ -266,6 +267,7 @@ export default function EntityDetail() {
         ...entity,
         metadata: {
           ...entity.metadata,
+          name: editMeta.name.trim() || entity.metadata.name,
           title: editMeta.title || undefined,
           description: editMeta.description || undefined,
           owner: editMeta.owner || undefined,
@@ -276,6 +278,9 @@ export default function EntityDetail() {
       }, namespace);
       setEntity(updated);
       setEditing(false);
+      if (updated.metadata.name !== name || (updated.metadata.namespace || 'default') !== namespace) {
+        navigate(catalogEntityPath(updated.kind, updated.metadata.name, updated.metadata.namespace), { replace: true });
+      }
     } catch (e: any) {
       setError(e.message);
     }
@@ -925,7 +930,7 @@ export default function EntityDetail() {
                         return (
                           <tr key={n} className="hover:bg-[var(--gantry-bg-secondary)]">
                             <td className="whitespace-nowrap px-4 py-3 text-sm font-medium">
-                              <Link to={`/catalog/API/${n}${(e?.metadata.namespace && e.metadata.namespace !== 'default') ? `?namespace=${e.metadata.namespace}` : ''}`} className="text-[var(--gantry-accent)] hover:underline">
+                              <Link to={catalogEntityPath('API', n, e?.metadata.namespace)} className="text-[var(--gantry-accent)] hover:underline">
                                 {e?.metadata.title || n}
                               </Link>
                             </td>
@@ -1001,6 +1006,20 @@ export default function EntityDetail() {
                   Metadata
                 </h3>
                 <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-[var(--gantry-text-primary)] mb-1">Name</label>
+                    <p className="text-xs text-[var(--gantry-text-secondary)] mb-1.5">URL-safe identifier. Use lowercase letters, numbers, hyphens, or dots.</p>
+                    <input
+                      type="text"
+                      className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--gantry-accent)]"
+                      value={editMeta.name}
+                      placeholder="payment-api"
+                      pattern="[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?"
+                      maxLength={253}
+                      onBlur={() => setEditMeta((m) => ({ ...m, name: sanitizeEntityName(m.name) }))}
+                      onChange={(e) => setEditMeta((m) => ({ ...m, name: e.target.value }))}
+                    />
+                  </div>
                   <div className="grid grid-cols-2 gap-4">
                     <div>
                       <label className="block text-sm font-medium text-[var(--gantry-text-primary)] mb-1">Title</label>

--- a/web/src/pages/EntityDetail.tsx
+++ b/web/src/pages/EntityDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { ChevronRight, Pencil, Trash2, X, ExternalLink, LayoutDashboard, BookOpen, FileText, Github, MessageSquare, Bell, Activity, Cpu, CircleHelp, RefreshCw, Workflow } from 'lucide-react';
 import { api } from '../lib/api';
-import { catalogEntityPath, isValidEntityName, pruneEmpty, sanitizeEntityName } from '../lib/utils';
+import { catalogEntityPath, isValidEntityName, pruneEmpty, sanitizeEntityName, sanitizeEntityNameInput } from '../lib/utils';
 import { useAuth } from '../hooks/useAuth';
 import type { Entity, JsonSchema, AuditEntry, GraphData, EntityLink, PluginRegistryEntry } from '../lib/types';
 import SchemaForm from '../components/SchemaForm';
@@ -1017,7 +1017,7 @@ export default function EntityDetail() {
                       pattern="[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?"
                       maxLength={253}
                       onBlur={() => setEditMeta((m) => ({ ...m, name: sanitizeEntityName(m.name) }))}
-                      onChange={(e) => setEditMeta((m) => ({ ...m, name: e.target.value }))}
+                      onChange={(e) => setEditMeta((m) => ({ ...m, name: sanitizeEntityNameInput(e.target.value) }))}
                     />
                   </div>
                   <div className="grid grid-cols-2 gap-4">

--- a/web/src/pages/Flow.tsx
+++ b/web/src/pages/Flow.tsx
@@ -69,6 +69,7 @@ import {
 } from '../lib/flow';
 import { useFlowHealth } from '../hooks/useFlowHealth';
 import { useTheme } from '../hooks/useTheme';
+import { catalogEntityPath } from '../lib/utils';
 
 const CANVAS_WIDTH = 1600;
 const CANVAS_HEIGHT = 900;
@@ -289,7 +290,7 @@ function shapeSelectionOverlay(shape: FlowMockShape, color: string, width: numbe
 
 
 function entityPath(kind: string, name: string, namespace?: string): string {
-  return `/catalog/${kind}/${name}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`;
+  return catalogEntityPath(kind, name, namespace);
 }
 
 function sanitizeFlowName(value: string): string {
@@ -1611,10 +1612,14 @@ export default function Flow() {
       setError(`Editing flows requires the ${flowSettings.editorRole} role or higher.`);
       return;
     }
-    const name = flowName.trim();
+    const rawName = flowName.trim();
+    const name = sanitizeFlowName(rawName);
     if (!name) {
-      setError('Flow name is required');
+      setError('Flow name is required. Use lowercase letters, numbers, hyphens, or dots.');
       return;
+    }
+    if (rawName !== name) {
+      setFlowName(name);
     }
 
     setSaving(true);
@@ -2972,8 +2977,11 @@ export default function Flow() {
                 <input
                   value={flowName}
                   onChange={(event) => setMeta(() => setFlowName(event.target.value))}
+                  onBlur={() => setFlowName((value) => sanitizeFlowName(value))}
                   disabled={currentFlowName !== null}
                   placeholder="checkout-system"
+                  pattern="[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?"
+                  title="Use lowercase letters, numbers, hyphens, or dots."
                   className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
                 />
               </label>

--- a/web/src/pages/Flow.tsx
+++ b/web/src/pages/Flow.tsx
@@ -69,7 +69,7 @@ import {
 } from '../lib/flow';
 import { useFlowHealth } from '../hooks/useFlowHealth';
 import { useTheme } from '../hooks/useTheme';
-import { catalogEntityPath } from '../lib/utils';
+import { catalogEntityPath, sanitizeEntityNameInput } from '../lib/utils';
 
 const CANVAS_WIDTH = 1600;
 const CANVAS_HEIGHT = 900;
@@ -1177,7 +1177,7 @@ export default function Flow() {
   function loadFlow(flow: Entity) {
     setCurrentFlowName(flow.metadata.name);
     setCurrentNamespace(flow.metadata.namespace || 'default');
-    setFlowName(flow.metadata.name);
+    setFlowName(sanitizeFlowName(flow.metadata.name) || flow.metadata.name);
     setFlowTitleValue(flow.metadata.title || '');
     setFlowDescription(flow.metadata.description || '');
     setFlowOwner(flow.metadata.owner || '');
@@ -2848,7 +2848,7 @@ export default function Flow() {
               </button>
               <button
                 onClick={saveFlow}
-                disabled={saving}
+                disabled={saving || !flowName.trim()}
                 className="inline-flex items-center gap-2 rounded-lg bg-[var(--gantry-accent)] px-4 py-2 text-sm font-medium text-[var(--gantry-bg-primary)] hover:bg-[var(--gantry-accent-hover)] disabled:opacity-60"
               >
                 {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
@@ -2976,11 +2976,12 @@ export default function Flow() {
                 <span className="text-xs font-medium uppercase tracking-wide text-[var(--gantry-text-secondary)]">Name</span>
                 <input
                   value={flowName}
-                  onChange={(event) => setMeta(() => setFlowName(event.target.value))}
+                  onChange={(event) => setMeta(() => setFlowName(sanitizeEntityNameInput(event.target.value)))}
                   onBlur={() => setFlowName((value) => sanitizeFlowName(value))}
                   disabled={currentFlowName !== null}
                   placeholder="checkout-system"
                   pattern="[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?"
+                  maxLength={253}
                   title="Use lowercase letters, numbers, hyphens, or dots."
                   className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-secondary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
                 />

--- a/web/src/pages/TopologyExplorer.tsx
+++ b/web/src/pages/TopologyExplorer.tsx
@@ -21,6 +21,7 @@ import {
   ChevronDown,
 } from 'lucide-react';
 import { api } from '../lib/api';
+import { catalogEntityPath } from '../lib/utils';
 import type {
   TopologyData,
   TopologyNode,
@@ -28,6 +29,12 @@ import type {
   TopologyEnvironment,
   TopologyStatusMap,
 } from '../lib/types';
+
+function topologyEntityPath(id: string): string {
+  const separator = id.indexOf('/');
+  if (separator === -1) return '/catalog';
+  return catalogEntityPath(id.slice(0, separator), id.slice(separator + 1));
+}
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -766,7 +773,7 @@ function DetailPanel({
             </span>
           )}
           <Link
-            to={`/catalog/${node.kind}/${node.name}`}
+            to={catalogEntityPath(node.kind, node.name, node.namespace)}
             className="flex items-center gap-1 rounded-lg border border-[var(--gantry-border)] px-3 py-1.5 text-xs font-medium text-[var(--gantry-accent)] hover:bg-[var(--gantry-accent)]/10"
           >
             View <ExternalLink className="h-3 w-3" />
@@ -825,7 +832,7 @@ function DetailPanel({
                     </span>
                     <ArrowRight className="h-3 w-3 shrink-0 text-[var(--gantry-text-secondary)]" />
                     <Link
-                      to={`/catalog/${e.to}`}
+                      to={topologyEntityPath(e.to)}
                       className="truncate text-[var(--gantry-accent)] hover:underline"
                     >
                       {e.to}
@@ -844,7 +851,7 @@ function DetailPanel({
                 {inbound.map((e, i) => (
                   <div key={i} className="flex items-center gap-2 text-xs">
                     <Link
-                      to={`/catalog/${e.from}`}
+                      to={topologyEntityPath(e.from)}
                       className="truncate text-[var(--gantry-accent)] hover:underline"
                     >
                       {e.from}


### PR DESCRIPTION
## Summary
- Reject invalid entity names going forward with shared slug validation at the entity, DB, REST, and GitOps layers
- Add a repair-capable update path so existing bad entities can be renamed to a valid slug instead of failing with `entity not found`
- Update Flow and catalog UI links to use encoded paths and expose the entity name in the edit drawer for remediation
- Add tests for invalid-name validation and repairing/deleting legacy bad records

## Testing
- `go test ./...`
- `npm run build`
- Added unit coverage for entity validation, GitOps import rejection, and DB repair/delete behavior