### PR TITLE
feat(documentation): link docs to related entities

### DIFF
--- a/internal/api/handlers/entities.go
+++ b/internal/api/handlers/entities.go
@@ -121,6 +121,33 @@ func (h *Handlers) GetEntity(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, e)
 }
 
+// ListEntityDocumentation handles GET /entities/{kind}/{name}/documentation.
+// It returns Documentation entities whose spec.relatedTo references this entity.
+func (h *Handlers) ListEntityDocumentation(w http.ResponseWriter, r *http.Request) {
+	kind := chi.URLParam(r, "kind")
+	name := chi.URLParam(r, "name")
+	namespace := r.URL.Query().Get("namespace")
+	if namespace == "" {
+		namespace = entity.DefaultNamespace
+	}
+
+	if _, err := h.DB.GetEntity(r.Context(), kind, namespace, name); err != nil {
+		if errors.Is(err, entity.ErrEntityNotFound) {
+			writeError(w, http.StatusNotFound, entityNotFoundMessage(kind, namespace, name))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to get entity")
+		return
+	}
+
+	docs, err := h.DB.ListDocumentationForEntity(r.Context(), kind, namespace, name)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list documentation")
+		return
+	}
+	writeJSON(w, http.StatusOK, docs)
+}
+
 // CreateEntity handles POST /entities.
 // Parses a JSON entity body, validates with SchemaValidator, saves to DB,
 // publishes an EntityCreated event, and writes an audit log entry.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -157,6 +157,7 @@ func NewServer(cfg *config.Config, database *db.DB, authSvc *auth.Service, event
 			// Entity CRUD. Read: any authenticated user. Write: developer+.
 			protected.Get("/entities", h.ListEntities)
 			protected.Get("/entities/{kind}", h.ListEntitiesByKind)
+			protected.Get("/entities/{kind}/{name}/documentation", h.ListEntityDocumentation)
 			protected.Get("/entities/{kind}/{name}", h.GetEntity)
 			protected.With(middleware.RequireRole("developer")).Post("/entities", h.CreateEntity)
 			protected.With(middleware.RequireRole("developer")).Put("/entities/{kind}/{name}", h.UpdateEntity)

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go2engle/gantry/internal/auth"
@@ -330,6 +331,28 @@ func (d *DB) ListEntities(ctx context.Context, kind, namespace string) ([]*entit
 	return entities, nil
 }
 
