### PR TITLE
fix(ui): improve entity description editing

### DIFF
--- a/web/src/components/SchemaForm.tsx
+++ b/web/src/components/SchemaForm.tsx
@@ -365,7 +365,7 @@ function FormField({ name, schema, value, onChange, required, error }: FieldProp
           onChange={(e) => handleStringChange(e.target.value)}
           rows={4}
           maxLength={schema.maxLength}
-          className={`w-full rounded-lg border bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:outline-none focus:ring-1 ${borderClass}`}
+          className={`min-h-28 w-full resize-y rounded-lg border bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:outline-none focus:ring-1 ${borderClass}`}
         />
         {error && <p className="text-xs text-[var(--gantry-danger)]">This field is required</p>}
       </div>

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -290,7 +290,7 @@ export default function Catalog() {
         },
         _title: { type: 'string', title: 'Title', description: 'Display name' },
         _owner: { type: 'string', title: 'Owner', description: 'Team or user that owns this entity', 'x-entity-ref': 'Team' },
-        _description: { type: 'string', title: 'Description' },
+        _description: { type: 'string', title: 'Description', format: 'textarea' },
         ...(kindSchema as any).properties,
         ...(showHarbor ? {
           _harbor_project: { type: 'string', title: 'Harbor Project', description: 'Harbor registry project name (e.g. my-project)' },

--- a/web/src/pages/EntityDetail.tsx
+++ b/web/src/pages/EntityDetail.tsx
@@ -336,9 +336,6 @@ export default function EntityDetail() {
           {entity.metadata.title && entity.metadata.title !== entity.metadata.name && (
             <p className="mt-1 text-sm text-[var(--gantry-text-secondary)]">{entity.metadata.title}</p>
           )}
-          {entity.metadata.description && (
-            <p className="mt-2 text-sm text-[var(--gantry-text-secondary)]">{entity.metadata.description}</p>
-          )}
           <div className="mt-3 flex flex-wrap items-center gap-3">
             {entity.metadata.owner && (
               <span className="text-sm text-[var(--gantry-text-secondary)]">
@@ -460,6 +457,14 @@ export default function EntityDetail() {
             {/* Spec */}
             <div className="lg:col-span-2">
               <div className="rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-6">
+                {entity.metadata.description && (
+                  <div className="mb-6 border-b border-[var(--gantry-border)] pb-6">
+                    <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Description</h3>
+                    <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[var(--gantry-text-secondary)]">
+                      {entity.metadata.description}
+                    </p>
+                  </div>
+                )}
                 <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Spec</h3>
                 {entity.spec && Object.keys(entity.spec).length > 0 ? (
                   <dl className="mt-4 space-y-3">
@@ -1045,8 +1050,8 @@ export default function EntityDetail() {
                   <div>
                     <label className="block text-sm font-medium text-[var(--gantry-text-primary)] mb-1">Description</label>
                     <textarea
-                      rows={2}
-                      className="w-full rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--gantry-accent)] resize-none"
+                      rows={4}
+                      className="min-h-28 w-full resize-y rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-3 py-2 text-sm text-[var(--gantry-text-primary)] focus:border-[var(--gantry-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--gantry-accent)]"
                       value={editMeta.description}
                       placeholder="A short description of this entity"
                       onChange={(e) => setEditMeta((m) => ({ ...m, description: e.target.value }))}


### PR DESCRIPTION
## What changed

- Moved entity descriptions out of the detail page header and into the Overview content above Spec.
- Made entity creation descriptions render as multiline textareas.
- Made the edit entity description textarea taller and vertically resizable.

## Why

Long descriptions looked like oversized header content and were awkward to enter or edit in single-line/fixed-height controls.

## Validation

- `npx tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Textarea fields for multiline text now support vertical resizing with enforced minimum heights.
  * Description fields are now rendered as expandable textareas for better usability.
  * Entity descriptions are repositioned in the detail view for improved visibility and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->