### PR TITLE
feat(github): render repository wikis in entity tabs

### DIFF
--- a/internal/api/handlers/github.go
+++ b/internal/api/handlers/github.go
@@ -429,6 +429,54 @@ func (h *Handlers) GetGitHubRepo(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// GetGitHubWiki fetches GitHub wiki metadata and optionally a page's markdown.
+// Query params:
+//   - url: repository URL (https://github.com/owner/repo)
+//   - page: optional wiki page slug/title
+//   - content=false: list pages without returning page markdown
+func (h *Handlers) GetGitHubWiki(w http.ResponseWriter, r *http.Request) {
+	repoURL := r.URL.Query().Get("url")
+	if repoURL == "" {
+		writeError(w, http.StatusBadRequest, "url query param is required")
+		return
+	}
+	if !strings.Contains(repoURL, "github.com") {
+		writeError(w, http.StatusBadRequest, "only github.com URLs are supported")
+		return
+	}
+
+	owner, repo, err := ghplugin.ParseGitHubURL(repoURL)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid GitHub URL: "+err.Error())
+		return
+	}
+
+	p, err := h.DB.GetPlugin(r.Context(), "github")
+	if err != nil || p == nil {
+		writeError(w, http.StatusNotFound, "GitHub plugin not installed")
+		return
+	}
+	if !p.Enabled {
+		writeError(w, http.StatusBadRequest, "GitHub plugin is not enabled")
+		return
+	}
+
+	client, err := ghplugin.NewClient(p.Config)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "GitHub client error: "+err.Error())
+		return
+	}
+
+	includeContent := r.URL.Query().Get("content") != "false"
+	wiki, err := client.GetWiki(r.Context(), owner, repo, h.DataDir, r.URL.Query().Get("page"), includeContent)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch wiki: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, wiki)
+}
+
 // requestHostname returns just the hostname from r.Host, stripping any port.
 func requestHostname(r *http.Request) string {
 	host := r.Host

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -210,6 +210,7 @@ func NewServer(cfg *config.Config, database *db.DB, authSvc *auth.Service, event
 			protected.Get("/plugins/kubernetes/pods/{namespace}/{pod}/containers/{container}/logs", h.StreamKubernetesPodLogs)
 			// GitHub-specific plugin endpoints.
 			protected.Get("/plugins/github/repo", h.GetGitHubRepo)
+			protected.Get("/plugins/github/wiki", h.GetGitHubWiki)
 			// Status Monitor plugin endpoints.
 			protected.Get("/plugins/status-monitor/statuses", h.GetStatusMonitorStatuses)
 			protected.Get("/plugins/status-monitor/providers", h.GetStatusMonitorProviders)

--- a/internal/plugins/github/types.go
+++ b/internal/plugins/github/types.go
@@ -71,11 +71,11 @@ type GitHubUser struct {
 
 // Release represents a GitHub release summary.
 type Release struct {
-	TagName    string `json:"tag_name"`
-	Name       string `json:"name"`
-	HTMLURL    string `json:"html_url"`
-	Prerelease bool   `json:"prerelease"`
-	Draft      bool   `json:"draft"`
+	TagName     string `json:"tag_name"`
+	Name        string `json:"name"`
+	HTMLURL     string `json:"html_url"`
+	Prerelease  bool   `json:"prerelease"`
+	Draft       bool   `json:"draft"`
 	PublishedAt string `json:"published_at"`
 }
 
@@ -86,6 +86,31 @@ type RepoInfo struct {
 	PullRequests  []PullRequest `json:"pullRequests"`
 	Readme        string        `json:"readme,omitempty"`
 	LatestRelease *Release      `json:"latestRelease,omitempty"`
+}
+
+// WikiPage represents a single page discovered in a GitHub wiki repository.
+type WikiPage struct {
+	Title string `json:"title"`
+	Slug  string `json:"slug"`
+	Path  string `json:"path"`
+}
+
+// WikiPageContent is the rendered-source payload for a wiki page.
+type WikiPageContent struct {
+	Title      string `json:"title"`
+	Slug       string `json:"slug"`
+	Path       string `json:"path"`
+	Markdown   string `json:"markdown"`
+	HTMLURL    string `json:"htmlUrl"`
+	RawBaseURL string `json:"rawBaseUrl,omitempty"`
+}
+
+// WikiInfo describes a repository wiki and optionally includes page content.
+type WikiInfo struct {
+	Available   bool             `json:"available"`
+	HTMLURL     string           `json:"htmlUrl"`
+	Pages       []WikiPage       `json:"pages"`
+	CurrentPage *WikiPageContent `json:"currentPage,omitempty"`
 }
 
 // GitHubTeam represents a GitHub organization team.

--- a/internal/plugins/github/wiki.go
+++ b/internal/plugins/github/wiki.go
@@ -1,0 +1,320 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+const (
+	wikiFetchTTL         = 5 * time.Minute
+	maxWikiMarkdownBytes = 2 * 1024 * 1024
+)
+
+var wikiCloneMu sync.Mutex
+
+// GetWiki fetches metadata and optionally Markdown content from a repository's
+// GitHub wiki. GitHub stores each wiki as a sibling Git repository, not as a
+// normal REST API resource.
+func (c *Client) GetWiki(ctx context.Context, owner, repo, dataDir, pageSlug string, includeContent bool) (*WikiInfo, error) {
+	htmlURL := fmt.Sprintf("https://github.com/%s/%s/wiki", owner, repo)
+	repoPath, available, err := c.ensureWikiClone(ctx, owner, repo, dataDir)
+	if err != nil {
+		if isMissingWikiError(err) {
+			return &WikiInfo{Available: false, HTMLURL: htmlURL, Pages: []WikiPage{}}, nil
+		}
+		return nil, err
+	}
+	if !available {
+		return &WikiInfo{Available: false, HTMLURL: htmlURL, Pages: []WikiPage{}}, nil
+	}
+
+	pages, err := listWikiPages(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(pages) == 0 {
+		return &WikiInfo{Available: false, HTMLURL: htmlURL, Pages: []WikiPage{}}, nil
+	}
+
+	info := &WikiInfo{
+		Available: true,
+		HTMLURL:   htmlURL,
+		Pages:     pages,
+	}
+	if !includeContent {
+		return info, nil
+	}
+
+	page := selectWikiPage(pages, pageSlug)
+	content, err := readWikiPage(repoPath, owner, repo, page)
+	if err != nil {
+		return nil, err
+	}
+	info.CurrentPage = content
+	return info, nil
+}
+
+func (c *Client) ensureWikiClone(ctx context.Context, owner, repo, dataDir string) (string, bool, error) {
+	wikiCloneMu.Lock()
+	defer wikiCloneMu.Unlock()
+
+	repoPath := filepath.Join(dataDir, "github-wikis", safeWikiPathSegment(owner), safeWikiPathSegment(repo))
+	markerPath := filepath.Join(repoPath, ".gantry-wiki-fetched")
+
+	if _, err := os.Stat(filepath.Join(repoPath, ".git")); err == nil {
+		if freshMarker(markerPath, wikiFetchTTL) {
+			return repoPath, true, nil
+		}
+
+		gitRepo, err := gogit.PlainOpen(repoPath)
+		if err != nil {
+			return "", false, fmt.Errorf("open cached wiki repo: %w", err)
+		}
+		worktree, err := gitRepo.Worktree()
+		if err != nil {
+			return "", false, fmt.Errorf("open cached wiki worktree: %w", err)
+		}
+		err = worktree.PullContext(ctx, &gogit.PullOptions{
+			RemoteName: "origin",
+			Auth:       c.gitAuth(),
+			Force:      true,
+		})
+		if err != nil && !errors.Is(err, gogit.NoErrAlreadyUpToDate) {
+			return "", false, fmt.Errorf("pull wiki repo: %w", err)
+		}
+		touchWikiMarker(markerPath)
+		return repoPath, true, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(repoPath), 0o755); err != nil {
+		return "", false, fmt.Errorf("create wiki cache dir: %w", err)
+	}
+
+	cloneURL := fmt.Sprintf("https://github.com/%s/%s.wiki.git", owner, repo)
+	_, err := gogit.PlainCloneContext(ctx, repoPath, false, &gogit.CloneOptions{
+		URL:  cloneURL,
+		Auth: c.gitAuth(),
+	})
+	if err != nil {
+		_ = os.RemoveAll(repoPath)
+		if errors.Is(err, transport.ErrEmptyRemoteRepository) || isMissingWikiError(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("clone wiki repo: %w", err)
+	}
+
+	touchWikiMarker(markerPath)
+	return repoPath, true, nil
+}
+
+func (c *Client) gitAuth() *githttp.BasicAuth {
+	if c.token == "" {
+		return nil
+	}
+	return &githttp.BasicAuth{
+		Username: "gantry",
+		Password: c.token,
+	}
+}
+
+func listWikiPages(repoPath string) ([]WikiPage, error) {
+	var pages []WikiPage
+	err := filepath.WalkDir(repoPath, func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isWikiMarkdownPath(filePath) {
+			return nil
+		}
+
+		rel, err := filepath.Rel(repoPath, filePath)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		slug := strings.TrimSuffix(rel, path.Ext(rel))
+		pages = append(pages, WikiPage{
+			Title: wikiTitleFromSlug(slug),
+			Slug:  slug,
+			Path:  rel,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list wiki pages: %w", err)
+	}
+
+	sort.Slice(pages, func(i, j int) bool {
+		if strings.EqualFold(pages[i].Slug, "Home") {
+			return true
+		}
+		if strings.EqualFold(pages[j].Slug, "Home") {
+			return false
+		}
+		return strings.ToLower(pages[i].Title) < strings.ToLower(pages[j].Title)
+	})
+	return pages, nil
+}
+
+func selectWikiPage(pages []WikiPage, requested string) WikiPage {
+	normalized := normalizeWikiSlug(requested)
+	if normalized != "" {
+		for _, page := range pages {
+			if strings.EqualFold(page.Slug, normalized) || strings.EqualFold(page.Title, normalized) {
+				return page
+			}
+		}
+	}
+	for _, page := range pages {
+		if strings.EqualFold(page.Slug, "Home") {
+			return page
+		}
+	}
+	return pages[0]
+}
+
+func readWikiPage(repoPath, owner, repo string, page WikiPage) (*WikiPageContent, error) {
+	filePath := filepath.Join(repoPath, filepath.FromSlash(page.Path))
+	cleanRepoPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	cleanFilePath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if cleanFilePath != cleanRepoPath && !strings.HasPrefix(cleanFilePath, cleanRepoPath+string(filepath.Separator)) {
+		return nil, fmt.Errorf("invalid wiki page path")
+	}
+
+	info, err := os.Stat(cleanFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("stat wiki page: %w", err)
+	}
+	if info.Size() > maxWikiMarkdownBytes {
+		return nil, fmt.Errorf("wiki page is too large to render")
+	}
+
+	body, err := os.ReadFile(cleanFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("read wiki page: %w", err)
+	}
+
+	pageDir := path.Dir(page.Path)
+	rawBaseURL := fmt.Sprintf("https://raw.githubusercontent.com/wiki/%s/%s/", owner, repo)
+	if pageDir != "." {
+		rawBaseURL += strings.TrimSuffix(pageDir, "/") + "/"
+	}
+
+	return &WikiPageContent{
+		Title:      page.Title,
+		Slug:       page.Slug,
+		Path:       page.Path,
+		Markdown:   string(body),
+		HTMLURL:    wikiPageHTMLURL(owner, repo, page.Slug),
+		RawBaseURL: rawBaseURL,
+	}, nil
+}
+
+func wikiPageHTMLURL(owner, repo, slug string) string {
+	parts := strings.Split(slug, "/")
+	for i, part := range parts {
+		parts[i] = pathEscape(part)
+	}
+	return fmt.Sprintf("https://github.com/%s/%s/wiki/%s", owner, repo, strings.Join(parts, "/"))
+}
+
+func pathEscape(segment string) string {
+	return url.PathEscape(segment)
+}
+
+func isWikiMarkdownPath(filePath string) bool {
+	switch strings.ToLower(path.Ext(filepath.ToSlash(filePath))) {
+	case ".md", ".markdown":
+		return true
+	default:
+		return false
+	}
+}
+
+func wikiTitleFromSlug(slug string) string {
+	base := path.Base(slug)
+	base = strings.ReplaceAll(base, "-", " ")
+	base = strings.ReplaceAll(base, "_", " ")
+	return strings.TrimSpace(base)
+}
+
+func normalizeWikiSlug(slug string) string {
+	slug = strings.TrimSpace(slug)
+	slug = strings.TrimSuffix(slug, ".md")
+	slug = strings.TrimSuffix(slug, ".markdown")
+	slug = strings.Trim(slug, "/")
+	if slug == "" {
+		return ""
+	}
+	cleaned := path.Clean(strings.ReplaceAll(slug, "\\", "/"))
+	if cleaned == "." || strings.HasPrefix(cleaned, "../") || cleaned == ".." {
+		return ""
+	}
+	return cleaned
+}
+
+func safeWikiPathSegment(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "_"
+	}
+	return b.String()
+}
+
+func freshMarker(path string, ttl time.Duration) bool {
+	info, err := os.Stat(path)
+	return err == nil && time.Since(info.ModTime()) < ttl
+}
+
+func touchWikiMarker(path string) {
+	now := time.Now()
+	if _, err := os.Stat(path); err == nil {
+		_ = os.Chtimes(path, now, now)
+		return
+	}
+	_ = os.WriteFile(path, []byte(now.Format(time.RFC3339)), 0o644)
+}
+
+func isMissingWikiError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "repository not found") ||
+		strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "authentication required") ||
+		strings.Contains(msg, "authorization failed")
+}

--- a/internal/plugins/github/wiki.go
+++ b/internal/plugins/github/wiki.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"net/url"
 	"os"
 	"path"
@@ -24,7 +25,7 @@ const (
 	maxWikiMarkdownBytes = 2 * 1024 * 1024
 )
 
-var wikiCloneMu sync.Mutex
+var repoWikiLocks sync.Map
 
 // GetWiki fetches metadata and optionally Markdown content from a repository's
 // GitHub wiki. GitHub stores each wiki as a sibling Git repository, not as a
@@ -69,8 +70,9 @@ func (c *Client) GetWiki(ctx context.Context, owner, repo, dataDir, pageSlug str
 }
 
 func (c *Client) ensureWikiClone(ctx context.Context, owner, repo, dataDir string) (string, bool, error) {
-	wikiCloneMu.Lock()
-	defer wikiCloneMu.Unlock()
+	repoLock := getRepoWikiLock(owner + "/" + repo)
+	repoLock.Lock()
+	defer repoLock.Unlock()
 
 	repoPath := filepath.Join(dataDir, "github-wikis", safeWikiPathSegment(owner), safeWikiPathSegment(repo))
 	markerPath := filepath.Join(repoPath, ".gantry-wiki-fetched")
@@ -129,6 +131,11 @@ func (c *Client) gitAuth() *githttp.BasicAuth {
 		Username: "gantry",
 		Password: c.token,
 	}
+}
+
+func getRepoWikiLock(repoKey string) *sync.Mutex {
+	lock, _ := repoWikiLocks.LoadOrStore(strings.ToLower(repoKey), &sync.Mutex{})
+	return lock.(*sync.Mutex)
 }
 
 func listWikiPages(repoPath string) ([]WikiPage, error) {
@@ -313,8 +320,41 @@ func isMissingWikiError(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
+	isAuthError := strings.Contains(msg, "authentication required") ||
+		strings.Contains(msg, "authorization failed")
+	if isAuthError {
+		log.Printf("github wiki: treating authentication error as unavailable: %s", redactWikiError(err.Error()))
+	}
 	return strings.Contains(msg, "repository not found") ||
 		strings.Contains(msg, "not found") ||
-		strings.Contains(msg, "authentication required") ||
-		strings.Contains(msg, "authorization failed")
+		isAuthError
+}
+
+func redactWikiError(message string) string {
+	message = redactURLCredentials(message)
+	message = redactBearerToken(message)
+	return message
+}
+
+func redactURLCredentials(message string) string {
+	parts := strings.Fields(message)
+	for i, part := range parts {
+		u, err := url.Parse(strings.Trim(part, `"'`))
+		if err != nil || u.User == nil {
+			continue
+		}
+		u.User = url.User("redacted")
+		parts[i] = strings.Replace(part, strings.Trim(part, `"'`), u.String(), 1)
+	}
+	return strings.Join(parts, " ")
+}
+
+func redactBearerToken(message string) string {
+	fields := strings.Fields(message)
+	for i := 0; i < len(fields)-1; i++ {
+		if strings.EqualFold(strings.TrimSuffix(fields[i], ":"), "bearer") {
+			fields[i+1] = "redacted"
+		}
+	}
+	return strings.Join(fields, " ")
 }

--- a/internal/plugins/github/wiki_test.go
+++ b/internal/plugins/github/wiki_test.go
@@ -1,0 +1,54 @@
+package github
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListWikiPagesSortsHomeFirst(t *testing.T) {
+	dir := t.TempDir()
+	writeTestWikiFile(t, dir, "Install-Guide.md", "# Install")
+	writeTestWikiFile(t, dir, "Home.md", "# Home")
+	writeTestWikiFile(t, dir, "nested/Runbook.markdown", "# Runbook")
+	writeTestWikiFile(t, dir, "notes.txt", "ignored")
+
+	pages, err := listWikiPages(dir)
+	if err != nil {
+		t.Fatalf("listWikiPages returned error: %v", err)
+	}
+	if len(pages) != 3 {
+		t.Fatalf("expected 3 markdown pages, got %d", len(pages))
+	}
+	if pages[0].Slug != "Home" {
+		t.Fatalf("expected Home first, got %q", pages[0].Slug)
+	}
+	if pages[1].Title != "Install Guide" {
+		t.Fatalf("expected normalized title, got %q", pages[1].Title)
+	}
+}
+
+func TestSelectWikiPageFallsBackToHome(t *testing.T) {
+	pages := []WikiPage{
+		{Title: "Install Guide", Slug: "Install-Guide", Path: "Install-Guide.md"},
+		{Title: "Home", Slug: "Home", Path: "Home.md"},
+	}
+
+	if page := selectWikiPage(pages, "Install Guide"); page.Slug != "Install-Guide" {
+		t.Fatalf("expected requested page, got %q", page.Slug)
+	}
+	if page := selectWikiPage(pages, "../Home"); page.Slug != "Home" {
+		t.Fatalf("expected unsafe slug to fall back to Home, got %q", page.Slug)
+	}
+}
+
+func writeTestWikiFile(t *testing.T, root, name, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir test wiki file: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write test wiki file: %v", err)
+	}
+}

--- a/web/src/components/GitHubTab.tsx
+++ b/web/src/components/GitHubTab.tsx
@@ -3,8 +3,8 @@ import {
   Star, GitFork, CircleDot, GitBranch, GitPullRequest,
   GitCommit, ExternalLink, Archive, Lock, Globe, RefreshCw, BookOpen, ChevronDown, ChevronUp, Tag,
 } from 'lucide-react';
-import { marked } from 'marked';
 import { api } from '../lib/api';
+import { renderMarkdown } from '../lib/markdown';
 import type { Entity, GitHubRepoInfo, GitHubPullRequest } from '../lib/types';
 
 function formatRelativeTime(dateStr: string): string {
@@ -70,16 +70,12 @@ export default function GitHubTab({ entity }: { entity: Entity }) {
 
   const readmeHtml = useMemo(() => {
     if (!data?.readme) return '';
-    let html = marked.parse(data.readme) as string;
-    // Rewrite relative image src URLs to GitHub raw content so logos/badges load.
     if (data.repo) {
       const branch = data.repo.default_branch;
       const rawBase = `https://raw.githubusercontent.com/${data.repo.full_name}/${branch}/`;
-      html = html.replace(/src="(?!https?:\/\/)([^"]+)"/g, (_, path) =>
-        `src="${rawBase}${path.replace(/^\.\//, '')}"`,
-      );
+      return renderMarkdown(data.readme, rawBase);
     }
-    return html;
+    return renderMarkdown(data.readme);
   }, [data?.readme, data?.repo?.full_name, data?.repo?.default_branch]);
 
   if (!repoUrl) {
@@ -344,7 +340,7 @@ export default function GitHubTab({ entity }: { entity: Entity }) {
           {readmeExpanded && (
             <div
               className="px-6 py-5 gantry-markdown"
-              // README content is fetched from GitHub's API for the user's own repo.
+              // README content is fetched from GitHub and sanitized before render.
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{ __html: readmeHtml }}
             />

--- a/web/src/components/GitHubWikiTab.tsx
+++ b/web/src/components/GitHubWikiTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type MouseEvent } from 'react';
 import { BookOpen, ExternalLink, RefreshCw } from 'lucide-react';
 import { api } from '../lib/api';
 import { renderMarkdown } from '../lib/markdown';
@@ -10,6 +10,44 @@ function repoURLFromEntity(entity: Entity): string {
   const owner = entity.metadata.annotations?.['github.com/owner'];
   const repo = entity.metadata.annotations?.['github.com/repo'];
   return owner && repo ? `https://github.com/${owner}/${repo}` : '';
+}
+
+function wikiSlugFromHref(href: string, currentSlug: string): string {
+  const trimmed = href.trim();
+  if (!trimmed || trimmed.startsWith('#')) return '';
+  if (/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      const wikiIndex = url.pathname.indexOf('/wiki/');
+      if (!url.hostname.endsWith('github.com') || wikiIndex === -1) return '';
+      return normalizeWikiSlug(decodeURIComponent(url.pathname.slice(wikiIndex + 6)));
+    } catch {
+      return '';
+    }
+  }
+
+  const [pathPart] = trimmed.split(/[?#]/, 1);
+  if (!pathPart || pathPart.startsWith('/')) return '';
+  const currentDir = currentSlug.includes('/') ? currentSlug.slice(0, currentSlug.lastIndexOf('/')) : '';
+  const combined = pathPart.startsWith('./') || pathPart.startsWith('../')
+    ? `${currentDir}/${pathPart}`
+    : pathPart;
+  return normalizeWikiSlug(combined);
+}
+
+function normalizeWikiSlug(slug: string): string {
+  let normalized = slug.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+  normalized = normalized.replace(/\.(?:md|markdown)$/i, '');
+  const parts: string[] = [];
+  for (const part of normalized.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.join('/');
 }
 
 export default function GitHubWikiTab({ entity }: { entity: Entity }) {
@@ -49,6 +87,21 @@ export default function GitHubWikiTab({ entity }: { entity: Entity }) {
     if (!data?.currentPage?.markdown) return '';
     return renderMarkdown(data.currentPage.markdown, data.currentPage.rawBaseUrl);
   }, [data?.currentPage?.markdown, data?.currentPage?.rawBaseUrl]);
+
+  const pageSlugs = useMemo(() => new Set(data?.pages.map((page) => page.slug.toLowerCase()) ?? []), [data?.pages]);
+
+  const handleWikiContentClick = useCallback((event: MouseEvent<HTMLDivElement>) => {
+    if (!(event.target instanceof Element)) return;
+    const link = event.target.closest('a');
+    if (!link) return;
+
+    const href = link.getAttribute('href') ?? '';
+    const slug = wikiSlugFromHref(href, data?.currentPage?.slug ?? '');
+    if (!slug || !pageSlugs.has(slug.toLowerCase())) return;
+
+    event.preventDefault();
+    load(slug);
+  }, [data?.currentPage?.slug, load, pageSlugs]);
 
   if (loading) {
     return (
@@ -120,6 +173,7 @@ export default function GitHubWikiTab({ entity }: { entity: Entity }) {
         </div>
         <div
           className="px-6 py-5 gantry-markdown"
+          onClick={handleWikiContentClick}
           // Wiki markdown is fetched from GitHub and sanitized before render.
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: pageHtml }}

--- a/web/src/components/GitHubWikiTab.tsx
+++ b/web/src/components/GitHubWikiTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BookOpen, ExternalLink, RefreshCw } from 'lucide-react';
 import { api } from '../lib/api';
 import { renderMarkdown } from '../lib/markdown';
@@ -6,7 +6,7 @@ import type { Entity, GitHubWikiInfo } from '../lib/types';
 
 function repoURLFromEntity(entity: Entity): string {
   const repoUrl = entity.spec?.repoUrl as string | undefined;
-  if (repoUrl) return repoUrl;
+  if (repoUrl?.includes('github.com')) return repoUrl;
   const owner = entity.metadata.annotations?.['github.com/owner'];
   const repo = entity.metadata.annotations?.['github.com/repo'];
   return owner && repo ? `https://github.com/${owner}/${repo}` : '';
@@ -20,8 +20,11 @@ export default function GitHubWikiTab({ entity }: { entity: Entity }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
-  function load(page = selectedPage) {
-    if (!repoUrl) return;
+  const load = useCallback((page: string) => {
+    if (!repoUrl) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError('');
     api
@@ -34,16 +37,13 @@ export default function GitHubWikiTab({ entity }: { entity: Entity }) {
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }
+  }, [repoUrl]);
 
   useEffect(() => {
-    setSelectedPage(defaultPage ?? '');
-  }, [defaultPage, repoUrl]);
-
-  useEffect(() => {
-    load(defaultPage ?? '');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [repoUrl, defaultPage]);
+    const initialPage = defaultPage ?? '';
+    setSelectedPage(initialPage);
+    load(initialPage);
+  }, [repoUrl, defaultPage, load]);
 
   const pageHtml = useMemo(() => {
     if (!data?.currentPage?.markdown) return '';
@@ -62,7 +62,7 @@ export default function GitHubWikiTab({ entity }: { entity: Entity }) {
     return (
       <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
         {error}
-        <button onClick={() => load()} className="ml-3 underline">Retry</button>
+        <button onClick={() => load(selectedPage)} className="ml-3 underline">Retry</button>
       </div>
     );
   }
@@ -80,7 +80,7 @@ export default function GitHubWikiTab({ entity }: { entity: Entity }) {
             <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Wiki</h3>
           </div>
           <button
-            onClick={() => load()}
+            onClick={() => load(selectedPage)}
             title="Refresh"
             className="rounded p-1 text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]"
           >

--- a/web/src/components/GitHubWikiTab.tsx
+++ b/web/src/components/GitHubWikiTab.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useState } from 'react';
+import { BookOpen, ExternalLink, RefreshCw } from 'lucide-react';
+import { api } from '../lib/api';
+import { renderMarkdown } from '../lib/markdown';
+import type { Entity, GitHubWikiInfo } from '../lib/types';
+
+function repoURLFromEntity(entity: Entity): string {
+  const repoUrl = entity.spec?.repoUrl as string | undefined;
+  if (repoUrl) return repoUrl;
+  const owner = entity.metadata.annotations?.['github.com/owner'];
+  const repo = entity.metadata.annotations?.['github.com/repo'];
+  return owner && repo ? `https://github.com/${owner}/${repo}` : '';
+}
+
+export default function GitHubWikiTab({ entity }: { entity: Entity }) {
+  const repoUrl = repoURLFromEntity(entity);
+  const defaultPage = entity.metadata.annotations?.['github.com/wiki-page'];
+  const [data, setData] = useState<GitHubWikiInfo | null>(null);
+  const [selectedPage, setSelectedPage] = useState(defaultPage ?? '');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  function load(page = selectedPage) {
+    if (!repoUrl) return;
+    setLoading(true);
+    setError('');
+    api
+      .getGitHubWiki(repoUrl, page || undefined)
+      .then((wiki) => {
+        setData(wiki);
+        if (wiki.currentPage) {
+          setSelectedPage(wiki.currentPage.slug);
+        }
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    setSelectedPage(defaultPage ?? '');
+  }, [defaultPage, repoUrl]);
+
+  useEffect(() => {
+    load(defaultPage ?? '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repoUrl, defaultPage]);
+
+  const pageHtml = useMemo(() => {
+    if (!data?.currentPage?.markdown) return '';
+    return renderMarkdown(data.currentPage.markdown, data.currentPage.rawBaseUrl);
+  }, [data?.currentPage?.markdown, data?.currentPage?.rawBaseUrl]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="h-7 w-7 animate-spin rounded-full border-2 border-[var(--gantry-accent)] border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        {error}
+        <button onClick={() => load()} className="ml-3 underline">Retry</button>
+      </div>
+    );
+  }
+
+  if (!data?.available || !data.currentPage) {
+    return null;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[16rem_minmax(0,1fr)]">
+      <div className="rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]">
+        <div className="flex items-center justify-between border-b border-[var(--gantry-border)] px-4 py-3">
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-4 w-4 text-[var(--gantry-text-secondary)]" />
+            <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Wiki</h3>
+          </div>
+          <button
+            onClick={() => load()}
+            title="Refresh"
+            className="rounded p-1 text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </button>
+        </div>
+        <nav className="max-h-[70vh] overflow-y-auto p-2">
+          {data.pages.map((page) => (
+            <button
+              key={page.slug}
+              onClick={() => load(page.slug)}
+              className={`block w-full rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                page.slug === data.currentPage?.slug
+                  ? 'bg-[var(--gantry-accent)]/10 text-[var(--gantry-accent)]'
+                  : 'text-[var(--gantry-text-secondary)] hover:bg-[var(--gantry-bg-secondary)] hover:text-[var(--gantry-text-primary)]'
+              }`}
+            >
+              <span className="line-clamp-2">{page.title}</span>
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      <div className="min-w-0 rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]">
+        <div className="flex items-center justify-between gap-3 border-b border-[var(--gantry-border)] px-5 py-3">
+          <h3 className="min-w-0 truncate text-sm font-semibold text-[var(--gantry-text-primary)]">
+            {data.currentPage.title}
+          </h3>
+          <a
+            href={data.currentPage.htmlUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--gantry-border)] px-3 py-1.5 text-sm text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-text-primary)]"
+          >
+            <ExternalLink className="h-4 w-4" /> Open
+          </a>
+        </div>
+        <div
+          className="px-6 py-5 gantry-markdown"
+          // Wiki markdown is fetched from GitHub and sanitized before render.
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: pageHtml }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse, NexusComponent, NexusAsset, NexusRepository, TopologyData, TopologyStatusMap, FlowPluginSettings, FlowSpec } from './types';
+import type { Entity, User, SearchResult, ActionRun, AuditEntry, APIKey, GraphData, PluginRegistryEntry, PluginDetail, PluginConfig, PluginSyncResult, K8sWorkloadInfo, GitHubRepoInfo, GitHubWikiInfo, ArgoCDAppStatus, ArgoCDAppWithInstance, GitHubWorkflow, ActionInputDef, DashboardConfig, HistoryEntry, StatusMonitorResult, GitOpsStatus, GitOpsSyncEntry, GitOpsFileEntry, Group, GroupDetail, PermissionRule, EffectivePermissions, RBACConfig, Role, VersionResponse, HarborRepository, HarborArtifact, HarborVulnerability, HarborSummaryResponse, NexusComponent, NexusAsset, NexusRepository, TopologyData, TopologyStatusMap, FlowPluginSettings, FlowSpec } from './types';
 import { encodePathSegment } from './utils';
 
 export const AUTH_UNAUTHORIZED_EVENT = 'auth:unauthorized';
@@ -171,6 +171,13 @@ export const api = {
 
   getGitHubRepo: (url: string) =>
     request<GitHubRepoInfo>('GET', `/plugins/github/repo?url=${encodeURIComponent(url)}`),
+
+  getGitHubWiki: (url: string, page?: string, includeContent = true) => {
+    const params = new URLSearchParams({ url });
+    if (page) params.set('page', page);
+    if (!includeContent) params.set('content', 'false');
+    return request<GitHubWikiInfo>('GET', `/plugins/github/wiki?${params.toString()}`);
+  },
 
   getArgoCDEntityApps: (appNames: string[]) =>
     request<ArgoCDAppWithInstance[]>('GET', `/plugins/argocd/entity-apps?appNames=${encodeURIComponent(appNames.join(','))}`),

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -24,7 +24,7 @@ function rewriteRelativeImageSources(html: string, rawImageBaseUrl?: string): st
 
 function sanitizeHtml(html: string): string {
   if (typeof DOMParser === 'undefined') {
-    return html;
+    return '';
   }
   const doc = new DOMParser().parseFromString(html, 'text/html');
   doc.body.querySelectorAll('*').forEach((el) => {
@@ -59,5 +59,15 @@ function isAbsoluteOrSpecialURL(value: string): boolean {
 
 function isUnsafeURL(value: string): boolean {
   const compact = value.replace(/[\u0000-\u001F\u007F\s]+/g, '').toLowerCase();
-  return compact.startsWith('javascript:') || compact.startsWith('data:text/html');
+  if (compact.startsWith('javascript:')) {
+    return true;
+  }
+  if (!compact.startsWith('data:')) {
+    return false;
+  }
+  const mediaType = compact.slice(5).split(/[;,]/, 1)[0];
+  return mediaType === 'text/html' ||
+    mediaType === 'text/xml' ||
+    mediaType === 'image/svg+xml' ||
+    mediaType.endsWith('+xml');
 }

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -1,0 +1,63 @@
+import { marked } from 'marked';
+
+const BLOCKED_TAGS = new Set(['script', 'iframe', 'object', 'embed', 'link', 'meta', 'style']);
+const URL_ATTRS = new Set(['href', 'src', 'xlink:href']);
+
+export function renderMarkdown(markdown: string, rawImageBaseUrl?: string): string {
+  const html = marked.parse(markdown) as string;
+  return sanitizeHtml(rewriteRelativeImageSources(html, rawImageBaseUrl));
+}
+
+function rewriteRelativeImageSources(html: string, rawImageBaseUrl?: string): string {
+  if (!rawImageBaseUrl || typeof DOMParser === 'undefined') {
+    return html;
+  }
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  doc.querySelectorAll('img[src]').forEach((img) => {
+    const src = img.getAttribute('src') ?? '';
+    if (!src || isAbsoluteOrSpecialURL(src)) return;
+    const normalized = src.replace(/^\.\//, '');
+    img.setAttribute('src', rawImageBaseUrl + normalized.split('/').map(encodeURIComponent).join('/'));
+  });
+  return doc.body.innerHTML;
+}
+
+function sanitizeHtml(html: string): string {
+  if (typeof DOMParser === 'undefined') {
+    return html;
+  }
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  doc.body.querySelectorAll('*').forEach((el) => {
+    if (BLOCKED_TAGS.has(el.tagName.toLowerCase())) {
+      el.remove();
+      return;
+    }
+
+    Array.from(el.attributes).forEach((attr) => {
+      const name = attr.name.toLowerCase();
+      const value = attr.value.trim();
+      if (name.startsWith('on') || name === 'srcdoc' || name === 'style') {
+        el.removeAttribute(attr.name);
+        return;
+      }
+      if (URL_ATTRS.has(name) && isUnsafeURL(value)) {
+        el.removeAttribute(attr.name);
+      }
+    });
+
+    if (el.tagName.toLowerCase() === 'a') {
+      el.setAttribute('target', '_blank');
+      el.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+  return doc.body.innerHTML;
+}
+
+function isAbsoluteOrSpecialURL(value: string): boolean {
+  return /^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(value);
+}
+
+function isUnsafeURL(value: string): boolean {
+  const compact = value.replace(/[\u0000-\u001F\u007F\s]+/g, '').toLowerCase();
+  return compact.startsWith('javascript:') || compact.startsWith('data:text/html');
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -403,6 +403,25 @@ export interface GitHubRepoInfo {
   latestRelease?: GitHubRelease;
 }
 
+export interface GitHubWikiPage {
+  title: string;
+  slug: string;
+  path: string;
+}
+
+export interface GitHubWikiPageContent extends GitHubWikiPage {
+  markdown: string;
+  htmlUrl: string;
+  rawBaseUrl?: string;
+}
+
+export interface GitHubWikiInfo {
+  available: boolean;
+  htmlUrl: string;
+  pages: GitHubWikiPage[];
+  currentPage?: GitHubWikiPageContent;
+}
+
 export interface EntityLink {
   title: string;
   url: string;

--- a/web/src/pages/EntityDetail.tsx
+++ b/web/src/pages/EntityDetail.tsx
@@ -9,6 +9,7 @@ import SchemaForm from '../components/SchemaForm';
 import EntityGraph from '../components/EntityGraph';
 import KubernetesTab from '../components/KubernetesTab';
 import GitHubTab from '../components/GitHubTab';
+import GitHubWikiTab from '../components/GitHubWikiTab';
 import ArgoCDTab from '../components/ArgoCDTab';
 import APIDocsTab from '../components/APIDocsTab';
 import HarborTab from '../components/HarborTab';
@@ -99,12 +100,13 @@ const LINK_ICONS: Record<string, React.ReactNode> = {
   other:     <CircleHelp className="h-3.5 w-3.5" />,
 };
 
-type Tab = 'overview' | 'yaml' | 'relationships' | 'activity' | 'kubernetes' | 'github' | 'argocd' | 'apidocs' | 'harbor' | 'nexus' | 'apis' | 'flow';
+type Tab = 'overview' | 'yaml' | 'relationships' | 'activity' | 'kubernetes' | 'github' | 'wiki' | 'argocd' | 'apidocs' | 'harbor' | 'nexus' | 'apis' | 'flow';
 
 const TAB_LABELS: Partial<Record<Tab, string>> = {
   relationships: 'Dependencies',
   kubernetes: 'Kubernetes',
   github: 'GitHub',
+  wiki: 'Wiki',
   argocd: 'ArgoCD',
   apidocs: 'API Docs',
   harbor: 'Harbor',
@@ -112,6 +114,15 @@ const TAB_LABELS: Partial<Record<Tab, string>> = {
   apis: 'APIs',
   flow: 'Flow',
 };
+
+function githubRepoURLFromEntity(entity: Entity | null): string {
+  if (!entity) return '';
+  const repoUrl = entity.spec?.repoUrl as string | undefined;
+  if (repoUrl?.includes('github.com')) return repoUrl;
+  const owner = entity.metadata.annotations?.['github.com/owner'];
+  const repo = entity.metadata.annotations?.['github.com/repo'];
+  return owner && repo ? `https://github.com/${owner}/${repo}` : '';
+}
 
 export default function EntityDetail() {
   const { kind, name } = useParams<{ kind: string; name: string }>();
@@ -136,6 +147,7 @@ export default function EntityDetail() {
   const [healthLoading, setHealthLoading] = useState(false);
   const [apiEntities, setApiEntities] = useState<Entity[]>([]);
   const [apisLoading, setApisLoading] = useState(false);
+  const [githubWikiAvailable, setGitHubWikiAvailable] = useState(false);
 
   useEffect(() => {
     if (!kind || !name) return;
@@ -162,6 +174,31 @@ export default function EntityDetail() {
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
   }, [kind, name, namespace]);
+
+  const githubRepoUrl = githubRepoURLFromEntity(entity);
+
+  useEffect(() => {
+    if (!githubRepoUrl || !enabledPlugins.has('github')) {
+      setGitHubWikiAvailable(false);
+      return;
+    }
+
+    let cancelled = false;
+    setGitHubWikiAvailable(false);
+    api.getGitHubWiki(githubRepoUrl, undefined, false)
+      .then((wiki) => {
+        if (!cancelled) {
+          setGitHubWikiAvailable(wiki.available && wiki.pages.length > 0);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setGitHubWikiAvailable(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [githubRepoUrl, enabledPlugins]);
 
   const healthCheckUrl = (entity?.spec?.healthCheckUrl as string) || '';
 
@@ -402,10 +439,7 @@ export default function EntityDetail() {
       {/* Tabs */}
       {(() => {
         const isK8sEntity = !!(entity.metadata.annotations?.['kubernetes.io/kind']);
-        const hasGitHub = !!(
-          (entity.spec?.repoUrl as string | undefined)?.includes('github.com') ||
-          entity.metadata.annotations?.['github.com/repo']
-        );
+        const hasGitHub = !!githubRepoUrl;
         const hasArgoCD = !!(
           entity.metadata.annotations?.['argocd.io/appNames'] ||
           entity.metadata.annotations?.['argocd.io/appName']
@@ -421,6 +455,10 @@ export default function EntityDetail() {
         if (hasFlow) tabs.splice(1, 0, 'flow');
         if (isK8sEntity && (entity.kind === 'Service' || entity.kind === 'Infrastructure') && enabledPlugins.has('kubernetes')) tabs.splice(1, 0, 'kubernetes');
         if (hasGitHub && enabledPlugins.has('github')) tabs.splice(1, 0, 'github');
+        if (hasGitHub && githubWikiAvailable && enabledPlugins.has('github')) {
+          const githubIndex = tabs.indexOf('github');
+          tabs.splice(githubIndex >= 0 ? githubIndex + 1 : 1, 0, 'wiki');
+        }
         if (hasArgoCD && entity.kind === 'Service' && enabledPlugins.has('argocd')) tabs.splice(1, 0, 'argocd');
         if (hasAPIDocs) tabs.splice(1, 0, 'apidocs');
         if (hasHarbor && (entity.kind === 'Service' || entity.kind === 'Infrastructure') && enabledPlugins.has('harbor')) tabs.splice(1, 0, 'harbor');
@@ -866,6 +904,10 @@ export default function EntityDetail() {
 
         {tab === 'github' && (
           <GitHubTab entity={entity} />
+        )}
+
+        {tab === 'wiki' && (
+          <GitHubWikiTab entity={entity} />
         )}
 
         {tab === 'argocd' && (


### PR DESCRIPTION
## Summary
- add a GitHub wiki endpoint that clones/caches repository wiki repos and returns page metadata/content
- show a dedicated Wiki tab on entity pages only when a GitHub wiki is available
- share sanitized markdown rendering between README and wiki content

## Verification
- `env GOCACHE=/tmp/go-build go test ./internal/plugins/github ./internal/api/handlers ./internal/api`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Wiki integration for repository exploration
  * Browse wiki pages with markdown rendering and secure content display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->