+// ListDocumentationForEntity returns Documentation entities in the namespace
+// whose spec.relatedTo (or legacy spec.associatedEntity) references the entity.
+func (d *DB) ListDocumentationForEntity(ctx context.Context, kind, namespace, name string) ([]*entity.Entity, error) {
+	if namespace == "" {
+		namespace = entity.DefaultNamespace
+	}
+	docs, err := d.ListEntities(ctx, "Documentation", namespace)
+	if err != nil {
+		return nil, err
+	}
+	var related []*entity.Entity
+	for _, doc := range docs {
+		if documentationRelatesTo(doc.Spec, kind, name) {
+			related = append(related, doc)
+		}
+	}
+	if related == nil {
+		related = []*entity.Entity{}
+	}
+	return related, nil
+}
+
 // CountEntitiesByKind returns a map of entity kind to count for all entities.
 func (d *DB) CountEntitiesByKind(ctx context.Context) (map[string]int64, error) {
 	rows, err := d.queryRows(ctx, `SELECT kind, COUNT(*) FROM entities GROUP BY kind`)
@@ -558,7 +581,7 @@ type GraphNode struct {
 type GraphEdge struct {
 	From     string `json:"from"`
 	To       string `json:"to"`
-	Relation string `json:"relation"` // "dependsOn", "providesApi", "consumesApi", "ownedBy"
+	Relation string `json:"relation"` // "dependsOn", "providesApi", "consumesApi", "ownedBy", "documents"
 }
 
 // GraphData is the complete relationship graph for a given root entity.
@@ -567,9 +590,80 @@ type GraphData struct {
 	Edges []GraphEdge `json:"edges"`
 }
 
+type entityRef struct {
+	Kind string
+	Name string
+}
+
+func relatedEntityRefs(spec map[string]any) []entityRef {
+	if spec == nil {
+		return nil
+	}
+	raw, ok := spec["relatedTo"]
+	if !ok {
+		return nil
+	}
+	refs, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	var out []entityRef
+	for _, ref := range refs {
+		m, ok := ref.(map[string]any)
+		if !ok {
+			continue
+		}
+		refKind, _ := m["kind"].(string)
+		refName, _ := m["name"].(string)
+		if refKind != "" && refName != "" {
+			out = append(out, entityRef{Kind: refKind, Name: refName})
+		}
+	}
+	return out
+}
+
+func documentationRelatesTo(spec map[string]any, kind, name string) bool {
+	for _, ref := range relatedEntityRefs(spec) {
+		if ref.Kind == kind && ref.Name == name {
+			return true
+		}
+	}
+
+	// Backward compatibility for older Documentation entities.
+	legacy, _ := spec["associatedEntity"].(string)
+	legacy = strings.TrimSpace(legacy)
+	if legacy == "" {
+		return false
+	}
+	return legacy == name || legacy == kind+"/"+name || legacy == kind+":"+name
+}
+
+func legacyDocumentationRef(spec map[string]any) (entityRef, bool) {
+	legacy, _ := spec["associatedEntity"].(string)
+	legacy = strings.TrimSpace(legacy)
+	if legacy == "" {
+		return entityRef{}, false
+	}
+	for _, sep := range []string{"/", ":"} {
+		if before, after, ok := strings.Cut(legacy, sep); ok && before != "" && after != "" {
+			return entityRef{Kind: before, Name: after}, true
+		}
+	}
+	return entityRef{}, false
+}
+
+func appendGraphEdge(edges []GraphEdge, edge GraphEdge) []GraphEdge {
+	for _, existing := range edges {
+		if existing == edge {
+			return edges
+		}
+	}
+	return append(edges, edge)
+}
+
 // GetEntityGraph builds a relationship graph centered on the given entity.
 // It includes direct forward relationships from the entity's spec and reverse
-// dependencies found by scanning all entities.
+// dependencies and documentation links found by scanning all entities.
 func (d *DB) GetEntityGraph(ctx context.Context, kind, namespace, name string) (*GraphData, error) {
 	root, err := d.GetEntity(ctx, kind, namespace, name)
 	if err != nil {
@@ -659,6 +753,18 @@ func (d *DB) GetEntityGraph(ctx context.Context, kind, namespace, name string) (
 		}
 	}
 
+	// Forward: relatedTo — Documentation entities document their related entities.
+	if root.Kind == "Documentation" {
+		for _, ref := range relatedEntityRefs(spec) {
+			addNode(ref.Kind, ref.Name)
+			edges = appendGraphEdge(edges, GraphEdge{From: rootID, To: ref.Kind + "/" + ref.Name, Relation: "documents"})
+		}
+		if ref, ok := legacyDocumentationRef(spec); ok {
+			addNode(ref.Kind, ref.Name)
+			edges = appendGraphEdge(edges, GraphEdge{From: rootID, To: ref.Kind + "/" + ref.Name, Relation: "documents"})
+		}
+	}
+
 	// Forward: owner (metadata) → Team
 	if root.Metadata.Owner != "" {
 		addNode("Team", root.Metadata.Owner)
@@ -706,6 +812,12 @@ func (d *DB) GetEntityGraph(ctx context.Context, kind, namespace, name string) (
 					}
 				}
 			}
+		}
+		if e.Kind == "Documentation" && e.Metadata.Namespace == namespace && documentationRelatesTo(e.Spec, kind, name) {
+			if _, exists := nodes[eID]; !exists {
+				nodes[eID] = GraphNode{ID: eID, Kind: e.Kind, Namespace: e.Metadata.Namespace, Name: e.Metadata.Name, Title: e.Metadata.Title}
+			}
+			edges = appendGraphEdge(edges, GraphEdge{From: eID, To: rootID, Relation: "documents"})
 		}
 	}
 

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -31,6 +31,119 @@ func newTestDB(t *testing.T) *DB {
 	return database
 }
 
