### PR TITLE
feat(search): index full entity data

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -162,6 +162,110 @@ func (d *DB) Migrate() error {
 			return fmt.Errorf("migration %d failed: %w", i+1, err)
 		}
 	}
+	if d.IsSQLite() {
+		if err := d.ensureEntitiesFTSSchema(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *DB) ensureEntitiesFTSSchema() error {
+	const createFTS = `CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
+		name,
+		namespace,
+		title,
+		description,
+		tags,
+		kind,
+		owner,
+		annotations,
+		labels,
+		spec,
+		api_version,
+		created_by,
+		content='entities',
+		content_rowid='rowid'
+	)`
+	const createInsertTrigger = `CREATE TRIGGER IF NOT EXISTS entities_ai AFTER INSERT ON entities BEGIN
+		INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+		VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
+	END`
+	const createDeleteTrigger = `CREATE TRIGGER IF NOT EXISTS entities_ad AFTER DELETE ON entities BEGIN
+		INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+		VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
+	END`
+	const createUpdateTrigger = `CREATE TRIGGER IF NOT EXISTS entities_au AFTER UPDATE ON entities BEGIN
+		INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+		VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
+		INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+		VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
+	END`
+
+	columns := map[string]bool{}
+	rows, err := d.Query(`PRAGMA table_info(entities_fts)`)
+	if err != nil {
+		return fmt.Errorf("checking entities_fts schema: %w", err)
+	}
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull, pk int
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &defaultValue, &pk); err != nil {
+			rows.Close()
+			return fmt.Errorf("scanning entities_fts schema: %w", err)
+		}
+		columns[name] = true
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing entities_fts schema rows: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating entities_fts schema: %w", err)
+	}
+
+	required := []string{
+		"name",
+		"namespace",
+		"title",
+		"description",
+		"tags",
+		"kind",
+		"owner",
+		"annotations",
+		"labels",
+		"spec",
+		"api_version",
+		"created_by",
+	}
+	needsRebuild := len(columns) == 0
+	for _, col := range required {
+		if !columns[col] {
+			needsRebuild = true
+			break
+		}
+	}
+	if !needsRebuild {
+		return nil
+	}
+
+	statements := []string{
+		`DROP TRIGGER IF EXISTS entities_ai`,
+		`DROP TRIGGER IF EXISTS entities_ad`,
+		`DROP TRIGGER IF EXISTS entities_au`,
+		`DROP TABLE IF EXISTS entities_fts`,
+		createFTS,
+		createInsertTrigger,
+		createDeleteTrigger,
+		createUpdateTrigger,
+		`INSERT INTO entities_fts(entities_fts) VALUES('rebuild')`,
+	}
+	for _, stmt := range statements {
+		if _, err := d.Exec(stmt); err != nil {
+			return fmt.Errorf("upgrading entities_fts schema: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -171,37 +171,6 @@ func (d *DB) Migrate() error {
 }
 
 func (d *DB) ensureEntitiesFTSSchema() error {
-	const createFTS = `CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
-		name,
-		namespace,
-		title,
-		description,
-		tags,
-		kind,
-		owner,
-		annotations,
-		labels,
-		spec,
-		api_version,
-		created_by,
-		content='entities',
-		content_rowid='rowid'
-	)`
-	const createInsertTrigger = `CREATE TRIGGER IF NOT EXISTS entities_ai AFTER INSERT ON entities BEGIN
-		INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
-		VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
-	END`
-	const createDeleteTrigger = `CREATE TRIGGER IF NOT EXISTS entities_ad AFTER DELETE ON entities BEGIN
-		INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
-		VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
-	END`
-	const createUpdateTrigger = `CREATE TRIGGER IF NOT EXISTS entities_au AFTER UPDATE ON entities BEGIN
-		INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
-		VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
-		INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
-		VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
-	END`
-
 	columns := map[string]bool{}
 	rows, err := d.Query(`PRAGMA table_info(entities_fts)`)
 	if err != nil {
@@ -247,6 +216,13 @@ func (d *DB) ensureEntitiesFTSSchema() error {
 		}
 	}
 	if !needsRebuild {
+		triggersOK, err := d.entitiesFTSTriggersExist()
+		if err != nil {
+			return err
+		}
+		needsRebuild = !triggersOK
+	}
+	if !needsRebuild {
 		return nil
 	}
 
@@ -255,10 +231,10 @@ func (d *DB) ensureEntitiesFTSSchema() error {
 		`DROP TRIGGER IF EXISTS entities_ad`,
 		`DROP TRIGGER IF EXISTS entities_au`,
 		`DROP TABLE IF EXISTS entities_fts`,
-		createFTS,
-		createInsertTrigger,
-		createDeleteTrigger,
-		createUpdateTrigger,
+		entitiesFTSTableSQL,
+		entitiesFTSInsertTriggerSQL,
+		entitiesFTSDeleteTriggerSQL,
+		entitiesFTSUpdateTriggerSQL,
 		`INSERT INTO entities_fts(entities_fts) VALUES('rebuild')`,
 	}
 	for _, stmt := range statements {
@@ -267,6 +243,43 @@ func (d *DB) ensureEntitiesFTSSchema() error {
 		}
 	}
 	return nil
+}
+
+func (d *DB) entitiesFTSTriggersExist() (bool, error) {
+	rows, err := d.Query(`
+		SELECT name, sql
+		FROM sqlite_master
+		WHERE type = 'trigger'
+			AND tbl_name = 'entities'
+			AND name IN ('entities_ai', 'entities_ad', 'entities_au')`)
+	if err != nil {
+		return false, fmt.Errorf("checking entities_fts triggers: %w", err)
+	}
+	defer rows.Close()
+
+	found := map[string]bool{}
+	expected := map[string]string{
+		"entities_ai": normalizeSQLiteSchemaSQL(entitiesFTSInsertTriggerSQL),
+		"entities_ad": normalizeSQLiteSchemaSQL(entitiesFTSDeleteTriggerSQL),
+		"entities_au": normalizeSQLiteSchemaSQL(entitiesFTSUpdateTriggerSQL),
+	}
+	for rows.Next() {
+		var name, sql string
+		if err := rows.Scan(&name, &sql); err != nil {
+			return false, fmt.Errorf("scanning entities_fts trigger: %w", err)
+		}
+		found[name] = normalizeSQLiteSchemaSQL(sql) == expected[name]
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterating entities_fts triggers: %w", err)
+	}
+	return found["entities_ai"] && found["entities_ad"] && found["entities_au"], nil
+}
+
+func normalizeSQLiteSchemaSQL(sql string) string {
+	normalized := strings.Join(strings.Fields(sql), " ")
+	normalized = strings.Replace(normalized, "CREATE TRIGGER IF NOT EXISTS ", "CREATE TRIGGER ", 1)
+	return strings.ToLower(normalized)
 }
 
 // pgDuplicateColumnRe matches PostgreSQL's duplicate-column error message:

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -171,8 +171,9 @@ func (d *DB) Migrate() error {
 }
 
 func (d *DB) ensureEntitiesFTSSchema() error {
+	ctx := context.Background()
 	columns := map[string]bool{}
-	rows, err := d.Query(`PRAGMA table_info(entities_fts)`)
+	rows, err := d.queryRows(ctx, `PRAGMA table_info(entities_fts)`)
 	if err != nil {
 		return fmt.Errorf("checking entities_fts schema: %w", err)
 	}
@@ -216,7 +217,7 @@ func (d *DB) ensureEntitiesFTSSchema() error {
 		}
 	}
 	if !needsRebuild {
-		triggersOK, err := d.entitiesFTSTriggersExist()
+		triggersOK, err := d.entitiesFTSTriggersExist(ctx)
 		if err != nil {
 			return err
 		}
@@ -238,15 +239,15 @@ func (d *DB) ensureEntitiesFTSSchema() error {
 		`INSERT INTO entities_fts(entities_fts) VALUES('rebuild')`,
 	}
 	for _, stmt := range statements {
-		if _, err := d.Exec(stmt); err != nil {
+		if _, err := d.exec(ctx, stmt); err != nil {
 			return fmt.Errorf("upgrading entities_fts schema: %w", err)
 		}
 	}
 	return nil
 }
 
-func (d *DB) entitiesFTSTriggersExist() (bool, error) {
-	rows, err := d.Query(`
+func (d *DB) entitiesFTSTriggersExist(ctx context.Context) (bool, error) {
+	rows, err := d.queryRows(ctx, `
 		SELECT name, sql
 		FROM sqlite_master
 		WHERE type = 'trigger'
@@ -264,11 +265,11 @@ func (d *DB) entitiesFTSTriggersExist() (bool, error) {
 		"entities_au": normalizeSQLiteSchemaSQL(entitiesFTSUpdateTriggerSQL),
 	}
 	for rows.Next() {
-		var name, sql string
-		if err := rows.Scan(&name, &sql); err != nil {
+		var name, triggerSQL string
+		if err := rows.Scan(&name, &triggerSQL); err != nil {
 			return false, fmt.Errorf("scanning entities_fts trigger: %w", err)
 		}
-		found[name] = normalizeSQLiteSchemaSQL(sql) == expected[name]
+		found[name] = normalizeSQLiteSchemaSQL(triggerSQL) == expected[name]
 	}
 	if err := rows.Err(); err != nil {
 		return false, fmt.Errorf("iterating entities_fts triggers: %w", err)

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -256,31 +256,37 @@ func allMigrations(dbType string) []string {
 			// FTS5 virtual table for full-text search across entities.
 			`CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
 				name,
+				namespace,
 				title,
 				description,
 				tags,
 				kind,
 				owner,
+				annotations,
+				labels,
+				spec,
+				api_version,
+				created_by,
 				content='entities',
 				content_rowid='rowid'
 			)`,
 
 			// Triggers to keep the FTS index in sync with the entities table.
 			`CREATE TRIGGER IF NOT EXISTS entities_ai AFTER INSERT ON entities BEGIN
-				INSERT INTO entities_fts(rowid, name, title, description, tags, kind, owner)
-				VALUES (new.rowid, new.name, new.title, new.description, new.tags, new.kind, new.owner);
+				INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+				VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
 			END`,
 
 			`CREATE TRIGGER IF NOT EXISTS entities_ad AFTER DELETE ON entities BEGIN
-				INSERT INTO entities_fts(entities_fts, rowid, name, title, description, tags, kind, owner)
-				VALUES ('delete', old.rowid, old.name, old.title, old.description, old.tags, old.kind, old.owner);
+				INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+				VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
 			END`,
 
 			`CREATE TRIGGER IF NOT EXISTS entities_au AFTER UPDATE ON entities BEGIN
-				INSERT INTO entities_fts(entities_fts, rowid, name, title, description, tags, kind, owner)
-				VALUES ('delete', old.rowid, old.name, old.title, old.description, old.tags, old.kind, old.owner);
-				INSERT INTO entities_fts(rowid, name, title, description, tags, kind, owner)
-				VALUES (new.rowid, new.name, new.title, new.description, new.tags, new.kind, new.owner);
+				INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+				VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
+				INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+				VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
 			END`,
 		)
 	}

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -9,6 +9,40 @@ const (
 	DefaultAdminPasswordHash = "$2a$10$eMgfxZdz20Vk.9EKPJ4oP.g99eQ1JgaHQs/JH7v2fpZZykUcN1Q8y"
 )
 
+const entitiesFTSTableSQL = `CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
+	name,
+	namespace,
+	title,
+	description,
+	tags,
+	kind,
+	owner,
+	annotations,
+	labels,
+	spec,
+	api_version,
+	created_by,
+	content='entities',
+	content_rowid='rowid'
+)`
+
+const entitiesFTSInsertTriggerSQL = `CREATE TRIGGER IF NOT EXISTS entities_ai AFTER INSERT ON entities BEGIN
+	INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+	VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
+END`
+
+const entitiesFTSDeleteTriggerSQL = `CREATE TRIGGER IF NOT EXISTS entities_ad AFTER DELETE ON entities BEGIN
+	INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+	VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
+END`
+
+const entitiesFTSUpdateTriggerSQL = `CREATE TRIGGER IF NOT EXISTS entities_au AFTER UPDATE ON entities BEGIN
+	INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+	VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
+	INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
+	VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
+END`
+
 // allMigrations returns the ordered list of SQL migration statements.
 // Each statement is idempotent (using IF NOT EXISTS) so migrations can be
 // run on every startup without harm.
@@ -254,40 +288,12 @@ func allMigrations(dbType string) []string {
 	if dbType == "sqlite" {
 		migrations = append(migrations,
 			// FTS5 virtual table for full-text search across entities.
-			`CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
-				name,
-				namespace,
-				title,
-				description,
-				tags,
-				kind,
-				owner,
-				annotations,
-				labels,
-				spec,
-				api_version,
-				created_by,
-				content='entities',
-				content_rowid='rowid'
-			)`,
+			entitiesFTSTableSQL,
 
 			// Triggers to keep the FTS index in sync with the entities table.
-			`CREATE TRIGGER IF NOT EXISTS entities_ai AFTER INSERT ON entities BEGIN
-				INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
-				VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
-			END`,
-
-			`CREATE TRIGGER IF NOT EXISTS entities_ad AFTER DELETE ON entities BEGIN
-				INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
-				VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
-			END`,
-
-			`CREATE TRIGGER IF NOT EXISTS entities_au AFTER UPDATE ON entities BEGIN
-				INSERT INTO entities_fts(entities_fts, rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
-				VALUES ('delete', old.rowid, old.name, old.namespace, old.title, old.description, old.tags, old.kind, old.owner, old.annotations, old.labels, old.spec, old.api_version, old.created_by);
-				INSERT INTO entities_fts(rowid, name, namespace, title, description, tags, kind, owner, annotations, labels, spec, api_version, created_by)
-				VALUES (new.rowid, new.name, new.namespace, new.title, new.description, new.tags, new.kind, new.owner, new.annotations, new.labels, new.spec, new.api_version, new.created_by);
-			END`,
+			entitiesFTSInsertTriggerSQL,
+			entitiesFTSDeleteTriggerSQL,
+			entitiesFTSUpdateTriggerSQL,
 		)
 	}
 

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -6,14 +6,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
-	"unicode"
 
 	"github.com/go2engle/gantry/internal/auth"
 	gantrycrypto "github.com/go2engle/gantry/internal/crypto"
 	"github.com/go2engle/gantry/internal/entity"
 	"github.com/go2engle/gantry/internal/plugins"
+	"github.com/go2engle/gantry/internal/search/fts"
 )
 
 // ---------------------------------------------------------------------------
@@ -483,7 +482,7 @@ func (d *DB) SearchEntities(ctx context.Context, query string) ([]*entity.Entity
 	var args []any
 
 	if d.IsSQLite() {
-		ftsQuery := sanitizeEntityFTSQuery(query)
+		ftsQuery := fts.SanitizeQuery(query)
 		if ftsQuery == "" {
 			return nil, nil
 		}
@@ -539,23 +538,6 @@ func (d *DB) SearchEntities(ctx context.Context, query string) ([]*entity.Entity
 		return nil, fmt.Errorf("iterating search results: %w", err)
 	}
 	return entities, nil
-}
-
-func sanitizeEntityFTSQuery(q string) string {
-	var b strings.Builder
-	for _, r := range q {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			b.WriteRune(r)
-		} else {
-			b.WriteByte(' ')
-		}
-	}
-	parts := strings.Fields(b.String())
-	if len(parts) == 0 {
-		return ""
-	}
-	parts[len(parts)-1] += "*"
-	return strings.Join(parts, " ")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -6,7 +6,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/go2engle/gantry/internal/auth"
 	gantrycrypto "github.com/go2engle/gantry/internal/crypto"
@@ -481,6 +483,10 @@ func (d *DB) SearchEntities(ctx context.Context, query string) ([]*entity.Entity
 	var args []any
 
 	if d.IsSQLite() {
+		ftsQuery := sanitizeEntityFTSQuery(query)
+		if ftsQuery == "" {
+			return nil, nil
+		}
 		// Use FTS5 for SQLite. The MATCH query supports prefix matching with *.
 		sqlQuery = `SELECT e.kind, e.api_version, e.name, e.namespace, e.title, e.description, e.owner,
 				e.tags, e.annotations, e.labels, e.spec, e.created_at, e.updated_at, e.created_by
@@ -488,17 +494,31 @@ func (d *DB) SearchEntities(ctx context.Context, query string) ([]*entity.Entity
 			JOIN entities_fts fts ON e.rowid = fts.rowid
 			WHERE entities_fts MATCH ?
 			ORDER BY rank`
-		// Append * for prefix matching so partial words match.
-		args = append(args, query+"*")
+		args = append(args, ftsQuery)
 	} else {
 		// Fallback LIKE search for PostgreSQL (tsvector search can be added later).
 		likePattern := "%" + query + "%"
 		sqlQuery = `SELECT kind, api_version, name, namespace, title, description, owner,
 				tags, annotations, labels, spec, created_at, updated_at, created_by
 			FROM entities
-			WHERE name ILIKE ? OR title ILIKE ? OR description ILIKE ? OR tags ILIKE ? OR kind ILIKE ? OR owner ILIKE ?
+			WHERE name ILIKE ? OR namespace ILIKE ? OR title ILIKE ? OR description ILIKE ?
+				OR tags ILIKE ? OR kind ILIKE ? OR owner ILIKE ? OR annotations ILIKE ?
+				OR labels ILIKE ? OR spec ILIKE ? OR api_version ILIKE ? OR created_by ILIKE ?
 			ORDER BY name`
-		args = append(args, likePattern, likePattern, likePattern, likePattern, likePattern, likePattern)
+		args = append(args,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+			likePattern,
+		)
 	}
 
 	rows, err := d.queryRows(ctx, sqlQuery, args...)
@@ -519,6 +539,23 @@ func (d *DB) SearchEntities(ctx context.Context, query string) ([]*entity.Entity
 		return nil, fmt.Errorf("iterating search results: %w", err)
 	}
 	return entities, nil
+}
+
+func sanitizeEntityFTSQuery(q string) string {
+	var b strings.Builder
+	for _, r := range q {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	parts := strings.Fields(b.String())
+	if len(parts) == 0 {
+		return ""
+	}
+	parts[len(parts)-1] += "*"
+	return strings.Join(parts, " ")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -31,6 +31,89 @@ func newTestDB(t *testing.T) *DB {
 	return database
 }
 
+func TestMigrateUpgradesEntityFTSForFullEntitySearch(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	cfg := config.Default()
+	cfg.DataDir = dataDir
+	cfg.DBDSN = filepath.Join(dataDir, "gantry.db")
+
+	database, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	if _, err := database.Exec(`CREATE TABLE entities (
+		id          TEXT PRIMARY KEY,
+		kind        TEXT NOT NULL,
+		api_version TEXT NOT NULL DEFAULT 'gantry.io/v1',
+		name        TEXT NOT NULL,
+		namespace   TEXT NOT NULL DEFAULT 'default',
+		title       TEXT,
+		description TEXT,
+		owner       TEXT,
+		tags        TEXT,
+		annotations TEXT,
+		labels      TEXT,
+		spec        TEXT,
+		created_at  TIMESTAMP,
+		updated_at  TIMESTAMP,
+		created_by  TEXT,
+		UNIQUE(kind, namespace, name)
+	)`); err != nil {
+		t.Fatalf("create entities table: %v", err)
+	}
+	if _, err := database.Exec(`CREATE VIRTUAL TABLE entities_fts USING fts5(
+		name,
+		title,
+		description,
+		tags,
+		kind,
+		owner,
+		content='entities',
+		content_rowid='rowid'
+	)`); err != nil {
+		t.Fatalf("create old entities_fts: %v", err)
+	}
+	if _, err := database.Exec(`INSERT INTO entities (
+		id, kind, api_version, name, namespace, title, description, owner,
+		tags, annotations, labels, spec, created_at, updated_at, created_by
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), ?)`,
+		newUUID(),
+		"Service",
+		entity.DefaultAPIVersion,
+		"billing",
+		entity.DefaultNamespace,
+		"Billing",
+		"Handles invoices",
+		"platform",
+		`["payments"]`,
+		`{"gantry.io/docs-url":"https://docs.example.com/runbooks/billing"}`,
+		`{"tier":"critical"}`,
+		`{"healthCheck":{"url":"https://status.example.com/billing/healthz"}}`,
+		"admin",
+	); err != nil {
+		t.Fatalf("insert entity: %v", err)
+	}
+
+	if err := database.Migrate(); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	results, err := database.SearchEntities(ctx, "https://status.example.com/billing/healthz")
+	if err != nil {
+		t.Fatalf("SearchEntities() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("SearchEntities() returned %d results, want 1", len(results))
+	}
+}
+
 func TestUpdateEntityByRefRepairsInvalidExistingName(t *testing.T) {
 	ctx := context.Background()
 	database := newTestDB(t)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -114,6 +114,90 @@ func TestMigrateUpgradesEntityFTSForFullEntitySearch(t *testing.T) {
 	}
 }
 
+func TestMigrateRepairsStaleEntityFTSTriggers(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	cfg := config.Default()
+	cfg.DataDir = dataDir
+	cfg.DBDSN = filepath.Join(dataDir, "gantry.db")
+
+	database, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	if _, err := database.Exec(`CREATE TABLE entities (
+		id          TEXT PRIMARY KEY,
+		kind        TEXT NOT NULL,
+		api_version TEXT NOT NULL DEFAULT 'gantry.io/v1',
+		name        TEXT NOT NULL,
+		namespace   TEXT NOT NULL DEFAULT 'default',
+		title       TEXT,
+		description TEXT,
+		owner       TEXT,
+		tags        TEXT,
+		annotations TEXT,
+		labels      TEXT,
+		spec        TEXT,
+		created_at  TIMESTAMP,
+		updated_at  TIMESTAMP,
+		created_by  TEXT,
+		UNIQUE(kind, namespace, name)
+	)`); err != nil {
+		t.Fatalf("create entities table: %v", err)
+	}
+	if _, err := database.Exec(entitiesFTSTableSQL); err != nil {
+		t.Fatalf("create entities_fts: %v", err)
+	}
+	for _, stmt := range []string{
+		`CREATE TRIGGER entities_ai AFTER INSERT ON entities BEGIN SELECT 1; END`,
+		`CREATE TRIGGER entities_ad AFTER DELETE ON entities BEGIN SELECT 1; END`,
+		`CREATE TRIGGER entities_au AFTER UPDATE ON entities BEGIN SELECT 1; END`,
+	} {
+		if _, err := database.Exec(stmt); err != nil {
+			t.Fatalf("create stale trigger: %v", err)
+		}
+	}
+
+	if _, err := database.Exec(`INSERT INTO entities (
+		id, kind, api_version, name, namespace, title, description, owner,
+		tags, annotations, labels, spec, created_at, updated_at, created_by
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), ?)`,
+		newUUID(),
+		"Service",
+		entity.DefaultAPIVersion,
+		"orders",
+		entity.DefaultNamespace,
+		"Orders",
+		"Handles orders",
+		"platform",
+		`["checkout"]`,
+		`{}`,
+		`{}`,
+		`{"healthCheck":{"url":"https://status.example.com/orders/healthz"}}`,
+		"admin",
+	); err != nil {
+		t.Fatalf("insert entity: %v", err)
+	}
+
+	if err := database.Migrate(); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	results, err := database.SearchEntities(ctx, "https://status.example.com/orders/healthz")
+	if err != nil {
+		t.Fatalf("SearchEntities() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("SearchEntities() returned %d results, want 1", len(results))
+	}
+}
+
 func TestUpdateEntityByRefRepairsInvalidExistingName(t *testing.T) {
 	ctx := context.Background()
 	database := newTestDB(t)

--- a/internal/search/fts/fts.go
+++ b/internal/search/fts/fts.go
@@ -1,0 +1,28 @@
+// Package fts contains shared helpers for Gantry FTS5 queries.
+package fts
+
+import (
+	"strings"
+	"unicode"
+)
+
+// SanitizeQuery converts raw user input into a safe FTS5 MATCH expression.
+// Punctuation and symbols become token boundaries so pasted values such as URLs
+// match the unicode61-tokenized index. The final token gets a '*' suffix for
+// search-as-you-type prefix matching.
+func SanitizeQuery(q string) string {
+	var b strings.Builder
+	for _, r := range q {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	parts := strings.Fields(b.String())
+	if len(parts) == 0 {
+		return ""
+	}
+	parts[len(parts)-1] += "*"
+	return strings.Join(parts, " ")
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 // Result represents a single search hit from the FTS5 index.
@@ -30,19 +31,17 @@ func New(db *sql.DB) *Service {
 	return &Service{db: db}
 }
 
-// Search performs a full-text search against the entity catalog.
-// The query string uses FTS5 match syntax (e.g., "service", "api AND auth",
-// "namespace:production"). Results are ordered by relevance rank.
+// Search performs a full-text search against the entity catalog. Raw user input
+// is normalized into an FTS5-safe token query before execution. Results are
+// ordered by relevance rank.
 func (s *Service) Search(ctx context.Context, query string) ([]*Result, error) {
 	if query == "" {
 		return nil, nil
 	}
 
-	// Sanitize: FTS5 treats '-', '+', '"', '*', '(', ')' as operators.
-	// The tokenizer also splits on '-' and '_', so "dxc-portal" is indexed
-	// as tokens "dxc" and "portal". Replace those separators with spaces so
-	// the query mirrors how the text was indexed, then add '*' for prefix
-	// matching on the last token. e.g. "dxc-port" → "dxc port*".
+	// Sanitize: FTS5 treats punctuation such as ':', '-', '/', and '"' as
+	// syntax. Those characters also appear in common entity values like URLs,
+	// so normalize them into token boundaries before adding prefix matching.
 	ftsQuery := sanitizeFTS5(query)
 	if ftsQuery == "" {
 		return nil, nil
@@ -79,18 +78,17 @@ func (s *Service) Search(ctx context.Context, query string) ([]*Result, error) {
 }
 
 // sanitizeFTS5 converts a raw user query into a safe FTS5 MATCH expression.
-// It replaces characters that are both FTS5 operators and common name
-// separators (-, _, +, etc.) with spaces so they align with how the FTS5
-// unicode61 tokenizer indexed the text. The last token gets a '*' suffix for
-// prefix matching, enabling search-as-you-type behaviour.
+// It replaces punctuation and symbols with spaces so raw input aligns with how
+// the FTS5 unicode61 tokenizer indexed text like names, labels, and URLs. The
+// last token gets a '*' suffix for prefix matching, enabling search-as-you-type
+// behaviour.
 func sanitizeFTS5(q string) string {
 	var b strings.Builder
 	for _, r := range q {
-		switch r {
-		case '-', '_', '+', '"', '(', ')', '*', '\\':
-			b.WriteByte(' ')
-		default:
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
 			b.WriteRune(r)
+		} else {
+			b.WriteByte(' ')
 		}
 	}
 	parts := strings.Fields(b.String())

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
-	"unicode"
+
+	"github.com/go2engle/gantry/internal/search/fts"
 )
 
 // Result represents a single search hit from the FTS5 index.
@@ -42,7 +42,7 @@ func (s *Service) Search(ctx context.Context, query string) ([]*Result, error) {
 	// Sanitize: FTS5 treats punctuation such as ':', '-', '/', and '"' as
 	// syntax. Those characters also appear in common entity values like URLs,
 	// so normalize them into token boundaries before adding prefix matching.
-	ftsQuery := sanitizeFTS5(query)
+	ftsQuery := fts.SanitizeQuery(query)
 	if ftsQuery == "" {
 		return nil, nil
 	}
@@ -75,28 +75,6 @@ func (s *Service) Search(ctx context.Context, query string) ([]*Result, error) {
 	}
 
 	return results, nil
-}
-
-// sanitizeFTS5 converts a raw user query into a safe FTS5 MATCH expression.
-// It replaces punctuation and symbols with spaces so raw input aligns with how
-// the FTS5 unicode61 tokenizer indexed text like names, labels, and URLs. The
-// last token gets a '*' suffix for prefix matching, enabling search-as-you-type
-// behaviour.
-func sanitizeFTS5(q string) string {
-	var b strings.Builder
-	for _, r := range q {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			b.WriteRune(r)
-		} else {
-			b.WriteByte(' ')
-		}
-	}
-	parts := strings.Fields(b.String())
-	if len(parts) == 0 {
-		return ""
-	}
-	parts[len(parts)-1] += "*"
-	return strings.Join(parts, " ")
 }
 
 // Reindex rebuilds the FTS5 index from the underlying entities table.

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go2engle/gantry/internal/config"
 	"github.com/go2engle/gantry/internal/db"
 	"github.com/go2engle/gantry/internal/entity"
+	"github.com/go2engle/gantry/internal/search/fts"
 )
 
 func newTestDB(t *testing.T) *db.DB {
@@ -82,9 +83,9 @@ func TestSearchMatchesEntityURLInMetadataAndSpec(t *testing.T) {
 }
 
 func TestSanitizeFTS5NormalizesURLPunctuation(t *testing.T) {
-	got := sanitizeFTS5("https://status.example.com/checkout/healthz?probe=ready")
+	got := fts.SanitizeQuery("https://status.example.com/checkout/healthz?probe=ready")
 	want := "https status example com checkout healthz probe ready*"
 	if got != want {
-		t.Fatalf("sanitizeFTS5() = %q, want %q", got, want)
+		t.Fatalf("SanitizeQuery() = %q, want %q", got, want)
 	}
 }

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,90 @@
+package search
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/go2engle/gantry/internal/config"
+	"github.com/go2engle/gantry/internal/db"
+	"github.com/go2engle/gantry/internal/entity"
+)
+
+func newTestDB(t *testing.T) *db.DB {
+	t.Helper()
+
+	dataDir := t.TempDir()
+	cfg := config.Default()
+	cfg.DataDir = dataDir
+	cfg.DBDSN = filepath.Join(dataDir, "gantry.db")
+
+	database, err := db.New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	if err := database.Migrate(); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	return database
+}
+
+func TestSearchMatchesEntityURLInMetadataAndSpec(t *testing.T) {
+	ctx := context.Background()
+	database := newTestDB(t)
+
+	catalogEntity := &entity.Entity{
+		Kind:       "Service",
+		APIVersion: entity.DefaultAPIVersion,
+		Metadata: entity.EntityMetadata{
+			Name:        "checkout",
+			Namespace:   entity.DefaultNamespace,
+			Title:       "Checkout",
+			Description: "Handles orders",
+			Annotations: map[string]string{
+				"gantry.io/docs-url": "https://docs.example.com/runbooks/checkout",
+			},
+		},
+		Spec: map[string]any{
+			"healthCheck": map[string]any{
+				"url": "https://status.example.com/checkout/healthz?probe=ready",
+			},
+		},
+	}
+	if err := database.CreateEntity(ctx, catalogEntity); err != nil {
+		t.Fatalf("CreateEntity() error = %v", err)
+	}
+
+	service := New(database.DB)
+	results, err := service.Search(ctx, "https://status.example.com/checkout/healthz?probe=ready")
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Search() returned %d results, want 1", len(results))
+	}
+	if got := results[0].Name; got != "checkout" {
+		t.Fatalf("Search() result name = %q, want checkout", got)
+	}
+
+	results, err = service.Search(ctx, "docs.example.com/runbooks/checkout")
+	if err != nil {
+		t.Fatalf("Search() metadata URL error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Search() metadata URL returned %d results, want 1", len(results))
+	}
+}
+
+func TestSanitizeFTS5NormalizesURLPunctuation(t *testing.T) {
+	got := sanitizeFTS5("https://status.example.com/checkout/healthz?probe=ready")
+	want := "https status example com checkout healthz probe ready*"
+	if got != want {
+		t.Fatalf("sanitizeFTS5() = %q, want %q", got, want)
+	}
+}

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -59,6 +59,15 @@ const KIND_META: Record<string, { icon: React.ReactNode; description: string; co
   },
 };
 
+function entitySearchText(entity: Entity) {
+  return JSON.stringify({
+    kind: entity.kind,
+    apiVersion: entity.apiVersion,
+    metadata: entity.metadata,
+    spec: entity.spec,
+  }).toLowerCase();
+}
+
 export default function Catalog() {
   const { kind } = useParams<{ kind?: string }>();
   const navigate = useNavigate();
@@ -158,12 +167,7 @@ export default function Catalog() {
       if (tagFilter && !(e.metadata.tags || []).includes(tagFilter)) return false;
       if (searchQuery) {
         const q = searchQuery.toLowerCase();
-        return (
-          e.metadata.name.toLowerCase().includes(q) ||
-          (e.metadata.title || '').toLowerCase().includes(q) ||
-          (e.metadata.owner || '').toLowerCase().includes(q) ||
-          (e.metadata.tags || []).some((t) => t.toLowerCase().includes(q))
-        );
+        return entitySearchText(e).includes(q);
       }
       return true;
     });

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -160,6 +160,14 @@ export default function Catalog() {
     return Array.from(tags).sort();
   }, [entities]);
 
+  const entitySearchTexts = useMemo(() => {
+    const searchTexts = new WeakMap<Entity, string>();
+    for (const e of entities) {
+      searchTexts.set(e, entitySearchText(e));
+    }
+    return searchTexts;
+  }, [entities]);
+
   const filtered = useMemo(() => {
     return entities.filter((e) => {
       if (!visibleKindNames.has(e.kind)) return false;
@@ -167,11 +175,11 @@ export default function Catalog() {
       if (tagFilter && !(e.metadata.tags || []).includes(tagFilter)) return false;
       if (searchQuery) {
         const q = searchQuery.toLowerCase();
-        return entitySearchText(e).includes(q);
+        return (entitySearchTexts.get(e) ?? entitySearchText(e)).includes(q);
       }
       return true;
     });
-  }, [entities, searchQuery, ownerFilter, tagFilter, visibleKindNames]);
+  }, [entities, entitySearchTexts, searchQuery, ownerFilter, tagFilter, visibleKindNames]);
 
   const hasFilters = searchQuery || ownerFilter || tagFilter;
 

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -59,13 +59,38 @@ const KIND_META: Record<string, { icon: React.ReactNode; description: string; co
   },
 };
 
+function appendSearchValue(value: unknown, parts: string[], seen: WeakSet<object>) {
+  if (value == null) return;
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    parts.push(String(value));
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) appendSearchValue(item, parts, seen);
+    return;
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) return;
+    seen.add(value);
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      parts.push(key);
+      appendSearchValue(nested, parts, seen);
+    }
+  }
+}
+
 function entitySearchText(entity: Entity) {
-  return JSON.stringify({
+  const parts: string[] = [];
+  appendSearchValue({
     kind: entity.kind,
     apiVersion: entity.apiVersion,
     metadata: entity.metadata,
     spec: entity.spec,
-  }).toLowerCase();
+  }, parts, new WeakSet<object>());
+  return parts.join(' ').toLowerCase();
 }
 
 export default function Catalog() {


### PR DESCRIPTION
## Summary

- Expand entity full-text search to index namespace, API version, annotations, labels, spec, and creator fields.
- Normalize punctuation-heavy queries such as URLs so pasted health check or docs links can match indexed entity data.
- Update catalog page filtering to search the full entity payload client-side.
- Add regression coverage for URL matches in metadata/spec and for upgrading existing SQLite FTS schemas.

## Impact

Users can search for URLs or other values embedded inside entity annotations, labels, or spec fields and still find the owning catalog entity.

## Validation

- `go test ./internal/db ./internal/search`
- `env GOCACHE=/tmp/go-build go test ./...`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded entity search to cover namespace, API version, specs, annotations, labels, created-by and other fields.
  * Improved query normalization and FTS-safe sanitization to better handle URLs and punctuation.

* **Bug Fixes**
  * Automatic detection and repair of full-text search schema and triggers during migration to restore reliable search results.

* **Tests**
  * Added tests validating search behavior and migration/repair of FTS setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->