+func TestListDocumentationForEntityUsesRelatedToAndLegacyAssociatedEntity(t *testing.T) {
+	ctx := context.Background()
+	database := newTestDB(t)
+
+	for _, e := range []*entity.Entity{
+		{
+			Kind:       "Service",
+			APIVersion: entity.DefaultAPIVersion,
+			Metadata:   entity.EntityMetadata{Name: "checkout", Namespace: entity.DefaultNamespace},
+			Spec:       map[string]any{},
+		},
+		{
+			Kind:       "Documentation",
+			APIVersion: entity.DefaultAPIVersion,
+			Metadata:   entity.EntityMetadata{Name: "checkout-runbook", Namespace: entity.DefaultNamespace},
+			Spec: map[string]any{
+				"url":  "https://docs.example.com/checkout/runbook",
+				"type": "runbook",
+				"relatedTo": []any{
+					map[string]any{"kind": "Service", "name": "checkout"},
+				},
+			},
+		},
+		{
+			Kind:       "Documentation",
+			APIVersion: entity.DefaultAPIVersion,
+			Metadata:   entity.EntityMetadata{Name: "checkout-legacy", Namespace: entity.DefaultNamespace},
+			Spec: map[string]any{
+				"url":              "https://docs.example.com/checkout/legacy",
+				"associatedEntity": "Service/checkout",
+			},
+		},
+		{
+			Kind:       "Documentation",
+			APIVersion: entity.DefaultAPIVersion,
+			Metadata:   entity.EntityMetadata{Name: "billing-runbook", Namespace: entity.DefaultNamespace},
+			Spec: map[string]any{
+				"url": "https://docs.example.com/billing/runbook",
+				"relatedTo": []any{
+					map[string]any{"kind": "Service", "name": "billing"},
+				},
+			},
+		},
+	} {
+		e.SetDefaults()
+		if err := database.CreateEntity(ctx, e); err != nil {
+			t.Fatalf("CreateEntity(%s/%s) error = %v", e.Kind, e.Metadata.Name, err)
+		}
+	}
+
+	docs, err := database.ListDocumentationForEntity(ctx, "Service", entity.DefaultNamespace, "checkout")
+	if err != nil {
+		t.Fatalf("ListDocumentationForEntity() error = %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("ListDocumentationForEntity() returned %d docs, want 2", len(docs))
+	}
+	got := map[string]bool{}
+	for _, doc := range docs {
+		got[doc.Metadata.Name] = true
+	}
+	for _, name := range []string{"checkout-runbook", "checkout-legacy"} {
+		if !got[name] {
+			t.Fatalf("ListDocumentationForEntity() missing %q", name)
+		}
+	}
+}
+
+func TestGetEntityGraphIncludesDocumentationEdges(t *testing.T) {
+	ctx := context.Background()
+	database := newTestDB(t)
+
+	for _, e := range []*entity.Entity{
+		{
+			Kind:       "Service",
+			APIVersion: entity.DefaultAPIVersion,
+			Metadata:   entity.EntityMetadata{Name: "checkout", Namespace: entity.DefaultNamespace},
+			Spec:       map[string]any{},
+		},
+		{
+			Kind:       "Documentation",
+			APIVersion: entity.DefaultAPIVersion,
+			Metadata:   entity.EntityMetadata{Name: "checkout-runbook", Namespace: entity.DefaultNamespace},
+			Spec: map[string]any{
+				"url": "https://docs.example.com/checkout/runbook",
+				"relatedTo": []any{
+					map[string]any{"kind": "Service", "name": "checkout"},
+				},
+			},
+		},
+	} {
+		e.SetDefaults()
+		if err := database.CreateEntity(ctx, e); err != nil {
+			t.Fatalf("CreateEntity(%s/%s) error = %v", e.Kind, e.Metadata.Name, err)
+		}
+	}
+
+	graph, err := database.GetEntityGraph(ctx, "Service", entity.DefaultNamespace, "checkout")
+	if err != nil {
+		t.Fatalf("GetEntityGraph() error = %v", err)
+	}
+	found := false
+	for _, edge := range graph.Edges {
+		if edge.From == "Documentation/checkout-runbook" && edge.To == "Service/checkout" && edge.Relation == "documents" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("GetEntityGraph() missing documentation edge: %#v", graph.Edges)
+	}
+}
+
 func TestMigrateUpgradesEntityFTSForFullEntitySearch(t *testing.T) {
 	ctx := context.Background()
 	dataDir := t.TempDir()

--- a/internal/entity/schemas/documentation.json
+++ b/internal/entity/schemas/documentation.json
@@ -16,7 +16,22 @@
     },
     "associatedEntity": {
       "type": "string",
-      "description": "Entity reference this documentation is associated with"
+      "description": "Legacy entity reference this documentation is associated with (for example, Service/checkout)",
+      "x-hidden": true
+    },
+    "relatedTo": {
+      "type": "array",
+      "title": "Relates to",
+      "items": {
+        "type": "object",
+        "properties": {
+          "kind": { "type": "string" },
+          "name": { "type": "string" }
+        },
+        "required": ["kind", "name"],
+        "additionalProperties": false
+      },
+      "description": "Entities this documentation relates to"
     },
     "format": {
       "type": "string",
@@ -25,28 +40,6 @@
     "system": {
       "type": "string",
       "description": "Parent system or domain"
-    },
-    "dependsOn": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "kind": { "type": "string" },
-          "name": { "type": "string" }
-        },
-        "required": ["kind", "name"]
-      },
-      "description": "Entities this documentation depends on"
-    },
-    "providesApis": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "APIs provided by this entity"
-    },
-    "consumesApis": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "APIs consumed by this entity"
     }
   },
   "required": ["url"],

--- a/web/src/components/DocumentationTab.tsx
+++ b/web/src/components/DocumentationTab.tsx
@@ -1,0 +1,83 @@
+import { ExternalLink, FileText } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { Entity } from '../lib/types';
+import { catalogEntityPath } from '../lib/utils';
+
+function docType(doc: Entity): string {
+  const type = doc.spec?.type as string | undefined;
+  return type ? type.replace(/-/g, ' ') : 'documentation';
+}
+
+function docUrl(doc: Entity): string {
+  return (doc.spec?.url as string | undefined) ?? '';
+}
+
+function docTitle(doc: Entity): string {
+  return doc.metadata.title || doc.metadata.name;
+}
+
+export default function DocumentationTab({ docs }: { docs: Entity[] }) {
+  if (docs.length === 0) {
+    return (
+      <div className="rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] px-6 py-10 text-center">
+        <FileText className="mx-auto h-7 w-7 text-[var(--gantry-text-secondary)]" />
+        <p className="mt-3 text-sm text-[var(--gantry-text-secondary)]">No documentation is linked to this entity yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)]">
+      <div className="border-b border-[var(--gantry-border)] px-5 py-4">
+        <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Documentation</h3>
+      </div>
+      <ul className="divide-y divide-[var(--gantry-border)]">
+        {docs.map((doc) => {
+          const url = docUrl(doc);
+          return (
+            <li key={`${doc.metadata.namespace || 'default'}:${doc.metadata.name}`} className="px-5 py-4">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 rounded-md bg-[var(--gantry-bg-tertiary)] p-2 text-[var(--gantry-text-secondary)]">
+                  <FileText className="h-4 w-4" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Link
+                      to={catalogEntityPath('Documentation', doc.metadata.name, doc.metadata.namespace)}
+                      className="font-medium text-[var(--gantry-text-primary)] hover:text-[var(--gantry-accent)]"
+                    >
+                      {docTitle(doc)}
+                    </Link>
+                    <span className="rounded-md bg-[var(--gantry-accent)]/10 px-2 py-0.5 text-xs capitalize text-[var(--gantry-accent)]">
+                      {docType(doc)}
+                    </span>
+                  </div>
+                  {doc.metadata.description && (
+                    <p className="mt-1 line-clamp-2 text-sm leading-6 text-[var(--gantry-text-secondary)]">
+                      {doc.metadata.description}
+                    </p>
+                  )}
+                  <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[var(--gantry-text-secondary)]">
+                    {doc.metadata.owner && <span>Owner: {doc.metadata.owner}</span>}
+                    {doc.metadata.updatedAt && <span>Updated {new Date(doc.metadata.updatedAt).toLocaleDateString()}</span>}
+                    {url && (
+                      <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-[var(--gantry-accent)] hover:underline"
+                      >
+                        Open source
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/EntityGraph.tsx
+++ b/web/src/components/EntityGraph.tsx
@@ -23,6 +23,7 @@ const RELATION_COLORS: Record<string, string> = {
   providesApi: '#10B981',
   consumesApi: '#3B82F6',
   ownedBy: '#8B5CF6',
+  documents: '#6B7280',
 };
 
 const RELATION_LABELS: Record<string, string> = {
@@ -30,6 +31,7 @@ const RELATION_LABELS: Record<string, string> = {
   providesApi: 'provides API',
   consumesApi: 'consumes API',
   ownedBy: 'owned by',
+  documents: 'documents',
 };
 
 function kindColor(kind: string): string {

--- a/web/src/components/SchemaForm.tsx
+++ b/web/src/components/SchemaForm.tsx
@@ -412,17 +412,19 @@ function ObjectFields({
 
   return (
     <div className="space-y-4">
-      {Object.entries(properties).map(([key, propSchema]) => (
-        <FormField
-          key={key}
-          name={key}
-          schema={propSchema}
-          value={value[key] ?? getDefaultValue(propSchema)}
-          onChange={(newVal) => onChange({ ...value, [key]: newVal })}
-          required={required.includes(key)}
-          error={errors ? errors.includes(key) : false}
-        />
-      ))}
+      {Object.entries(properties)
+        .filter(([, propSchema]) => !propSchema['x-hidden'])
+        .map(([key, propSchema]) => (
+          <FormField
+            key={key}
+            name={key}
+            schema={propSchema}
+            value={value[key] ?? getDefaultValue(propSchema)}
+            onChange={(newVal) => onChange({ ...value, [key]: newVal })}
+            required={required.includes(key)}
+            error={errors ? errors.includes(key) : false}
+          />
+        ))}
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -131,6 +131,9 @@ export const api = {
   getEntityGraph: (kind: string, name: string, namespace?: string) =>
     request<GraphData>('GET', `/graph/${encodePathSegment(kind)}/${encodePathSegment(name)}${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
 
+  listEntityDocumentation: (kind: string, name: string, namespace?: string) =>
+    request<Entity[]>('GET', `/entities/${encodePathSegment(kind)}/${encodePathSegment(name)}/documentation${namespace && namespace !== 'default' ? `?namespace=${encodeURIComponent(namespace)}` : ''}`),
+
   // Plugin marketplace
   listPlugins: () => request<PluginRegistryEntry[]>('GET', '/plugins'),
   getPlugin: (name: string) => request<PluginDetail>('GET', `/plugins/${name}`),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -113,6 +113,8 @@ export interface JsonSchema {
   'x-entity-ref'?: string;
   /** Custom extension: keep this string as a URL-safe entity slug. */
   'x-slug'?: boolean;
+  /** Custom extension: allow a schema field but omit it from generated forms. */
+  'x-hidden'?: boolean;
   /** Custom extension: render a dropdown of Gantry roles. */
   'x-role-picker'?: boolean;
 }

--- a/web/src/pages/EntityDetail.tsx
+++ b/web/src/pages/EntityDetail.tsx
@@ -15,6 +15,7 @@ import APIDocsTab from '../components/APIDocsTab';
 import HarborTab from '../components/HarborTab';
 import NexusTab from '../components/NexusTab';
 import FlowTab from '../components/FlowTab';
+import DocumentationTab from '../components/DocumentationTab';
 
 const ACTION_COLORS: Record<string, string> = {
   'entity.created': 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
@@ -100,7 +101,7 @@ const LINK_ICONS: Record<string, React.ReactNode> = {
   other:     <CircleHelp className="h-3.5 w-3.5" />,
 };
 
-type Tab = 'overview' | 'yaml' | 'relationships' | 'activity' | 'kubernetes' | 'github' | 'wiki' | 'argocd' | 'apidocs' | 'harbor' | 'nexus' | 'apis' | 'flow';
+type Tab = 'overview' | 'yaml' | 'relationships' | 'activity' | 'kubernetes' | 'github' | 'wiki' | 'argocd' | 'apidocs' | 'harbor' | 'nexus' | 'apis' | 'flow' | 'docs';
 
 const TAB_LABELS: Partial<Record<Tab, string>> = {
   relationships: 'Dependencies',
@@ -113,6 +114,7 @@ const TAB_LABELS: Partial<Record<Tab, string>> = {
   nexus: 'Nexus',
   apis: 'APIs',
   flow: 'Flow',
+  docs: 'Docs',
 };
 
 function githubRepoURLFromEntity(entity: Entity | null): string {
@@ -122,6 +124,18 @@ function githubRepoURLFromEntity(entity: Entity | null): string {
   const owner = entity.metadata.annotations?.['github.com/owner'];
   const repo = entity.metadata.annotations?.['github.com/repo'];
   return owner && repo ? `https://github.com/${owner}/${repo}` : '';
+}
+
+function isClickableURLField(key: string, value: unknown): value is string {
+  if (typeof value !== 'string' || value.trim() === '') return false;
+  const looksLikeURLField = key === 'url' || key.endsWith('Url') || key.endsWith('URL');
+  if (!looksLikeURLField && !/^https?:\/\//i.test(value)) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 export default function EntityDetail() {
@@ -148,23 +162,27 @@ export default function EntityDetail() {
   const [apiEntities, setApiEntities] = useState<Entity[]>([]);
   const [apisLoading, setApisLoading] = useState(false);
   const [githubWikiAvailable, setGitHubWikiAvailable] = useState(false);
+  const [relatedDocs, setRelatedDocs] = useState<Entity[]>([]);
 
   useEffect(() => {
     if (!kind || !name) return;
     setTab('overview');
     setGraphData(null);
     setApiEntities([]);
+    setRelatedDocs([]);
     setLoading(true);
     Promise.all([
       api.getEntity(kind, name, namespace),
       api.getSchema(kind).catch(() => null),
       api.listAuditEntries(100, 0).catch(() => [] as AuditEntry[]),
       api.listPlugins().catch(() => [] as PluginRegistryEntry[]),
+      api.listEntityDocumentation(kind, name, namespace).catch(() => [] as Entity[]),
     ])
-      .then(([e, s, audit, plugins]) => {
+      .then(([e, s, audit, plugins, docs]) => {
         setEnabledPlugins(new Set((plugins as PluginRegistryEntry[]).filter((p) => p.enabled).map((p) => p.name)));
         setEntity(e);
         setSchema(s);
+        setRelatedDocs(docs);
         api.recordView(kind, name, namespace).catch(() => {});
         const entries = (audit ?? []).filter(
           (a) => a.resourceName === name && a.resourceType === kind
@@ -451,8 +469,10 @@ export default function EntityDetail() {
         const serviceProvidedApis = (entity.spec?.providesApis as string[] | undefined) ?? [];
         const serviceConsumedApis = (entity.spec?.consumesApis as string[] | undefined) ?? [];
         const hasApis = entity.kind === 'Service' && (serviceProvidedApis.length > 0 || serviceConsumedApis.length > 0);
+        const hasDocs = relatedDocs.length > 0;
         const tabs: Tab[] = ['overview', 'relationships', 'yaml', 'activity'];
         if (hasFlow) tabs.splice(1, 0, 'flow');
+        if (hasDocs) tabs.splice(1, 0, 'docs');
         if (isK8sEntity && (entity.kind === 'Service' || entity.kind === 'Infrastructure') && enabledPlugins.has('kubernetes')) tabs.splice(1, 0, 'kubernetes');
         if (hasGitHub && enabledPlugins.has('github')) tabs.splice(1, 0, 'github');
         if (hasGitHub && githubWikiAvailable && enabledPlugins.has('github')) {
@@ -480,6 +500,11 @@ export default function EntityDetail() {
                 {t === 'activity' && activity.length > 0 && (
                   <span className="ml-1.5 rounded-full bg-[var(--gantry-bg-tertiary)] px-1.5 py-0.5 text-xs">
                     {activity.length}
+                  </span>
+                )}
+                {t === 'docs' && relatedDocs.length > 0 && (
+                  <span className="ml-1.5 rounded-full bg-[var(--gantry-bg-tertiary)] px-1.5 py-0.5 text-xs">
+                    {relatedDocs.length}
                   </span>
                 )}
               </button>
@@ -521,6 +546,7 @@ export default function EntityDetail() {
                         Array.isArray(value) &&
                         value.length > 0 &&
                         (value as any[]).every((v) => v && typeof v === 'object' && 'kind' in v && 'name' in v);
+                      const isURLField = isClickableURLField(key, value);
 
                       return (
                         <div key={key}>
@@ -560,6 +586,16 @@ export default function EntityDetail() {
                               <pre className="mt-1 overflow-auto rounded-md bg-[var(--gantry-bg-tertiary)] p-2 text-xs">
                                 {JSON.stringify(value, null, 2)}
                               </pre>
+                            ) : isURLField ? (
+                              <a
+                                href={value}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex max-w-full items-center gap-1.5 text-[var(--gantry-accent)] hover:underline"
+                              >
+                                <span className="truncate">{value}</span>
+                                <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                              </a>
                             ) : (
                               String(value)
                             )}
@@ -723,6 +759,55 @@ export default function EntityDetail() {
                 );
               })()}
 
+              {/* Related documentation — shown when Documentation entities point at this entity */}
+              {relatedDocs.length > 0 && (
+                <div className="rounded-lg border border-[var(--gantry-border)] bg-[var(--gantry-bg-primary)] p-6">
+                  <div className="flex items-center justify-between gap-3">
+                    <h3 className="text-sm font-semibold text-[var(--gantry-text-primary)]">Documentation</h3>
+                    <button
+                      type="button"
+                      onClick={() => setTab('docs')}
+                      className="text-xs font-medium text-[var(--gantry-accent)] hover:underline"
+                    >
+                      View all
+                    </button>
+                  </div>
+                  <ul className="mt-3 space-y-2">
+                    {relatedDocs.slice(0, 5).map((doc) => {
+                      const url = doc.spec?.url as string | undefined;
+                      const docType = (doc.spec?.type as string | undefined)?.replace(/-/g, ' ');
+                      return (
+                        <li key={`${doc.metadata.namespace || 'default'}:${doc.metadata.name}`} className="flex items-start gap-2">
+                          <FileText className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--gantry-text-secondary)]" />
+                          <div className="min-w-0 flex-1">
+                            <Link
+                              to={catalogEntityPath('Documentation', doc.metadata.name, doc.metadata.namespace)}
+                              className="block truncate text-sm font-medium text-[var(--gantry-accent)] hover:underline"
+                            >
+                              {doc.metadata.title || doc.metadata.name}
+                            </Link>
+                            <p className="mt-0.5 truncate text-xs capitalize text-[var(--gantry-text-secondary)]">
+                              {docType || 'documentation'}
+                            </p>
+                          </div>
+                          {url && (
+                            <a
+                              href={url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="mt-0.5 shrink-0 rounded p-0.5 text-[var(--gantry-text-secondary)] hover:text-[var(--gantry-accent)]"
+                              title="Open documentation"
+                            >
+                              <ExternalLink className="h-3.5 w-3.5" />
+                            </a>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
+
               {/* Links card — shown when entity has spec.links or spec.repoUrl */}
               {(() => {
                 const links = (entity.spec?.links as EntityLink[] | undefined) ?? [];
@@ -849,6 +934,10 @@ export default function EntityDetail() {
               })()}
             </div>
           </div>
+        )}
+
+        {tab === 'docs' && (
+          <DocumentationTab docs={relatedDocs} />
         )}
 
         {tab === 'yaml' && (


### PR DESCRIPTION
## Summary
- Add `Documentation.spec.relatedTo` as the preferred way to link docs to services, APIs, infrastructure, and other entities.
- Add an entity documentation API, graph `documents` relationship, and related documentation UI on entity overview/details.
- Hide legacy `associatedEntity` from generated forms while preserving compatibility, and render URL spec fields as clickable links.

## Verification
- `go test ./...`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new documentation tab to entity details, displaying all related documentation with type, description, owner, and last update date.
  * Enabled associating documentation with entities through a new relationship structure.

* **Tests**
  * Added comprehensive tests for documentation associations and entity graph relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->